### PR TITLE
Fix named graph indexing, simplify field spec API, update docs

### DIFF
--- a/demo/test/queries/09-matchraw-multivalue.rq
+++ b/demo/test/queries/09-matchraw-multivalue.rq
@@ -8,7 +8,7 @@ PREFIX ex:  <http://example.org/mining/>
 
 SELECT ?entity ?score ?matchRaw ?identifier
 WHERE {
-    (?entity ?score ?matchRaw) luc:query ("urn:jena:lucene:field#identifier" "94130" 10) .
+    (?entity ?score ?matchRaw) luc:query ('["urn:jena:lucene:field#identifier"]' "94130" 10) .
     ?entity ex:identifier ?identifier .
 }
 ORDER BY ?identifier

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -13,7 +13,7 @@ Supports field-scoped queries, CQL2-JSON filter arguments, sort pushdown, and fa
 ### Syntax
 
 ```
-(?s ?score ?literal ?totalHits ?graph ?field) luc:query (fieldSpec queryString filter? sort? limit? highlight?)
+(?entity ?score ?match ?totalHits ?graph ?field) luc:query (fieldSpec queryString filter? sort? limit? highlight?)
 ```
 
 ### Arguments (positional, left to right)
@@ -29,12 +29,12 @@ Supports field-scoped queries, CQL2-JSON filter arguments, sort pushdown, and fa
 
 ### Field specification
 
-The `fieldSpec` argument controls which Lucene fields are searched. Field IRIs are required — the `idx:fieldName` (Lucene field name) is internal and not accepted here.
+The `fieldSpec` argument controls which Lucene fields are searched. It accepts either `"default"` or a JSON array of field IRIs.
 
 | Value | Meaning |
 |-------|---------|
 | `"default"` | Search all fields marked `idx:defaultSearch true` in the index configuration |
-| `"urn:jena:lucene:field#title"` | Search only the field with this IRI |
+| `'["urn:jena:lucene:field#title"]'` | Search a single specific field (JSON array with one IRI) |
 | `'["urn:jena:lucene:field#title","urn:jena:lucene:field#description"]'` | Search multiple specific fields (JSON array of IRIs) |
 | *(omitted)* | Same as `"default"` |
 
@@ -44,12 +44,12 @@ Field IRIs correspond to the named resource IRIs in the SHACL index configuratio
 
 | Variable | Required | Type | Description |
 |----------|----------|------|-------------|
-| ?s | Yes | URI | Matched entity |
+| ?entity | Yes | IRI | Matched entity |
 | ?score | No | float | Lucene relevance score |
-| ?literal | No | Node | Stored value for the matched field. KEYWORD fields return an IRI, TEXT fields return a string literal, numeric fields return typed literals |
-| ?totalHits | No | xsd:long | Total matching documents (same value on every row) |
-| ?graph | No | URI | Named graph of the match |
-| ?field | No | URI | Field IRI identifying the matched field (bound for single-field queries, unbound for multi-field) |
+| ?match | No | IRI or literal | Stored value for the matched field. KEYWORD fields return an IRI, TEXT fields return a string literal, numeric fields return typed literals |
+| ?totalHits | No | xsd:integer | Total matching documents (same value on every row) |
+| ?graph | No | IRI | Named graph of the match |
+| ?field | No | IRI | Field IRI identifying the matched field (bound for single-field queries, unbound for multi-field) |
 
 The `?totalHits` binding returns the total number of documents matching the query and filters, regardless of the `limit` parameter. This is useful for displaying "Showing X of Y results" in search UIs. The value is computed efficiently using `IndexSearcher.count()` and is only evaluated when the variable is present in the subject.
 
@@ -62,34 +62,34 @@ PREFIX luc: <urn:jena:lucene:index#>
 PREFIX field: <urn:jena:lucene:field#>
 
 # Simple search (all default fields)
-(?s ?score) luc:query ("machine learning") .
+(?entity ?score) luc:query ("machine learning") .
 
 # Search with explicit "default"
-(?s ?score) luc:query ("default" "machine learning") .
+(?entity ?score) luc:query ("default" "machine learning") .
 
-# Search a specific field (by IRI)
-(?s ?score) luc:query ("urn:jena:lucene:field#title" "machine learning") .
+# Search a specific field (JSON array with one IRI)
+(?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning") .
 
 # Search multiple fields (JSON array of IRIs)
-(?s ?score) luc:query ('["urn:jena:lucene:field#title", "urn:jena:lucene:field#description"]' "machine learning") .
+(?entity ?score) luc:query ('["urn:jena:lucene:field#title", "urn:jena:lucene:field#description"]' "machine learning") .
 
 # Search with limit
-(?s ?score) luc:query ("urn:jena:lucene:field#title" "machine learning" 20) .
+(?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning" 20) .
 
 # Search with total hit count
-(?s ?score ?literal ?totalHits) luc:query ("machine learning" 20) .
+(?entity ?score ?match ?totalHits) luc:query ("machine learning" 20) .
 
 # Search with field binding
-(?s ?score ?lit ?totalHits ?g ?field) luc:query ("urn:jena:lucene:field#title" "machine learning" 20) .
+(?entity ?score ?match ?totalHits ?g ?field) luc:query ('["urn:jena:lucene:field#title"]' "machine learning" 20) .
 
 # Search with CQL filter (only Technology books)
-(?s ?score) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
+(?entity ?score) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
 
 # Search with filter and total hit count
-(?s ?score ?_lit ?totalHits) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
+(?entity ?score ?_match ?totalHits) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
 
 # Search with sort (by field IRI)
-(?s ?score) luc:query ("default" "learning" '{"field":"urn:jena:lucene:field#year","order":"desc"}' 10) .
+(?entity ?score) luc:query ("default" "learning" '{"field":"urn:jena:lucene:field#year","order":"desc"}' 10) .
 ```
 
 ### Filter JSON format (CQL2-JSON)
@@ -129,9 +129,9 @@ Filters use CQL2-JSON syntax. The `property` value is a field IRI:
 
 | Variable | Required | Type | Description |
 |----------|----------|------|-------------|
-| ?field | Yes | URI | Field IRI identifying the facet field (auto-generated `urn:jena:lucene:field#{fieldName}` for blank node fields) |
-| ?value | No | Node | Facet value. KEYWORD fields return IRIs, TEXT fields return string literals |
-| ?count | No | xsd:long | Number of matching documents |
+| ?field | Yes | IRI | Field IRI identifying the facet field (auto-generated `urn:jena:lucene:field#{fieldName}` for blank node fields) |
+| ?value | No | IRI or literal | Facet value. KEYWORD fields return IRIs, TEXT fields return string literals |
+| ?count | No | xsd:integer | Number of matching documents |
 
 ### Examples
 
@@ -171,8 +171,8 @@ Use one query for hits, another for facets. Each returns a clean result shape wi
 PREFIX luc: <urn:jena:lucene:index#>
 
 # Query 1: search results
-SELECT ?s ?score WHERE {
-    (?s ?score) luc:query ("learning") .
+SELECT ?entity ?score WHERE {
+    (?entity ?score) luc:query ("learning") .
 }
 
 # Query 2: facet counts
@@ -191,15 +191,15 @@ If a single SPARQL request is preferred, use `UNION` to return both result sets 
 ```sparql
 PREFIX luc: <urn:jena:lucene:index#>
 
-SELECT ?s ?score ?totalHits ?field ?value ?count WHERE {
-    { (?s ?score ?_lit ?totalHits) luc:query ("default" "learning" 10) . }
+SELECT ?entity ?score ?totalHits ?field ?value ?count WHERE {
+    { (?entity ?score ?_match ?totalHits) luc:query ("default" "learning" 10) . }
     UNION
     { (?field ?value ?count) luc:facet ("default" "learning"
         '["urn:jena:lucene:field#category"]' 10) . }
 }
 ```
 
-This returns N + M rows (not N × M). Hit rows have `?field`, `?value`, `?count` unbound; facet rows have `?s`, `?score`, `?totalHits` unbound. The consumer splits results by checking which columns are present. `?totalHits` appears on every hit row with the same value — read it from the first row. Both PFs share a single Lucene execution via `SearchExecution` (see below).
+This returns N + M rows (not N × M). Hit rows have `?field`, `?value`, `?count` unbound; facet rows have `?entity`, `?score`, `?totalHits` unbound. The consumer splits results by checking which columns are present. `?totalHits` appears on every hit row with the same value — read it from the first row. Both PFs share a single Lucene execution via `SearchExecution` (see below).
 
 ### Avoid: Combined BGP (cartesian product)
 
@@ -207,8 +207,8 @@ Placing both PFs in the same basic graph pattern produces a cartesian product:
 
 ```sparql
 # WARNING: produces N × M rows
-SELECT ?s ?score ?field ?value ?count WHERE {
-    (?s ?score) luc:query ("learning") .
+SELECT ?entity ?score ?field ?value ?count WHERE {
+    (?entity ?score) luc:query ("learning") .
     (?field ?value ?count) luc:facet ("default" "learning"
         '["urn:jena:lucene:field#category"]' 10) .
 }

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -49,11 +49,13 @@ Field IRIs correspond to the named resource IRIs in the SHACL index configuratio
 | ?match | No | IRI or literal | Stored value for the matched field. KEYWORD fields return an IRI, TEXT fields return a string literal, numeric fields return typed literals |
 | ?totalHits | No | xsd:integer | Total matching documents (same value on every row) |
 | ?graph | No | IRI | Named graph of the match |
-| ?field | No | IRI | Field IRI identifying the matched field (bound for single-field queries, unbound for multi-field) |
+| ?field | No | IRI | Field IRI identifying the matched field (see below) |
 
 The `?totalHits` binding returns the total number of documents matching the query and filters, regardless of the `limit` parameter. This is useful for displaying "Showing X of Y results" in search UIs. The value is computed efficiently using `IndexSearcher.count()` and is only evaluated when the variable is present in the subject.
 
-The `?field` binding returns the IRI of the Lucene field that was searched. For fields defined as named resources in the configuration, the resource's own IRI is used. For fields defined on blank nodes, an auto-generated IRI of the form `urn:jena:lucene:field#{fieldName}` is used. For single-field queries, this is always bound. For multi-field queries, it is unbound.
+The `?field` binding returns the IRI of the Lucene field that was searched. For single-field queries (JSON array with one IRI), this is always bound to that field's IRI. For multi-field queries (`"default"` or array with multiple IRIs), this is currently unbound — Lucene returns hits at the document level without identifying which field matched. This is a known limitation; see [#48](https://github.com/aiworkerjohns/jena/issues/48).
+
+> **Note:** All fields must be defined as named resources (with IRIs) in the SHACL index configuration. Blank node field definitions are not supported.
 
 ### Examples
 
@@ -129,7 +131,7 @@ Filters use CQL2-JSON syntax. The `property` value is a field IRI:
 
 | Variable | Required | Type | Description |
 |----------|----------|------|-------------|
-| ?field | Yes | IRI | Field IRI identifying the facet field (auto-generated `urn:jena:lucene:field#{fieldName}` for blank node fields) |
+| ?field | Yes | IRI | Field IRI identifying the facet field |
 | ?value | No | IRI or literal | Facet value. KEYWORD fields return IRIs, TEXT fields return string literals |
 | ?count | No | xsd:integer | Number of matching documents |
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java
@@ -28,6 +28,8 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.query.text.ShaclIndexMapping.*;
 import org.apache.jena.query.text.changes.TextQuadAction;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.graph.GraphUnionRead;
 import org.apache.jena.sparql.path.P_Link;
 import org.apache.jena.sparql.path.Path;
 import org.apache.jena.sparql.path.eval.PathEval;
@@ -120,12 +122,11 @@ public class ShaclTextDocProducer implements TextDocProducer {
         String entityUri = TextQueryFuncs.subjectToString(subject);
         log.trace("rebuildEntityDocuments: {}", entityUri);
 
-        // Get rdf:type values for the entity
+        // Get rdf:type values for the entity across all graphs (default + named)
         Set<Node> types = new HashSet<>();
-        Iterator<Node> typeIter = baseDataset.getDefaultGraph().find(subject, RDF_TYPE, Node.ANY)
-            .mapWith(t -> t.getObject());
+        Iterator<Quad> typeIter = baseDataset.find(Node.ANY, subject, RDF_TYPE, Node.ANY);
         while (typeIter.hasNext()) {
-            types.add(typeIter.next());
+            types.add(typeIter.next().getObject());
         }
 
         // Find matching profiles
@@ -153,7 +154,7 @@ public class ShaclTextDocProducer implements TextDocProducer {
      */
     private Entity buildEntity(Node subject, String entityUri, IndexProfile profile) {
         Entity entity = new Entity(entityUri, null);
-        Graph graph = baseDataset.getDefaultGraph();
+        Graph graph = allGraphsView();
 
         for (FieldDef fieldDef : profile.getFields()) {
             Path path = fieldDef.getPath();
@@ -185,6 +186,17 @@ public class ShaclTextDocProducer implements TextDocProducer {
         }
 
         return entity;
+    }
+
+    /**
+     * Return a read-only graph view that spans the default graph and all named graphs.
+     * This ensures the change listener finds data regardless of which graph it was added to.
+     */
+    private Graph allGraphsView() {
+        List<Node> graphNames = new ArrayList<>();
+        graphNames.add(Quad.defaultGraphIRI);
+        baseDataset.listGraphNodes().forEachRemaining(graphNames::add);
+        return new GraphUnionRead(baseDataset, graphNames);
     }
 
     private Object nodeToValue(Node obj, FieldType fieldType) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
@@ -61,12 +61,12 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Argument format:
  * <pre>
- * (?s ?score ?literal ?totalHits ?graph ?field) luc:query (fieldSpec queryString cqlFilter? sortSpec? limit? highlight?)
+ * (?entity ?score ?match ?totalHits ?graph ?field) luc:query (fieldSpec queryString cqlFilter? sortSpec? limit? highlight?)
  * </pre>
  * <p>
  * The first string literal is the field specification: {@code "default"} searches all
- * defaultSearch fields, a bare field name searches that field, and a JSON array
- * like {@code '["title","description"]'} searches multiple fields.
+ * defaultSearch fields, and a JSON array of field IRIs like
+ * {@code '["urn:jena:lucene:field#title","urn:jena:lucene:field#description"]'} searches specific fields.
  */
 public class ShaclTextQueryPF extends PropertyFunctionBase {
     private static final Logger log = LoggerFactory.getLogger(ShaclTextQueryPF.class);
@@ -228,7 +228,7 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         Var literalVar = (literal == null) ? null : Var.alloc(literal);
         Var totalHitsVar = (totalHitsNode == null) ? null : Var.alloc(totalHitsNode);
         Node totalHitsValue = totalHitsVar != null
-            ? NodeFactory.createLiteralDT(String.valueOf(totalHits), XSDDatatype.XSDlong) : null;
+            ? NodeFactory.createLiteralDT(String.valueOf(totalHits), XSDDatatype.XSDinteger) : null;
         Var graphVar = (graph == null) ? null : Var.alloc(graph);
         Var fieldVar = (field == null) ? null : Var.alloc(field);
 
@@ -287,19 +287,18 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
 
         int idx = 0;
 
-        // First literal = field spec
+        // First literal = field spec: "default" or JSON array of field IRIs
         if (idx < list.size() && list.get(idx).isLiteral()) {
             String lex = list.get(idx).getLiteralLexicalForm();
             if (lex.startsWith("[")) {
-                // JSON array of field names
+                // JSON array of field IRIs
                 JsonArray arr = JSON.parseAny(lex).getAsArray();
                 for (int i = 0; i < arr.size(); i++) {
                     searchFields.add(arr.get(i).getAsString().value());
                 }
                 idx++;
-            } else if (!lex.startsWith("{") && !isJsonLike(lex)) {
-                // Bare field name or "default"
-                searchFields.add(lex);
+            } else if ("default".equals(lex)) {
+                searchFields.add("default");
                 idx++;
             }
         }

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
@@ -268,17 +268,11 @@ public class TextFacetPF extends PropertyFunctionBase {
         List<Node> list = argObject.getArgList();
         int idx = 0;
 
-        // 1. First literal = field spec
+        // 1. First literal = field spec: "default" or JSON array of field IRIs
         if (idx < list.size() && list.get(idx).isLiteral()) {
             String lex = list.get(idx).getLiteralLexicalForm();
-            if (lex.startsWith("[")) {
-                // Could be field spec array or facet fields array — check context
-                // If no query string has been seen, treat first array-like literal as field spec
-                // only if it's followed by another literal (the query string)
-                // For simplicity: first non-JSON, non-integer literal = field spec
-                // JSON arrays are handled below as facet fields
-            } else if (!lex.startsWith("{") && !isInteger(lex)) {
-                searchFields.add(lex);
+            if ("default".equals(lex)) {
+                searchFields.add("default");
                 idx++;
             }
         }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
@@ -210,7 +210,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('urn:jena:lucene:field#label' 'Pilbara') .\n" +
+            "  (?s ?score) luc:query ('[\"urn:jena:lucene:field#label\"]' 'Pilbara') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -236,7 +236,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('urn:jena:lucene:field#label' 'GSWA') .\n" +
+            "  (?s ?score) luc:query ('[\"urn:jena:lucene:field#label\"]' 'GSWA') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -288,7 +288,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('urn:jena:lucene:field#identifier' '" + prefix + "') .\n" +
+            "  (?s ?score) luc:query ('[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
@@ -114,7 +114,7 @@ public class TestShaclLucQueryRawValueOnMultiValuedField {
     public void testLucQueryReturnsMatchedRawValueForMultiValuedField() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?matchRaw WHERE {\n" +
-            "  (?s ?score ?matchRaw) luc:query (\"" + FIELD_IRI_PREFIX + "identifier\" \"94130\" 10)\n" +
+            "  (?s ?score ?matchRaw) luc:query ('[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -230,10 +230,10 @@ public class TestTextQueryPFFilters {
 
     @Test
     public void testLucQueryByFieldIRI() {
-        // Search only the "title" field via its IRI
+        // Search only the "title" field via its IRI (JSON array)
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?s ?score) luc:query (\"" + FIELD_IRI_PREFIX + "title\" \"learning\" 10)\n" +
+            "  (?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -282,7 +282,7 @@ public class TestTextQueryPFFilters {
         // Search a single field and check that ?field is bound to the field IRI
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score ?lit ?totalHits ?g ?field WHERE {\n" +
-            "  (?s ?score ?lit ?totalHits ?g ?field) luc:query (\"" + FIELD_IRI_PREFIX + "title\" \"learning\" 10)\n" +
+            "  (?s ?score ?lit ?totalHits ?g ?field) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -310,7 +310,7 @@ public class TestTextQueryPFFilters {
         // ?lit should be populated with the stored value from the matched field
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score ?lit WHERE {\n" +
-            "  (?s ?score ?lit) luc:query (\"" + FIELD_IRI_PREFIX + "title\" \"machine\" 10)\n" +
+            "  (?s ?score ?lit) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -365,7 +365,7 @@ public class TestTextQueryPFFilters {
         // Search specific field (by IRI) with CQL filter
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?s ?score) luc:query (\"" + FIELD_IRI_PREFIX + "title\" \"learning\" " +
+            "  (?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" " +
             "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' 20)\n" +
             "}";
 


### PR DESCRIPTION
## Summary
- **#38**: Fix `ShaclTextDocProducer` to search all graphs (default + named) when rebuilding entity documents, using quad-level iteration for type lookup and `GraphUnionRead` for entity building — matches `ShaclBulkIndexer` behavior
- **#29**: Simplify `luc:query` and `luc:facet` field spec to only accept `"default"` or a JSON array of field IRIs (e.g. `'["urn:jena:lucene:field#title"]'`), removing bare field name support
- **#31, #34**: Rename `?s`→`?entity`, `?literal`→`?match` in docs; change URI→IRI in type columns; change `?totalHits` type from `xsd:long` to `xsd:integer`

## Test plan
- [x] All 494 jena-text tests pass (0 failures, 0 errors)
- [ ] Verify named graph data is indexed by the change listener
- [ ] Verify `"default"` and JSON array field specs work in SPARQL queries
- [ ] Verify bare field names are no longer accepted

Closes #38, closes #29, closes #31, closes #34