### PR TITLE
Implement luc:match property function for per-hit field attribution

### DIFF
--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -750,7 +750,7 @@ function searchApp() {
             return `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?count
 WHERE {
-    { (?entity ?score ?_lit ?totalHits) luc:query ('${searchField}' '${escaped}'${filterArg} ${this.limit}) }
+    { (?hit ?entity ?score ?_lit ?totalHits) luc:query ('${searchField}' '${escaped}'${filterArg} ${this.limit}) }
     UNION
     { (?field ?value ?count) luc:facet ('${searchField}' '${escaped}' '${facetFieldsJson}'${filterArg} ${this.maxFacetValues}) }
 }`;
@@ -762,7 +762,7 @@ WHERE {
             return `${SPARQL_PREFIXES}
 SELECT DISTINCT ?identifier
 WHERE {
-    (?entity ?score) luc:query ('${fieldSpec}' '${escaped}' 8) .
+    (?hit ?entity ?score) luc:query ('${fieldSpec}' '${escaped}' 8) .
     ?entity ex:identifier ?identifier .
 }
 ORDER BY LCASE(STR(?identifier))
@@ -1474,7 +1474,7 @@ function statsApp() {
                 const statsQuery = `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?count
 WHERE {
-    { (?entity ?score ?_lit ?totalHits) luc:query ('default' '*' 0) }
+    { (?hit ?entity ?score ?_lit ?totalHits) luc:query ('default' '*' 0) }
     UNION
     { (?field ?value ?count) luc:facet ('default' '*' '${facetFieldsJson}' 0) }
 }`;

--- a/demo/project-overview/index.html
+++ b/demo/project-overview/index.html
@@ -611,7 +611,7 @@ body {
 <span class="comment">-- Search with filters</span>
 <span class="kw">SELECT</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?totalHits</span>
 <span class="kw">WHERE</span> {
-    (<span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>)
+    (<span class="var">?hit</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>)
         <span class="fn">luc:query</span> (<span class="str">'default'</span> <span class="str">'gold'</span>
             <span class="str">'{"op":"=","args":[{"property":"element"},"Au"]}'</span> 10)
 }</pre>
@@ -771,7 +771,7 @@ body {
 
 <span class="kw">SELECT</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?totalHits</span>
 <span class="kw">WHERE</span> {
-    (<span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>)
+    (<span class="var">?hit</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>)
         <span class="fn">luc:query</span> (<span class="str">'default'</span> <span class="str">'Maitland'</span>
             <span class="str">'{"op":"=","args":[{"property":"element"},"Au"]}'</span> 10)
 }</pre>
@@ -820,7 +820,7 @@ body {
 
 <span class="kw">SELECT</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?totalHits</span> <span class="var">?label</span>
 <span class="kw">WHERE</span> {
-    (<span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>)
+    (<span class="var">?hit</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>)
         <span class="fn">luc:query</span> (<span class="str">'default'</span> <span class="str">'Maitland'</span> 5) .
     <span class="var">?entity</span> <span class="fn">rdfs:label</span> <span class="var">?label</span> .
 }</pre>
@@ -840,7 +840,7 @@ body {
 
 <span class="kw">SELECT</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?label</span>
 <span class="kw">WHERE</span> {
-    (<span class="var">?entity</span> <span class="var">?score</span>)
+    (<span class="var">?hit</span> <span class="var">?entity</span> <span class="var">?score</span>)
         <span class="fn">luc:query</span> (<span class="str">'default'</span> <span class="str">'*'</span>
             <span class="str">'{"op":"and","args":[{"op":"=","args":[{"property":"element"},"Au"]},{"op":"=","args":[{"property":"procedure"},"XRF"]}]}'</span> 10) .
     <span class="var">?entity</span> <span class="fn">rdfs:label</span> <span class="var">?label</span> .
@@ -958,7 +958,7 @@ body {
 <span class="kw">SELECT</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?totalHits</span>
        <span class="var">?field</span> <span class="var">?value</span> <span class="var">?count</span>
 <span class="kw">WHERE</span> {
-  { (<span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>)
+  { (<span class="var">?hit</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>)
         <span class="fn">luc:query</span> (<span class="str">'default'</span> <span class="str">'gold'</span> 10) }
   <span class="kw">UNION</span>
   { (<span class="var">?field</span> <span class="var">?value</span> <span class="var">?count</span>)
@@ -1032,7 +1032,7 @@ body {
 
 <span class="kw">SELECT</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?totalHits</span> <span class="var">?field</span> <span class="var">?value</span> <span class="var">?count</span>
 <span class="kw">WHERE</span> {
-    { (<span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>) <span class="fn">luc:query</span> (<span class="str">'default'</span> <span class="str">'Maitland'</span> 5) }
+    { (<span class="var">?hit</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?_lit</span> <span class="var">?totalHits</span>) <span class="fn">luc:query</span> (<span class="str">'default'</span> <span class="str">'Maitland'</span> 5) }
     <span class="kw">UNION</span>
     { (<span class="var">?field</span> <span class="var">?value</span> <span class="var">?count</span>) <span class="fn">luc:facet</span> (<span class="str">'default'</span> <span class="str">'Maitland'</span> <span class="str">'["element","procedure","lab"]'</span> 10) }
 }</pre>
@@ -1097,7 +1097,7 @@ body {
 
 <span class="kw">SELECT</span> <span class="var">?entity</span> <span class="var">?score</span> <span class="var">?label</span>
 <span class="kw">WHERE</span> {
-    (<span class="var">?entity</span> <span class="var">?score</span>) <span class="fn">luc:query</span>
+    (<span class="var">?hit</span> <span class="var">?entity</span> <span class="var">?score</span>) <span class="fn">luc:query</span>
         (<span class="str">'default'</span> <span class="str">'*'</span> <span class="str">'{"op":"and","args":[{"op":"=","args":[{"property":"element"},"Au"]},{"op":"=","args":[{"property":"lab"},"ALS"]}]}'</span> 5) .
     <span class="var">?entity</span> <span class="fn">rdfs:label</span> <span class="var">?label</span> .
 }
@@ -1466,7 +1466,7 @@ async function runLiveSearch() {
   btn.disabled = true;
   el.innerHTML = '<span class="spinner"></span> Querying...';
   try {
-    const q = `PREFIX luc: <urn:jena:lucene:index#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nSELECT ?entity ?score ?totalHits ?label\nWHERE {\n    (?entity ?score ?_lit ?totalHits) luc:query ('default' 'Maitland' 5) .\n    ?entity rdfs:label ?label .\n}`;
+    const q = `PREFIX luc: <urn:jena:lucene:index#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nSELECT ?entity ?score ?totalHits ?label\nWHERE {\n    (?hit ?entity ?score ?_lit ?totalHits) luc:query ('default' 'Maitland' 5) .\n    ?entity rdfs:label ?label .\n}`;
     const { data, ms } = await sparql(FUSEKI_ENDPOINT, q);
     el.innerHTML = resultToText(data, ms);
   } catch (e) { el.innerHTML = `<span style="color:var(--red)">Error: ${e.message}</span>`; }
@@ -1479,7 +1479,7 @@ async function runLiveFilteredSearch() {
   btn.disabled = true;
   el.innerHTML = '<span class="spinner"></span> Querying...';
   try {
-    const q = `PREFIX luc: <urn:jena:lucene:index#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nSELECT ?entity ?score ?label\nWHERE {\n    (?entity ?score) luc:query ('default' '*' '{"op":"and","args":[{"op":"=","args":[{"property":"element"},"Au"]},{"op":"=","args":[{"property":"procedure"},"XRF"]}]}' 10) .\n    ?entity rdfs:label ?label .\n}`;
+    const q = `PREFIX luc: <urn:jena:lucene:index#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nSELECT ?entity ?score ?label\nWHERE {\n    (?hit ?entity ?score) luc:query ('default' '*' '{"op":"and","args":[{"op":"=","args":[{"property":"element"},"Au"]},{"op":"=","args":[{"property":"procedure"},"XRF"]}]}' 10) .\n    ?entity rdfs:label ?label .\n}`;
     const { data, ms } = await sparql(FUSEKI_ENDPOINT, q);
     el.innerHTML = resultToText(data, ms);
   } catch (e) { el.innerHTML = `<span style="color:var(--red)">Error: ${e.message}</span>`; }
@@ -1520,7 +1520,7 @@ async function runLiveCombined() {
   searchEl.innerHTML = '<span class="spinner"></span> Querying...';
   facetEl.innerHTML = '<span class="spinner"></span>';
   try {
-    const q = `PREFIX luc: <urn:jena:lucene:index#>\nSELECT ?entity ?score ?totalHits ?field ?value ?count\nWHERE {\n    { (?entity ?score ?_lit ?totalHits) luc:query ('default' 'Maitland' 5) }\n    UNION\n    { (?field ?value ?count) luc:facet ('default' 'Maitland' '["element","procedure","lab"]' 10) }\n}`;
+    const q = `PREFIX luc: <urn:jena:lucene:index#>\nSELECT ?entity ?score ?totalHits ?field ?value ?count\nWHERE {\n    { (?hit ?entity ?score ?_lit ?totalHits) luc:query ('default' 'Maitland' 5) }\n    UNION\n    { (?field ?value ?count) luc:facet ('default' 'Maitland' '["element","procedure","lab"]' 10) }\n}`;
     const { data, ms } = await sparql(FUSEKI_ENDPOINT, q);
     const rows = data.results.bindings;
     const hits = rows.filter(r => r.entity);
@@ -1554,7 +1554,7 @@ async function runLivePaths() {
   btn.disabled = true;
   el.innerHTML = '<span class="spinner"></span> Querying...';
   try {
-    const q = `PREFIX luc: <urn:jena:lucene:index#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nSELECT ?entity ?score ?label\nWHERE {\n    (?entity ?score) luc:query ('default' '*' '{"op":"and","args":[{"op":"=","args":[{"property":"element"},"Au"]},{"op":"=","args":[{"property":"lab"},"ALS"]}]}' 5) .\n    ?entity rdfs:label ?label .\n}\nORDER BY DESC(?score)`;
+    const q = `PREFIX luc: <urn:jena:lucene:index#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nSELECT ?entity ?score ?label\nWHERE {\n    (?hit ?entity ?score) luc:query ('default' '*' '{"op":"and","args":[{"op":"=","args":[{"property":"element"},"Au"]},{"op":"=","args":[{"property":"lab"},"ALS"]}]}' 5) .\n    ?entity rdfs:label ?label .\n}\nORDER BY DESC(?score)`;
     const { data, ms } = await sparql(FUSEKI_ENDPOINT, q);
     el.innerHTML = resultToText(data, ms);
   } catch (e) { el.innerHTML = `<span style="color:var(--red)">Error: ${e.message}</span>`; }

--- a/demo/test/queries/01-basic-search.rq
+++ b/demo/test/queries/01-basic-search.rq
@@ -7,6 +7,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score
 WHERE {
-    (?entity ?score) luc:query ("default" "copper")
+    (?hit ?entity ?score) luc:query ("default" "copper")
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/02-filtered-search.rq
+++ b/demo/test/queries/02-filtered-search.rq
@@ -7,6 +7,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score
 WHERE {
-    (?entity ?score) luc:query ("default" "copper" '{"op":"=","args":[{"property":"state"},"QLD"]}')
+    (?hit ?entity ?score) luc:query ("default" "copper" '{"op":"=","args":[{"property":"state"},"QLD"]}')
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/05-combined.rq
+++ b/demo/test/queries/05-combined.rq
@@ -8,7 +8,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score ?field ?value ?count
 WHERE {
-    { (?entity ?score) luc:query ("default" "iron ore") }
+    { (?hit ?entity ?score) luc:query ("default" "iron ore") }
     UNION
     { (?field ?value ?count) luc:facet ("default" "iron ore" '["state", "status"]' 10) }
 }

--- a/demo/test/queries/07-filter-by-author.rq
+++ b/demo/test/queries/07-filter-by-author.rq
@@ -8,7 +8,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?entity ?score ?label
 WHERE {
-    (?entity ?score) luc:query ("default" "*" '{"op":"=","args":[{"property":"authorName"},"Dr Sarah Jones"]}') .
+    (?hit ?entity ?score) luc:query ("default" "*" '{"op":"=","args":[{"property":"authorName"},"Dr Sarah Jones"]}') .
     ?entity rdfs:label ?label .
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/08-spatial-bbox.rq
+++ b/demo/test/queries/08-spatial-bbox.rq
@@ -3,7 +3,7 @@
 # bbox = [swLon, swLat, neLon, neLat] = [112, -44, 154, -10]
 PREFIX luc: <urn:jena:lucene:index#>
 SELECT ?entity ?score WHERE {
-  (?entity ?score) luc:query ("default" "*"
+  (?hit ?entity ?score) luc:query ("default" "*"
     '{"op":"s_intersects","args":[{"property":"location"},{"bbox":[112,-44,154,-10]}]}'
     20)
 }

--- a/demo/test/queries/09-matchraw-multivalue.rq
+++ b/demo/test/queries/09-matchraw-multivalue.rq
@@ -8,7 +8,7 @@ PREFIX ex:  <http://example.org/mining/>
 
 SELECT ?entity ?score ?matchRaw ?identifier
 WHERE {
-    (?entity ?score ?matchRaw) luc:query ('["urn:jena:lucene:field#identifier"]' "94130" 10) .
+    (?hit ?entity ?score ?matchRaw) luc:query ('["urn:jena:lucene:field#identifier"]' "94130" 10) .
     ?entity ex:identifier ?identifier .
 }
 ORDER BY ?identifier

--- a/demo/test/queries/10-match-field-details.rq
+++ b/demo/test/queries/10-match-field-details.rq
@@ -1,0 +1,14 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Per-hit field match details using luc:match.
+# Searches the title field for "copper" and joins with luc:match
+# to retrieve which field matched and its stored value.
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?entity ?score ?field ?value
+WHERE {
+    (?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#label"]' "copper") .
+    (?hit ?field ?value) luc:match () .
+}
+ORDER BY DESC(?score)

--- a/docs/01-user-guide.md
+++ b/docs/01-user-guide.md
@@ -102,7 +102,7 @@ INSERT DATA {
 PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?s ?score WHERE {
-    (?s ?score) luc:query ("machine learning") .
+    (?hit ?s ?score) luc:query ("machine learning") .
 }
 ```
 
@@ -138,7 +138,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 # Only return results where category is "Technology"
 SELECT ?s ?score WHERE {
-    (?s ?score) luc:query ("default" "learning"
+    (?hit ?s ?score) luc:query ("default" "learning"
         '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
         20) .
 }
@@ -353,7 +353,7 @@ curl -s -X POST "http://localhost:3030/ds" \
     -H "Accept: application/json" \
     -d 'PREFIX luc: <urn:jena:lucene:index#>
 SELECT ?s ?score WHERE {
-  (?s ?score) luc:query ("learning") .
+  (?hit ?s ?score) luc:query ("learning") .
 } ORDER BY DESC(?score)'
 
 # Facets
@@ -371,7 +371,7 @@ curl -s -X POST "http://localhost:3030/ds" \
     -H "Accept: application/json" \
     -d 'PREFIX luc: <urn:jena:lucene:index#>
 SELECT ?s ?score WHERE {
-  (?s ?score) luc:query ("default" "learning" '\''{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'\'' 20)
+  (?hit ?s ?score) luc:query ("default" "learning" '\''{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'\'' 20)
 } ORDER BY DESC(?score)'
 ```
 

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -13,7 +13,7 @@ Supports field-scoped queries, CQL2-JSON filter arguments, sort pushdown, and fa
 ### Syntax
 
 ```
-(?entity ?score ?match ?totalHits ?graph ?field) luc:query (fieldSpec queryString filter? sort? limit? highlight?)
+(?hit ?entity ?score ?match ?totalHits ?graph) luc:query (fieldSpec queryString filter? sort? limit? highlight?)
 ```
 
 ### Arguments (positional, left to right)
@@ -44,16 +44,18 @@ Field IRIs correspond to the named resource IRIs in the SHACL index configuratio
 
 | Variable | Required | Type | Description |
 |----------|----------|------|-------------|
-| ?entity | Yes | IRI | Matched entity |
+| ?hit | Yes | Blank node | Query-scoped hit identifier for joining with `luc:match` |
+| ?entity | No | IRI | Matched entity |
 | ?score | No | float | Lucene relevance score |
-| ?match | No | IRI or literal | Stored value for the matched field. KEYWORD fields return an IRI, TEXT fields return a string literal, numeric fields return typed literals |
+| ?match | No | IRI or literal | Stored value for the first matched field. KEYWORD fields return an IRI, TEXT fields return a string literal, numeric fields return typed literals |
 | ?totalHits | No | xsd:integer | Total matching documents (same value on every row) |
 | ?graph | No | IRI | Named graph of the match |
-| ?field | No | IRI | Field IRI identifying the matched field (see below) |
+
+The `?hit` binding is a blank node (e.g. `_:hit0`, `_:hit1`) scoped to the query execution. It serves as a join key with `luc:match` to retrieve per-field match details. Each hit gets a unique blank node.
 
 The `?totalHits` binding returns the total number of documents matching the query and filters, regardless of the `limit` parameter. This is useful for displaying "Showing X of Y results" in search UIs. The value is computed efficiently using `IndexSearcher.count()` and is only evaluated when the variable is present in the subject.
 
-The `?field` binding returns the IRI of the Lucene field that was searched. For single-field queries (JSON array with one IRI), this is always bound to that field's IRI. For multi-field queries (`"default"` or array with multiple IRIs), this is currently unbound — Lucene returns hits at the document level without identifying which field matched. This is a known limitation; see [#48](https://github.com/aiworkerjohns/jena/issues/48).
+The `?match` binding returns the stored value from the first matched field. For full per-field match details (which fields matched, their values), use `luc:match`.
 
 > **Note:** All fields must be defined as named resources (with IRIs) in the SHACL index configuration. Blank node field definitions are not supported.
 
@@ -64,34 +66,35 @@ PREFIX luc: <urn:jena:lucene:index#>
 PREFIX field: <urn:jena:lucene:field#>
 
 # Simple search (all default fields)
-(?entity ?score) luc:query ("machine learning") .
+(?hit ?entity ?score) luc:query ("machine learning") .
 
 # Search with explicit "default"
-(?entity ?score) luc:query ("default" "machine learning") .
+(?hit ?entity ?score) luc:query ("default" "machine learning") .
 
 # Search a specific field (JSON array with one IRI)
-(?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning") .
+(?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning") .
 
 # Search multiple fields (JSON array of IRIs)
-(?entity ?score) luc:query ('["urn:jena:lucene:field#title", "urn:jena:lucene:field#description"]' "machine learning") .
+(?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title", "urn:jena:lucene:field#description"]' "machine learning") .
 
 # Search with limit
-(?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning" 20) .
+(?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning" 20) .
 
 # Search with total hit count
-(?entity ?score ?match ?totalHits) luc:query ("machine learning" 20) .
-
-# Search with field binding
-(?entity ?score ?match ?totalHits ?g ?field) luc:query ('["urn:jena:lucene:field#title"]' "machine learning" 20) .
+(?hit ?entity ?score ?match ?totalHits) luc:query ("machine learning" 20) .
 
 # Search with CQL filter (only Technology books)
-(?entity ?score) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
+(?hit ?entity ?score) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
 
 # Search with filter and total hit count
-(?entity ?score ?_match ?totalHits) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
+(?hit ?entity ?score ?_match ?totalHits) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
 
 # Search with sort (by field IRI)
-(?entity ?score) luc:query ("default" "learning" '{"field":"urn:jena:lucene:field#year","order":"desc"}' 10) .
+(?hit ?entity ?score) luc:query ("default" "learning" '{"field":"urn:jena:lucene:field#year","order":"desc"}' 10) .
+
+# Search with per-field match details (join with luc:match)
+(?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning") .
+(?hit ?field ?value) luc:match () .
 ```
 
 ### Filter JSON format (CQL2-JSON)
@@ -106,6 +109,64 @@ Filters use CQL2-JSON syntax. The `property` value is a field IRI:
 - `"and"` / `"or"` — boolean combinators
 - `"s_intersects"` — spatial intersection (LATLON fields)
 - Numeric comparisons (`">"`, `"<"`, `">="`, `"<="`) for INT/LONG/DOUBLE fields
+
+---
+
+## luc:match — Per-Hit Field Match Details
+
+Returns per-field match information for each hit from a preceding `luc:query`. Joins with `luc:query` via the shared `?hit` blank node.
+
+### Syntax
+
+```
+(?hit ?field ?value) luc:match ()
+```
+
+The object is always an empty list `()`.
+
+### Return bindings
+
+| Variable | Required | Type | Description |
+|----------|----------|------|-------------|
+| ?hit | Yes | Blank node | Join key — must match `?hit` from `luc:query` |
+| ?field | No | IRI | Field IRI identifying which field matched (e.g. `urn:jena:lucene:field#title`) |
+| ?value | No | IRI or literal | Stored value for the matched field. KEYWORD fields return IRIs, TEXT fields return string literals, numeric fields return typed literals |
+
+`luc:match` produces one row per matched field per hit. If a document matched on two fields (e.g. both `title` and `description`), two rows are returned for that hit.
+
+### How it works
+
+`luc:match` uses Lucene's `NamedMatches` API to determine which fields contributed to each hit. During the initial `luc:query` search, each per-field sub-query is wrapped with `NamedMatches.wrapQuery(fieldIri, fieldQuery)`. After search, `Weight.matches()` is called per hit to extract field-level match details without re-scoring.
+
+### Requirements
+
+- `luc:match` must appear in the same SPARQL query as a `luc:query` — it reads from `luc:query`'s shared `SearchExecution` state
+- Without a preceding `luc:query`, `luc:match` returns no results
+- The `?hit` variable must be shared between `luc:query` and `luc:match` for the join to work
+
+### Examples
+
+```sparql
+PREFIX luc: <urn:jena:lucene:index#>
+
+# Get field match details for each hit
+SELECT ?entity ?field ?value WHERE {
+    (?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "learning") .
+    (?hit ?field ?value) luc:match () .
+}
+
+# Multi-field search with field attribution
+SELECT ?entity ?score ?field ?value WHERE {
+    (?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title", "urn:jena:lucene:field#description"]' "machine learning") .
+    (?hit ?field ?value) luc:match () .
+}
+
+# OPTIONAL match — hits still returned even without field details
+SELECT ?entity ?score ?field ?value WHERE {
+    (?hit ?entity ?score) luc:query ("default" "learning") .
+    OPTIONAL { (?hit ?field ?value) luc:match () . }
+}
+```
 
 ---
 
@@ -174,7 +235,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 # Query 1: search results
 SELECT ?entity ?score WHERE {
-    (?entity ?score) luc:query ("learning") .
+    (?hit ?entity ?score) luc:query ("learning") .
 }
 
 # Query 2: facet counts
@@ -194,7 +255,7 @@ If a single SPARQL request is preferred, use `UNION` to return both result sets 
 PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score ?totalHits ?field ?value ?count WHERE {
-    { (?entity ?score ?_match ?totalHits) luc:query ("default" "learning" 10) . }
+    { (?hit ?entity ?score ?_match ?totalHits) luc:query ("default" "learning" 10) . }
     UNION
     { (?field ?value ?count) luc:facet ("default" "learning"
         '["urn:jena:lucene:field#category"]' 10) . }
@@ -210,7 +271,7 @@ Placing both PFs in the same basic graph pattern produces a cartesian product:
 ```sparql
 # WARNING: produces N × M rows
 SELECT ?entity ?score ?field ?value ?count WHERE {
-    (?entity ?score) luc:query ("learning") .
+    (?hit ?entity ?score) luc:query ("learning") .
     (?field ?value ?count) luc:facet ("default" "learning"
         '["urn:jena:lucene:field#category"]' 10) .
 }
@@ -222,7 +283,7 @@ With 100 hits and 10 facet values, this returns 1,000 rows — every hit paired 
 
 ## Shared Execution
 
-When `luc:query` and `luc:facet` appear in the same SPARQL query (whether in a BGP, UNION, or subquery) with matching parameters, they share a single Lucene execution internally. One Lucene query, one index reader snapshot, consistent results.
+When `luc:query`, `luc:facet`, and `luc:match` appear in the same SPARQL query (whether in a BGP, UNION, or subquery) with matching parameters, they share a single Lucene execution internally. One Lucene query, one index reader snapshot, consistent results.
 
 The match is based on normalised keys — search field IRIs are sorted, CQL filter maps are sorted by field. If parameters differ, each PF executes independently.
 

--- a/docs/04-architecture.md
+++ b/docs/04-architecture.md
@@ -99,7 +99,7 @@ sequenceDiagram
     SE->>L: Execute query (first access, lazy)
     L-->>SE: Hits + reader snapshot
     SE-->>QP: Hit URIs + scores
-    QP-->>S: (?s ?score) bindings
+    QP-->>S: (?hit ?s ?score) bindings
 
     S->>FP: luc:facet ("default" "learning" '["urn:jena:lucene:field#category"]')
     FP->>SE: getOrCreate(same key) — reuses existing

--- a/docs/06-design-decisions.md
+++ b/docs/06-design-decisions.md
@@ -85,7 +85,7 @@
 For the public SPARQL/API contract, field references are always IRIs. The internal Lucene field name from `idx:fieldName` is not exposed to users. The only plain strings that remain in the external syntax are the Lucene query string itself and the special `"default"` fieldSpec shorthand.
 
 ```sparql
-(?s ?sc) luc:query ("default" "learning"
+(?hit ?s ?sc) luc:query ("default" "learning"
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}') .
 (?f ?v ?c) luc:facet ("default" "learning"
     '["urn:jena:lucene:field#category", "urn:jena:lucene:field#author"]') .

--- a/docs/08-use-cases.md
+++ b/docs/08-use-cases.md
@@ -29,14 +29,14 @@ flowchart LR
 
 ```sparql
 # Simple search
-(?s ?score) luc:query ("climate change") .
+(?hit ?s ?score) luc:query ("climate change") .
 
 # Search narrowed to a publisher (CQL2-JSON filter)
-(?s ?score) luc:query ("default" "climate change"
+(?hit ?s ?score) luc:query ("default" "climate change"
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#publisher"},"CSIRO"]}') .
 
 # Multiple filters (AND across fields)
-(?s ?score) luc:query ("default" "climate"
+(?hit ?s ?score) luc:query ("default" "climate"
     '{"op":"and","args":[{"op":"=","args":[{"property":"urn:jena:lucene:field#publisher"},"CSIRO"]},{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Environment"]}]}') .
 ```
 
@@ -106,7 +106,7 @@ flowchart TB
 # Recommended: separate queries, clean result shapes
 # Query 1 — hits
 SELECT ?s ?score WHERE {
-    (?s ?score) luc:query ("climate change") .
+    (?hit ?s ?score) luc:query ("climate change") .
 }
 
 # Query 2 — facets
@@ -116,7 +116,7 @@ SELECT ?field ?value ?count WHERE {
 
 # Alternative: single query via UNION (N+M rows, no cartesian product)
 SELECT ?s ?score ?field ?value ?count WHERE {
-    { (?s ?score) luc:query ("climate change") . }
+    { (?hit ?s ?score) luc:query ("climate change") . }
     UNION
     { (?field ?value ?count) luc:facet ("climate change" '["urn:jena:lucene:field#category", "urn:jena:lucene:field#publisher"]' 10) . }
 }
@@ -254,7 +254,7 @@ field:referencedBy
 Filter search results and facet counts by geographic region using CQL2-JSON spatial operators. Supports bounding box and polygon geometries via Lucene `LatLonShape`.
 
 ```sparql
-(?s ?score) luc:query ("default" "gold mine"
+(?hit ?s ?score) luc:query ("default" "gold mine"
     '{"op":"s_intersects","args":[{"property":"urn:jena:lucene:field#location"},{"bbox":[115,-35,120,-30]}]}'
     20)
 ```
@@ -309,7 +309,7 @@ Example query:
 PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?s ?score WHERE {
-    (?s ?score) luc:query ("urn:jena:lucene:field#identifier" "BH12") .
+    (?hit ?s ?score) luc:query ("urn:jena:lucene:field#identifier" "BH12") .
 }
 ```
 

--- a/docs/09-spatial.md
+++ b/docs/09-spatial.md
@@ -67,7 +67,7 @@ Use the `s_intersects` operator in the CQL2-JSON filter argument of `luc:query`:
 PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score WHERE {
-    (?entity ?score) luc:query ("default" "*"
+    (?hit ?entity ?score) luc:query ("default" "*"
         '{"op":"s_intersects","args":[{"property":"urn:jena:lucene:field#location"},{"bbox":[112,-44,154,-10]}]}'
         20)
 }
@@ -79,7 +79,7 @@ The `bbox` array follows the CQL2 convention: `[swLon, swLat, neLon, neLat]`.
 
 ```sparql
 SELECT ?entity ?score WHERE {
-    (?entity ?score) luc:query ("default" "gold mine"
+    (?hit ?entity ?score) luc:query ("default" "gold mine"
         '{"op":"s_intersects","args":[{"property":"urn:jena:lucene:field#location"},{"bbox":[115,-35,120,-30]}]}'
         20)
 }
@@ -93,7 +93,7 @@ Spatial filters can be combined with property filters using `and`:
 
 ```sparql
 SELECT ?entity ?score WHERE {
-    (?entity ?score) luc:query ("default" "*"
+    (?hit ?entity ?score) luc:query ("default" "*"
         '{"op":"and","args":[{"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"WA"]},{"op":"s_intersects","args":[{"property":"urn:jena:lucene:field#location"},{"bbox":[115,-35,120,-30]}]}]}'
         20)
 }

--- a/docs/2026-03-30_identifier_prefix_search_use_case.md
+++ b/docs/2026-03-30_identifier_prefix_search_use_case.md
@@ -88,7 +88,7 @@ Example prefix query:
 PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?s ?score WHERE {
-    (?s ?score) luc:query ("urn:jena:lucene:field#identifier" "BH12") .
+    (?hit ?s ?score) luc:query ("urn:jena:lucene:field#identifier" "BH12") .
 }
 ```
 

--- a/docs/2026-04-02_luc_match_design.md
+++ b/docs/2026-04-02_luc_match_design.md
@@ -1,0 +1,536 @@
+---
+title: "luc:match design for field-level search matches and highlighting"
+date: "2026-04-02"
+---
+
+# 2026-04-02 `luc:match` Design
+
+## Purpose
+
+This note defines the proposed architecture for adding a new `luc:match` SPARQL property function alongside the existing `luc:query` and `luc:facet` functions.
+
+The goal is to support:
+
+- field-level match attribution for entity-per-document search hits
+- optional field-level highlighting/snippets
+- a clean mapping from RDF/SHACL field definitions to Lucene fields
+- a result model that does not collapse document hits and per-field match details into one ambiguous flat row shape
+
+This design is motivated primarily by issue `#48` (`?field binding unbound for multi-field luc:query`) and by the requirement to preserve a sensible architecture rather than patching around Lucene behavior heuristically.
+
+## Problem
+
+In the current SHACL-mode design:
+
+- one RDF entity becomes one Lucene document
+- one SHACL field definition becomes one Lucene field name plus one external field IRI
+- `luc:query` returns document hits
+- the optional `?field` binding in `luc:query` is only meaningful when exactly one search field was queried
+
+This is not an accident. Lucene search returns top documents, not "document x field" pairs. In Lucene 10.3.1:
+
+- `TopDocs` returns top-ranked documents
+- `ScoreDoc` exposes `doc`, `score`, and `shardIndex`
+- neither `TopDocs` nor `ScoreDoc` directly exposes which field matched
+
+This means the current behavior is correct: multi-field search cannot derive a reliable scalar `?field` binding from `TopDocs` alone.
+
+## Design Constraints
+
+The design must preserve these architectural rules:
+
+- external search field identity is the field IRI, not the internal Lucene field name
+- the search field is an indexed field definition, not necessarily an RDF predicate
+- a field may correspond to a direct predicate, an inverse path, a sequence path, or other SHACL path-derived value
+- `luc:query` remains document-hit-oriented
+- `luc:facet` remains aggregation-oriented
+- field match details must not be modeled as though Lucene inherently returns a single matching field per hit
+
+This means the correct conceptual model is:
+
+- one search hit maps to zero, one, or many field matches
+
+## Why A New PF Is Needed
+
+Trying to force field matches into `luc:query` creates several problems:
+
+- `luc:query` is currently one row per hit; field matches are a child relation of a hit
+- multi-field matches can produce multiple valid field bindings for a single hit
+- optional highlighting is naturally field-scoped, not hit-scoped
+- row expansion inside `luc:query` would make limit, pagination, and ranking semantics harder to reason about
+
+Therefore the API should be split:
+
+- `luc:query` returns hits
+- `luc:match` returns per-hit field match details
+
+This mirrors the earlier decision to keep `luc:query` and `luc:facet` separate instead of flattening hits and aggregations into one shape.
+
+## Motivation For The Split
+
+The existing `luc:query` + `luc:facet` split avoids a cartesian product between two unrelated result sets:
+
+- search hits
+- facet aggregations
+
+Those two shapes have no natural join key, so `UNION` is the right way to combine them in a single SPARQL response.
+
+`luc:query` + `luc:match` is different. `luc:match` is not an unrelated aggregation. It is a child relation of a specific hit.
+
+That means a join key is natural and correct here. The row count grows with actual field match multiplicity, not with an accidental cross join between unrelated shapes.
+
+## Proposed Surface API
+
+### `luc:query`
+
+Keep `luc:query` document-oriented.
+
+Current conceptual shape:
+
+```sparql
+(?hit ?s ?score ?totalHits) luc:query (fieldSpec queryString filter? sort? limit?)
+```
+
+Notes:
+
+- `?hit` is a query-scoped hit identifier
+- `?s` is the entity URI
+- `?score` and `?totalHits` remain hit-level values
+- optional scalar `?field` on `luc:query` should remain conservative:
+  - bound when exactly one matched field is known
+  - unbound when there are zero or multiple field matches
+
+The existing subject shape can be extended carefully or a new result ordering can be introduced, but the core requirement is that `luc:query` exposes a hit id if `luc:match` is to join to it.
+
+### `luc:match`
+
+Add a new PF returning field-level matches for a hit:
+
+```sparql
+(?hit ?field ?value ?snippet) luc:match ()
+```
+
+Alternative forms are possible, but the intended semantics are:
+
+- one row per matched field for a specific hit
+- `?field` is the field IRI
+- `?value` is the matched stored value when one can be sensibly selected
+- `?snippet` is an optional highlight/snippet for that field
+
+This PF should operate against the current shared `SearchExecution`, not run a second independent Lucene search.
+
+### Example Shape
+
+```sparql
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?s ?score ?field ?snippet WHERE {
+  (?hit ?s ?score ?totalHits) luc:query (
+    '["urn:jena:lucene:field#title","urn:jena:lucene:field#description"]'
+    "machine learning"
+    10
+  ) .
+
+  OPTIONAL {
+    (?hit ?field ?value ?snippet) luc:match () .
+  }
+}
+```
+
+This produces:
+
+- one row for each hit-field match pair
+- one row with unbound `?field` / `?value` / `?snippet` for hits with zero field matches when the `OPTIONAL` branch is used
+
+It does not produce the bad `N x M` cartesian product that occurs when joining unrelated hit and facet result sets without a shared variable.
+
+## Zero, One, Or Many Field Matches
+
+### Zero
+
+A hit may legitimately have zero field matches. Main cases:
+
+- `MatchAllDocsQuery`
+- a filter-only search with no meaningful text clause
+- any query shape where a document is admitted without a field-specific text match suitable for attribution or highlighting
+
+This is acceptable and should not be patched over with a fake field IRI.
+
+### One
+
+This is likely the most common case in ordinary search UX:
+
+- a user query happens to match only one indexed field on a hit
+- that hit gets one `luc:match` row
+- scalar `?field` in `luc:query` may also be bound if we choose to preserve that shortcut
+
+### Many
+
+This is also legitimate:
+
+- the same hit may match `field:title` and `field:description`
+- a future UI may wish to show two snippets
+- a downstream flat model may wish to emit both field IRIs as predicates on a search-hit node
+
+The architecture must preserve that multiplicity rather than collapsing it prematurely.
+
+## Public Semantics
+
+### Field identity
+
+The public field identifier remains the field IRI from the SHACL configuration.
+
+This is essential because:
+
+- the internal Lucene field name is an implementation detail
+- the field may come from a complex SHACL path, not a single RDF predicate
+- customer-facing flat models can use field IRIs directly as predicates if desired
+
+### `?value`
+
+`?value` should be interpreted as:
+
+- the representative stored value for that field on that hit that corresponds to the match, when such a value can be identified
+
+This is already approximated for single-field queries via `extractValueNode()` and `selectStoredValue()` in the current SHACL query path. That logic can be reused, but only after the field match set is known.
+
+### `?snippet`
+
+`?snippet` is optional. If highlighting is not requested, it can be left unbound.
+
+If highlighting is requested:
+
+- `?snippet` should be field-specific
+- one snippet per field match is the cleanest first version
+- later work can add multiple passages per field if needed
+
+## Lucene Architecture
+
+### Key Lucene APIs
+
+The important Lucene 10.3.1 APIs for this design are:
+
+- `TopDocs`
+- `ScoreDoc`
+- `IndexSearcher.createWeight(Query, ScoreMode, float)`
+- `Weight.matches(LeafReaderContext, int)`
+- `Matches`
+- `NamedMatches`
+- `NamedMatches.wrapQuery(String, Query)`
+- `NamedMatches.findNamedMatches(Matches)`
+- `UnifiedHighlighter`
+- `UnifiedHighlighter.highlightFields(String[], Query, TopDocs, int[])`
+
+The relevant confirmed signatures are:
+
+- `Weight.matches(LeafReaderContext, int)`
+- `NamedMatches.wrapQuery(String, Query)`
+- `NamedMatches.findNamedMatches(Matches)`
+
+That gives us a clean field attribution path:
+
+1. Build one Lucene subquery per search field.
+2. Wrap each field-specific subquery with a name.
+3. Combine them into a single Lucene query.
+4. Run one top-doc search.
+5. For each hit, inspect `Matches` and extract named subquery hits.
+6. Map those names back to field IRIs.
+
+## Why Not Rely On `TopDocs` Alone
+
+`TopDocs` is only the ranked document result set. It does not answer:
+
+- which field clause matched
+- how many field clauses matched
+- where the match occurred inside the field text
+
+That information lives lower in Lucene's query/match model, not in the top-hit container.
+
+## Why `NamedMatches` Is The Right Fit
+
+`NamedMatches` is consistent with the intended design because the field attribution model is:
+
+- one named Lucene subquery per field
+
+That is exactly the structure we need.
+
+The field name used in `NamedMatches.wrapQuery(name, query)` should be a stable public identifier. The preferred choice is the field IRI string.
+
+This yields:
+
+- Lucene internal execution over field-specific clauses
+- clean extraction of matched field identifiers
+- no need to infer field identity heuristically from `Explanation` strings or top-doc metadata
+
+## Highlighting And Its Relationship To `luc:match`
+
+Highlighting does not replace field attribution. It complements it.
+
+Recommended division of responsibility:
+
+- `NamedMatches` determines which field clauses matched
+- highlighting generates display snippets for those fields
+
+For highlighting, Lucene's `UnifiedHighlighter` is the main API to investigate first because it supports:
+
+- field-aware highlighting
+- multi-field highlighting
+- use of `TopDocs`
+- `setWeightMatches(true)` for match-aware highlighting behavior
+
+The suggested order of operations is:
+
+1. determine matched fields using `NamedMatches`
+2. if highlighting was requested, ask `UnifiedHighlighter` for snippets only for those matched fields
+
+This keeps highlighting as an optional display concern rather than the primary truth source for match attribution.
+
+## Query Construction Strategy
+
+### Current behavior
+
+Current SHACL-mode query construction uses:
+
+- `QueryParser` for one field
+- `MultiFieldQueryParser` for multiple fields
+
+This is implemented in `ShaclTextIndexLucene.parseQueryForFields(...)`.
+
+That is fine for plain search, but for field attribution it is too opaque. `MultiFieldQueryParser` hides the per-field subquery structure that we need to name explicitly.
+
+### Proposed behavior
+
+Introduce a new multi-field query builder for SHACL mode:
+
+- if one field is searched:
+  - keep the single-field parser path
+- if multiple fields are searched:
+  - parse the user query once per field using a field-specific `QueryParser`
+  - wrap each field query with `NamedMatches.wrapQuery(fieldIri, fieldQuery)`
+  - combine wrapped field queries in a `BooleanQuery` using `SHOULD`
+
+This preserves document-level ranking while making field-level matches inspectable.
+
+Conceptually:
+
+```java
+BooleanQuery.Builder bq = new BooleanQuery.Builder();
+for (ResolvedField f : fields) {
+    QueryParser qp = new QueryParser(f.luceneFieldName(), analyzer);
+    Query fieldQuery = qp.parse(queryString);
+    Query named = NamedMatches.wrapQuery(f.fieldIri(), fieldQuery);
+    bq.add(named, BooleanClause.Occur.SHOULD);
+}
+Query query = bq.build();
+```
+
+If future requirements need more exact parity with `MultiFieldQueryParser`, this builder can be expanded. The important architectural point is that multi-field search must retain explicit field clause identity.
+
+## Shared Execution Design
+
+`luc:match` should reuse the same shared `SearchExecution` mechanism already used by `luc:query` and `luc:facet`.
+
+Current `SearchExecution` stores:
+
+- hits
+- facet counts
+- total hit count
+
+It should be extended to store:
+
+- a query-scoped list of hit records with stable hit ids
+- per-hit field match details
+- optional per-hit, per-field snippets when highlighting is requested
+
+Recommended internal model:
+
+```text
+SearchHit
+  hitId
+  entityNode
+  score
+  totalHits
+  graph?
+
+FieldMatch
+  hitId
+  fieldIri
+  valueNode?
+  snippet?
+```
+
+This remains query-scoped, not globally materialized RDF.
+
+## Join Semantics
+
+Joining `luc:query` and `luc:match` on `?hit` is expected and correct.
+
+This is not the same problem as joining `luc:query` and `luc:facet` without a shared variable.
+
+Row growth is proportional to actual field-match multiplicity:
+
+- roughly `sum(fieldMatchesPerHit)`
+
+This may expand rows, but it is not a cartesian explosion between unrelated relations.
+
+## Repo Classes To Change
+
+### Likely core classes
+
+- `jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java`
+- `jena-text/src/main/java/org/apache/jena/query/text/SearchExecution.java`
+- `jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java`
+- `jena-text/src/main/java/org/apache/jena/query/text/TextHit.java`
+- `jena-text/src/main/java/org/apache/jena/query/text/TextQuery.java`
+
+### New classes likely needed
+
+- `LucMatchPF.java` or `TextMatchPF.java`
+- `SearchHit.java`
+- `FieldMatch.java`
+- possibly a small helper class for resolved search fields:
+  - field IRI
+  - Lucene field name
+  - field definition
+
+### Tests likely needed
+
+- `TestLucMatchPF`
+- `TestShaclLucMatchSingleField`
+- `TestShaclLucMatchMultiField`
+- `TestShaclLucMatchHighlighting`
+- `TestShaclLucMatchMatchAllDocs`
+- `TestSearchExecution` updates for hit id and match caching
+
+## Detailed Implementation Plan
+
+### 1. Introduce a resolved field abstraction
+
+Current code often resolves directly to Lucene field names. For `luc:match`, we need both:
+
+- field IRI
+- Lucene field name
+
+Add a helper in `ShaclTextIndexLucene` or `ShaclIndexMapping` that resolves a requested field spec into a richer object rather than just a string list.
+
+### 2. Replace opaque multi-field parsing in the SHACL query path
+
+Keep the current single-field path for the simple case.
+
+For multi-field:
+
+- build one field-specific query per field
+- wrap it with `NamedMatches.wrapQuery(fieldIri, q)`
+- OR them together with `BooleanQuery`
+
+This query object should become the canonical text query used by:
+
+- top-doc search
+- `Weight.matches(...)`
+- optional highlighting
+
+### 3. Extend `SearchExecution`
+
+`SearchExecution` should own:
+
+- the shared top-doc search result
+- a stable hit list with hit ids
+- optional lazy field-match computation
+- optional lazy highlighting computation
+
+Possible new methods:
+
+- `List<SearchHit> getSearchHits(int limit, String highlight)`
+- `List<FieldMatch> getFieldMatches()`
+- `List<FieldMatch> getFieldMatchesForHit(String hitId)`
+
+### 4. Compute field matches lazily from Lucene `Matches`
+
+For each returned `ScoreDoc`:
+
+- determine the correct `LeafReaderContext`
+- convert the global doc id in `ScoreDoc.doc` to the segment-local doc id for that leaf
+- build a `Weight` from the rewritten query using `IndexSearcher.createWeight(query, ScoreMode.COMPLETE, 1.0f)`
+- call `weight.matches(leaf, segmentDocId)`
+- call `NamedMatches.findNamedMatches(matches)`
+- convert named match results to field IRIs
+
+This match computation should happen only when `luc:match` or scalar `?field` actually requires it.
+
+### 5. Rework scalar `?field` in `luc:query`
+
+Scalar `?field` should remain a convenience binding only.
+
+Suggested rule:
+
+- if exactly one field match exists for a hit, bind it
+- otherwise leave `?field` unbound
+
+This preserves simple use while avoiding incorrect collapse of many-to-one match data.
+
+### 6. Add `luc:match`
+
+Implement a new PF that:
+
+- reads the shared `SearchExecution`
+- joins by `?hit`
+- emits one row per field match
+- optionally emits `?value` and `?snippet`
+
+The PF must not trigger an independent Lucene search when a matching `SearchExecution` already exists.
+
+### 7. Add optional highlighting
+
+When a highlight option is present:
+
+- compute matched fields first
+- request snippets only for matched fields
+- store snippets as part of `FieldMatch`
+
+`UnifiedHighlighter` should be the primary API investigated first.
+
+## Open Questions
+
+### Hit id shape
+
+The hit id should be query-scoped and stable within one execution. Options:
+
+- a blank-node-like synthetic node
+- a generated URI in an internal namespace
+- a literal key
+
+A generated internal URI or stable blank-node-like abstraction is sufficient. It does not need to be persistent across requests.
+
+### Should `luc:match` require a search term?
+
+Architecturally no, but product-wise top docs for bare `MatchAllDocsQuery` are weak. It is reasonable to document that UIs should avoid presenting ranked top docs until the user has entered a query or otherwise meaningfully narrowed the result set.
+
+### Should field IRIs be emitted as predicates directly?
+
+That can be supported as a projection layer over `FieldMatch`, but the search core should not pretend those triples are part of the source RDF graph. The clean semantic model is:
+
+- hit node
+- field match rows on the hit node
+
+## Recommendation
+
+Proceed with a new `luc:match` PF rather than trying to overload `luc:query`.
+
+The recommended architecture is:
+
+- `luc:query` returns hits
+- `luc:facet` returns aggregations
+- `luc:match` returns per-hit field matches
+- shared Lucene execution is held in `SearchExecution`
+- field attribution is computed with Lucene `Matches` / `NamedMatches`
+- highlighting is optional and field-scoped
+- field IRIs remain the public identifier
+
+This is the cleanest way to support:
+
+- field-level attribution
+- optional snippets
+- correct zero/one/many field multiplicity
+- customer-facing flat models based on field IRIs
+
+without sacrificing the entity-per-document architecture or relying on heuristics built on top of `TopDocs`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ This documentation covers the faceted search and entity-per-document indexing fe
 | Entity-per-document indexing | Done | — | SHACL shapes define entity types with typed fields (TEXT, KEYWORD, INT, LONG, DOUBLE, LATLON) |
 | Text search with filters | Done | `luc:query` | Full-text search with CQL2-JSON structured filters |
 | Facet counts | Done | `luc:facet` | Field value counts with maxValues, minCount controls |
-| Shared execution | Done | — | `luc:query` + `luc:facet` share a single Lucene search when co-occurring |
+| Per-hit field match details | Done | `luc:match` | Join with `luc:query` via `?hit` to get which fields matched and their values |
+| Shared execution | Done | — | `luc:query` + `luc:facet` + `luc:match` share a single Lucene search when co-occurring |
 | Automatic index maintenance | Done | — | Change listener rebuilds entity docs on triple add/delete |
 | Inverse and sequence paths | Done | — | `sh:inversePath` and multi-hop sequence paths for cross-entity indexing |
 | Spatial filtering | Done | `luc:query`/`luc:facet` | Bounding-box and polygon filter via LatLonShape. See [Spatial Filtering](09-spatial.md) |
@@ -25,7 +26,7 @@ This documentation covers the faceted search and entity-per-document indexing fe
 
 All proposed extensions are additive — no breaking changes to existing query or response models.
 
-Public API rule: external field references are always IRIs in `luc:query`, `luc:facet`, CQL filter `property` entries, sort specs, and returned `?field` bindings. Internal Lucene field names from `idx:fieldName` remain implementation details, except for the special `"default"` fieldSpec shorthand and ordinary Lucene query strings supplied as search text.
+Public API rule: external field references are always IRIs in `luc:query`, `luc:facet`, `luc:match`, CQL filter `property` entries, sort specs, and returned `?field` bindings. Internal Lucene field names from `idx:fieldName` remain implementation details, except for the special `"default"` fieldSpec shorthand and ordinary Lucene query strings supplied as search text.
 
 ### Component Architecture (current implementation)
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/FieldMatch.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/FieldMatch.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import org.apache.jena.graph.Node;
+
+/**
+ * A per-field match detail for a search hit.
+ * <p>
+ * Represents one field that matched a query for a specific document,
+ * with optional stored value and highlight snippet.
+ */
+public class FieldMatch {
+    private final Node fieldIRI;
+    private final Node value;
+    private final Node snippet;
+
+    public FieldMatch(Node fieldIRI, Node value, Node snippet) {
+        this.fieldIRI = fieldIRI;
+        this.value = value;
+        this.snippet = snippet;
+    }
+
+    public Node getFieldIRI() { return fieldIRI; }
+    public Node getValue() { return value; }
+    public Node getSnippet() { return snippet; }
+
+    @Override
+    public String toString() {
+        return "FieldMatch{field=" + fieldIRI + " value=" + value + "}";
+    }
+}

--- a/jena-text/src/main/java/org/apache/jena/query/text/SearchExecution.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SearchExecution.java
@@ -52,9 +52,11 @@ public class SearchExecution {
 
     // Lazy results
     private List<TextHit> hits;
+    private List<SearchHit> searchHits;
     private Map<String, List<FacetValue>> facetCounts;
     private long totalHits = -1;
     private boolean hitsComputed = false;
+    private boolean searchHitsComputed = false;
     private boolean facetCountsComputed = false;
 
     public SearchExecution(List<String> searchFields, String queryString,
@@ -143,6 +145,25 @@ public class SearchExecution {
             hitsComputed = true;
         }
         return hits;
+    }
+
+    /**
+     * Get search hits with stable hit IDs and field match data.
+     * Uses NamedMatches for field-level match attribution.
+     */
+    public synchronized List<SearchHit> getSearchHits(int limit) {
+        if (!searchHitsComputed) {
+            try {
+                List<String> resolved = textIndex.resolveSearchFields(searchFields);
+                searchHits = textIndex.searchWithHitIds(resolved, queryString, filter,
+                    sortSpecs, graphURI, lang, limit);
+            } catch (Exception e) {
+                log.error("Error computing search hits: {}", e.getMessage());
+                searchHits = Collections.emptyList();
+            }
+            searchHitsComputed = true;
+        }
+        return searchHits;
     }
 
     /**

--- a/jena-text/src/main/java/org/apache/jena/query/text/SearchHit.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SearchHit.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+
+/**
+ * A search hit with a stable query-scoped identifier for joining with {@code luc:match}.
+ * <p>
+ * Each hit gets a blank node ID like {@code _:hit0}, {@code _:hit1}, etc.
+ * that is stable within a single SPARQL query execution.
+ */
+public class SearchHit {
+    private final Node hitId;
+    private final Node entityNode;
+    private final float score;
+    private final Node graph;
+    private final int luceneDocId;
+    private List<FieldMatch> fieldMatches;
+
+    public SearchHit(int index, Node entityNode, float score, Node graph, int luceneDocId) {
+        this.hitId = NodeFactory.createBlankNode("hit" + index);
+        this.entityNode = entityNode;
+        this.score = score;
+        this.graph = graph;
+        this.luceneDocId = luceneDocId;
+    }
+
+    public Node getHitId() { return hitId; }
+    public Node getEntityNode() { return entityNode; }
+    public float getScore() { return score; }
+    public Node getGraph() { return graph; }
+    public int getLuceneDocId() { return luceneDocId; }
+
+    public List<FieldMatch> getFieldMatches() {
+        return fieldMatches != null ? fieldMatches : Collections.emptyList();
+    }
+
+    public void setFieldMatches(List<FieldMatch> fieldMatches) {
+        this.fieldMatches = fieldMatches != null ? new ArrayList<>(fieldMatches) : null;
+    }
+
+    @Override
+    public String toString() {
+        return "SearchHit{id=" + hitId + " entity=" + entityNode + " score=" + score + "}";
+    }
+}

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -48,12 +48,15 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.*;
+import org.apache.lucene.search.NamedMatches;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
@@ -170,6 +173,194 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
         MultiFieldQueryParser mqp = new MultiFieldQueryParser(fieldArray, getQueryAnalyzer());
         mqp.setAllowLeadingWildcard(true);
         return mqp.parse(queryString);
+    }
+
+    /**
+     * Build a query with NamedMatches wrapping for field attribution.
+     * For multi-field queries, each field gets a named sub-query so
+     * we can later determine which field(s) matched each hit.
+     */
+    protected Query buildNamedQuery(String queryString, List<String> resolvedFields) throws ParseException {
+        if ("*".equals(queryString)) {
+            return new MatchAllDocsQuery();
+        }
+        if (resolvedFields.size() == 1) {
+            String fieldName = resolvedFields.get(0);
+            QueryParser qp = new QueryParser(fieldName, getQueryAnalyzer());
+            qp.setAllowLeadingWildcard(true);
+            Query fieldQuery = qp.parse(queryString);
+            // Wrap with field IRI as the name
+            ShaclIndexMapping.FieldDef fd = shaclMapping.findFieldByName(fieldName);
+            String name = fd != null ? fd.getFieldIRI().getURI() : fieldName;
+            return NamedMatches.wrapQuery(name, fieldQuery);
+        }
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        for (String fieldName : resolvedFields) {
+            QueryParser qp = new QueryParser(fieldName, getQueryAnalyzer());
+            qp.setAllowLeadingWildcard(true);
+            Query fieldQuery = qp.parse(queryString);
+            ShaclIndexMapping.FieldDef fd = shaclMapping.findFieldByName(fieldName);
+            String name = fd != null ? fd.getFieldIRI().getURI() : fieldName;
+            Query named = NamedMatches.wrapQuery(name, fieldQuery);
+            bq.add(named, BooleanClause.Occur.SHOULD);
+        }
+        return bq.build();
+    }
+
+    /**
+     * Execute a search and return SearchHit objects with stable hit IDs.
+     * The returned hits carry Lucene doc IDs for later field match extraction.
+     */
+    public List<SearchHit> searchWithHitIds(List<String> resolvedFields, String qs,
+            CqlExpression cqlFilter, List<SortSpec> sortSpecs,
+            String graphURI, String lang, int limit) {
+        try (IndexReader indexReader = DirectoryReader.open(getDirectory())) {
+            IndexSearcher searcher = new IndexSearcher(indexReader);
+
+            Query textQuery;
+            if (qs == null || qs.isEmpty()) {
+                textQuery = new MatchAllDocsQuery();
+            } else {
+                textQuery = buildNamedQuery(qs, resolvedFields);
+            }
+
+            Query finalQuery;
+            if (cqlFilter != null) {
+                BooleanQuery.Builder combined = new BooleanQuery.Builder();
+                combined.add(textQuery, BooleanClause.Occur.MUST);
+                CqlToLuceneCompiler compiler = new CqlToLuceneCompiler(shaclMapping);
+                CqlToLuceneCompiler.CompileResult result = compiler.compile(cqlFilter);
+                if (result.pushed() != null) {
+                    combined.add(result.pushed(), BooleanClause.Occur.MUST);
+                }
+                if (result.residual() != null) {
+                    log.warn("CQL filter has residual expressions ignored: {}",
+                        result.residual().toCanonical());
+                }
+                finalQuery = combined.build();
+            } else {
+                finalQuery = textQuery;
+            }
+
+            int maxHits = limit > 0 ? limit : MAX_N;
+            Sort luceneSort = buildLuceneSort(sortSpecs);
+
+            TopDocs topDocs;
+            if (luceneSort != null) {
+                topDocs = searcher.search(finalQuery, maxHits, luceneSort);
+            } else {
+                topDocs = searcher.search(finalQuery, maxHits);
+            }
+
+            String entityField = getDocDef().getEntityField();
+            StoredFields storedFields = searcher.storedFields();
+            List<SearchHit> results = new ArrayList<>();
+            int idx = 0;
+            for (ScoreDoc sd : topDocs.scoreDocs) {
+                Document doc = storedFields.document(sd.doc);
+                String uri = doc.get(entityField);
+                if (uri != null) {
+                    Node entityNode = TextQueryFuncs.stringToNode(uri);
+                    results.add(new SearchHit(idx++, entityNode, sd.score, null, sd.doc));
+                }
+            }
+
+            // Compute field matches using NamedMatches
+            if (!results.isEmpty() && !(textQuery instanceof MatchAllDocsQuery)) {
+                computeFieldMatches(searcher, textQuery, resolvedFields, results);
+            }
+
+            return results;
+        } catch (IOException ex) {
+            throw new TextIndexException("searchWithHitIds", ex);
+        } catch (ParseException ex) {
+            throw new TextIndexParseException(qs, ex.getMessage());
+        }
+    }
+
+    /**
+     * Compute field-level matches for each hit using Lucene's Matches/NamedMatches API.
+     */
+    private void computeFieldMatches(IndexSearcher searcher, Query textQuery,
+            List<String> resolvedFields, List<SearchHit> hits) throws IOException {
+        Query rewritten = searcher.rewrite(textQuery);
+        Weight weight = searcher.createWeight(rewritten, ScoreMode.COMPLETE, 1.0f);
+        List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
+
+        for (SearchHit hit : hits) {
+            int docId = hit.getLuceneDocId();
+            // Find the leaf context for this doc
+            int leafIdx = ReaderUtil.subIndex(docId, leaves);
+            LeafReaderContext leaf = leaves.get(leafIdx);
+            int segmentDocId = docId - leaf.docBase;
+
+            Matches matches = weight.matches(leaf, segmentDocId);
+            if (matches == null) continue;
+
+            // Extract named matches → field IRIs
+            Collection<NamedMatches> namedMatchList = NamedMatches.findNamedMatches(matches);
+            List<FieldMatch> fieldMatches = new ArrayList<>();
+
+            StoredFields storedFields = searcher.storedFields();
+            Document doc = storedFields.document(docId);
+
+            for (NamedMatches nm : namedMatchList) {
+                String name = nm.getName(); // This is the field IRI string
+                Node fieldIRI = NodeFactory.createURI(name);
+
+                ShaclIndexMapping.FieldDef fd = shaclMapping.findField(name);
+                Node valueNode = null;
+                if (fd != null) {
+                    String[] storedValues = doc.getValues(fd.getFieldName());
+                    if (storedValues != null && storedValues.length > 0) {
+                        String selected = selectStoredValue(fd.getFieldName(), storedValues, textQuery);
+                        valueNode = fieldValueToNode(fd, selected);
+                    }
+                }
+
+                fieldMatches.add(new FieldMatch(fieldIRI, valueNode, null));
+            }
+
+            // If no named matches found, fall back to field-level match check
+            if (fieldMatches.isEmpty()) {
+                for (String fieldName : resolvedFields) {
+                    MatchesIterator mi = matches.getMatches(fieldName);
+                    if (mi != null && mi.next()) {
+                        ShaclIndexMapping.FieldDef fd = shaclMapping.findFieldByName(fieldName);
+                        Node fieldIRI = fd != null ? fd.getFieldIRI()
+                            : NodeFactory.createLiteralString(fieldName);
+                        Node valueNode = null;
+                        if (fd != null) {
+                            String[] storedValues = doc.getValues(fieldName);
+                            if (storedValues != null && storedValues.length > 0) {
+                                String selected = selectStoredValue(fieldName, storedValues, textQuery);
+                                valueNode = fieldValueToNode(fd, selected);
+                            }
+                        }
+                        fieldMatches.add(new FieldMatch(fieldIRI, valueNode, null));
+                    }
+                }
+            }
+
+            hit.setFieldMatches(fieldMatches);
+        }
+    }
+
+    /**
+     * Convert a stored field value to an appropriate RDF node based on field type.
+     */
+    private Node fieldValueToNode(ShaclIndexMapping.FieldDef fd, String value) {
+        if (value == null || fd == null) return null;
+        return switch (fd.getFieldType()) {
+            case KEYWORD -> looksLikeUri(value)
+                ? NodeFactory.createURI(value)
+                : NodeFactory.createLiteralString(value);
+            case TEXT    -> NodeFactory.createLiteralString(value);
+            case INT     -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDinteger);
+            case LONG    -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDlong);
+            case DOUBLE  -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDdouble);
+            case LATLON  -> null;
+        };
     }
 
     // ---- Document building ----

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
@@ -46,7 +46,6 @@ import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.binding.BindingBuilder;
-import org.apache.jena.sparql.engine.binding.BindingFactory;
 import org.apache.jena.sparql.engine.iterator.QueryIterPlainWrapper;
 import org.apache.jena.sparql.engine.iterator.QueryIterSlice;
 import org.apache.jena.sparql.pfunction.PropFuncArg;
@@ -61,9 +60,10 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Argument format:
  * <pre>
- * (?entity ?score ?match ?totalHits ?graph ?field) luc:query (fieldSpec queryString cqlFilter? sortSpec? limit? highlight?)
+ * (?hit ?entity ?score ?match ?totalHits ?graph) luc:query (fieldSpec queryString cqlFilter? sortSpec? limit?)
  * </pre>
  * <p>
+ * {@code ?hit} is a query-scoped blank node identifier for joining with {@code luc:match}.
  * The first string literal is the field specification: {@code "default"} searches all
  * defaultSearch fields, and a JSON array of field IRIs like
  * {@code '["urn:jena:lucene:field#title","urn:jena:lucene:field#description"]'} searches specific fields.
@@ -83,7 +83,8 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         if (argSubject.isList()) {
             int size = argSubject.getArgListSize();
             if (size == 0 || size > 6) {
-                throw new QueryBuildException("Subject has " + size + " elements, must be 1-6: " + argSubject);
+                throw new QueryBuildException("Subject has " + size + " elements, must be 1-6 " +
+                    "(?hit ?entity ?score ?match ?totalHits ?graph): " + argSubject);
             }
         }
 
@@ -141,40 +142,39 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         argSubject = Substitute.substitute(argSubject, binding);
         argObject = Substitute.substitute(argObject, binding);
 
-        Node s = null, score = null, literal = null, totalHitsNode = null, graph = null, field = null;
+        // Subject shape: (?hit ?entity ?score ?match ?totalHits ?graph)
+        Node hit = null, entity = null, score = null, match = null, totalHitsNode = null, graph = null;
 
         if (argSubject.isList()) {
-            s = argSubject.getArg(0);
+            hit = argSubject.getArg(0);
             if (argSubject.getArgListSize() > 1) {
-                score = argSubject.getArg(1);
-                if (!score.isVariable())
-                    throw new QueryExecException("Hit score is not a variable: " + argSubject);
+                entity = argSubject.getArg(1);
             }
             if (argSubject.getArgListSize() > 2) {
-                literal = argSubject.getArg(2);
-                if (!literal.isVariable())
-                    throw new QueryExecException("Hit literal is not a variable: " + argSubject);
+                score = argSubject.getArg(2);
+                if (!score.isVariable())
+                    throw new QueryExecException("Score is not a variable: " + argSubject);
             }
             if (argSubject.getArgListSize() > 3) {
-                totalHitsNode = argSubject.getArg(3);
+                match = argSubject.getArg(3);
+                if (!match.isVariable())
+                    throw new QueryExecException("Match is not a variable: " + argSubject);
+            }
+            if (argSubject.getArgListSize() > 4) {
+                totalHitsNode = argSubject.getArg(4);
                 if (!totalHitsNode.isVariable())
                     throw new QueryExecException("Total hits is not a variable: " + argSubject);
             }
-            if (argSubject.getArgListSize() > 4) {
-                graph = argSubject.getArg(4);
-                if (!graph.isVariable())
-                    throw new QueryExecException("Hit graph is not a variable: " + argSubject);
-            }
             if (argSubject.getArgListSize() > 5) {
-                field = argSubject.getArg(5);
-                if (!field.isVariable())
-                    throw new QueryExecException("Hit field is not a variable: " + argSubject);
+                graph = argSubject.getArg(5);
+                if (!graph.isVariable())
+                    throw new QueryExecException("Graph is not a variable: " + argSubject);
             }
         } else {
-            s = argSubject.getArg();
+            hit = argSubject.getArg();
         }
 
-        if (s.isLiteral())
+        if (hit != null && hit.isLiteral())
             return IterLib.noResults(execCxt);
 
         QueryArgs args = parseArgs(argObject);
@@ -191,57 +191,62 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
             return IterLib.result(binding, execCxt);
         }
 
-        // Use SearchExecution for shared state with luc:facet
+        // Use SearchExecution for shared state with luc:facet and luc:match
         SearchExecution se = SearchExecution.getOrCreate(
             execCxt, args.searchFields, args.queryString,
             args.cqlFilter, args.sortSpecs, textIndex, null, null);
 
         int limit = args.limit > 0 ? args.limit : 10000;
-        List<TextHit> allHits = se.getHits(limit, args.highlight);
+        List<SearchHit> allHits = se.getSearchHits(limit);
 
-        Collection<TextHit> hits;
-        if (Var.isVar(s)) {
-            hits = allHits;
-        } else {
-            String subjStr = TextQueryFuncs.subjectToString(s);
+        Collection<SearchHit> hits;
+        if (entity != null && !Var.isVar(entity)) {
+            String entityStr = TextQueryFuncs.subjectToString(entity);
             hits = new ArrayList<>();
-            for (TextHit hit : allHits) {
-                if (subjStr.equals(TextQueryFuncs.subjectToString(hit.getNode()))) {
-                    hits.add(hit);
+            for (SearchHit sh : allHits) {
+                if (entityStr.equals(TextQueryFuncs.subjectToString(sh.getEntityNode()))) {
+                    hits.add(sh);
                 }
             }
+        } else {
+            hits = allHits;
         }
 
         long totalHits = totalHitsNode != null ? se.getTotalHits() : -1;
-        QueryIterator qIter = resultsToQueryIterator(binding, s, score, literal, totalHitsNode, totalHits, graph, field, hits, execCxt);
+        QueryIterator qIter = resultsToQueryIterator(binding, hit, entity, score, match,
+            totalHitsNode, totalHits, graph, hits, execCxt);
         if (args.limit >= 0)
             qIter = new QueryIterSlice(qIter, 0, args.limit, execCxt);
         return qIter;
     }
 
-    private QueryIterator resultsToQueryIterator(Binding binding, Node subj, Node score, Node literal,
-                                                  Node totalHitsNode, long totalHits,
-                                                  Node graph, Node field, Collection<TextHit> results,
-                                                  ExecutionContext execCxt) {
-        Var sVar = Var.isVar(subj) ? Var.alloc(subj) : null;
-        Var scoreVar = (score == null) ? null : Var.alloc(score);
-        Var literalVar = (literal == null) ? null : Var.alloc(literal);
+    private QueryIterator resultsToQueryIterator(Binding binding,
+                                                  Node hitNode, Node entityNode, Node scoreNode, Node matchNode,
+                                                  Node totalHitsNode, long totalHits, Node graphNode,
+                                                  Collection<SearchHit> results, ExecutionContext execCxt) {
+        Var hitVar = Var.isVar(hitNode) ? Var.alloc(hitNode) : null;
+        Var entityVar = (entityNode != null && Var.isVar(entityNode)) ? Var.alloc(entityNode) : null;
+        Var scoreVar = (scoreNode == null) ? null : Var.alloc(scoreNode);
+        Var matchVar = (matchNode == null) ? null : Var.alloc(matchNode);
         Var totalHitsVar = (totalHitsNode == null) ? null : Var.alloc(totalHitsNode);
         Node totalHitsValue = totalHitsVar != null
             ? NodeFactory.createLiteralDT(String.valueOf(totalHits), XSDDatatype.XSDinteger) : null;
-        Var graphVar = (graph == null) ? null : Var.alloc(graph);
-        Var fieldVar = (field == null) ? null : Var.alloc(field);
+        Var graphVar = (graphNode == null) ? null : Var.alloc(graphNode);
 
-        Function<TextHit, Binding> converter = (TextHit hit) -> {
-            if (score == null && literal == null && totalHitsVar == null)
-                return sVar != null ? BindingFactory.binding(binding, sVar, hit.getNode()) : BindingFactory.binding(binding);
+        Function<SearchHit, Binding> converter = (SearchHit sh) -> {
             BindingBuilder bmap = Binding.builder(binding);
-            if (sVar != null) bmap.add(sVar, hit.getNode());
-            if (scoreVar != null) bmap.add(scoreVar, NodeFactoryExtra.floatToNode(hit.getScore()));
-            if (literalVar != null && hit.getLiteral() != null) bmap.add(literalVar, hit.getLiteral());
+            if (hitVar != null) bmap.add(hitVar, sh.getHitId());
+            if (entityVar != null) bmap.add(entityVar, sh.getEntityNode());
+            if (scoreVar != null) bmap.add(scoreVar, NodeFactoryExtra.floatToNode(sh.getScore()));
+            if (matchVar != null) {
+                // Bind ?match to the first field match value if available
+                List<FieldMatch> fieldMatches = sh.getFieldMatches();
+                if (!fieldMatches.isEmpty() && fieldMatches.get(0).getValue() != null) {
+                    bmap.add(matchVar, fieldMatches.get(0).getValue());
+                }
+            }
             if (totalHitsVar != null) bmap.add(totalHitsVar, totalHitsValue);
-            if (graphVar != null && hit.getGraph() != null) bmap.add(graphVar, hit.getGraph());
-            if (fieldVar != null && hit.getProp() != null) bmap.add(fieldVar, hit.getProp());
+            if (graphVar != null && sh.getGraph() != null) bmap.add(graphVar, sh.getGraph());
             return bmap.build();
         };
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextMatchPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextMatchPF.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.query.QueryBuildException;
+import org.apache.jena.query.QueryExecException;
+import org.apache.jena.sparql.core.Substitute;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
+import org.apache.jena.sparql.engine.iterator.QueryIterPlainWrapper;
+import org.apache.jena.sparql.pfunction.PropFuncArg;
+import org.apache.jena.sparql.pfunction.PropertyFunctionBase;
+import org.apache.jena.sparql.util.IterLib;
+import org.apache.jena.sparql.util.Symbol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SPARQL property function for per-hit field match details ({@code luc:match}).
+ * <p>
+ * Joins with {@code luc:query} via a shared {@code ?hit} blank node identifier.
+ * Returns one row per matched field for each hit.
+ * <p>
+ * <b>Syntax:</b>
+ * <pre>
+ * (?hit ?field ?value ?snippet) luc:match ()
+ * </pre>
+ * <p>
+ * The object argument list is empty — all state comes from the shared
+ * {@link SearchExecution} stored in the {@link ExecutionContext}.
+ */
+public class TextMatchPF extends PropertyFunctionBase {
+    private static final Logger log = LoggerFactory.getLogger(TextMatchPF.class);
+
+    public TextMatchPF() {}
+
+    @Override
+    public void build(PropFuncArg argSubject, Node predicate, PropFuncArg argObject, ExecutionContext execCxt) {
+        super.build(argSubject, predicate, argObject, execCxt);
+
+        if (argSubject.isList()) {
+            int size = argSubject.getArgListSize();
+            if (size < 1 || size > 4) {
+                throw new QueryBuildException("Subject must have 1-4 elements " +
+                    "(?hit ?field ?value ?snippet): " + argSubject);
+            }
+        }
+    }
+
+    @Override
+    public QueryIterator exec(Binding binding,
+                              PropFuncArg argSubject, Node predicate, PropFuncArg argObject,
+                              ExecutionContext execCxt) {
+
+        argSubject = Substitute.substitute(argSubject, binding);
+
+        // Parse subject: (?hit ?field ?value ?snippet)
+        Node hitNode = null, fieldNode = null, valueNode = null, snippetNode = null;
+
+        if (argSubject.isList()) {
+            hitNode = argSubject.getArg(0);
+            if (argSubject.getArgListSize() > 1) {
+                fieldNode = argSubject.getArg(1);
+                if (!fieldNode.isVariable())
+                    throw new QueryExecException("Field must be a variable: " + argSubject);
+            }
+            if (argSubject.getArgListSize() > 2) {
+                valueNode = argSubject.getArg(2);
+                if (!valueNode.isVariable())
+                    throw new QueryExecException("Value must be a variable: " + argSubject);
+            }
+            if (argSubject.getArgListSize() > 3) {
+                snippetNode = argSubject.getArg(3);
+                if (!snippetNode.isVariable())
+                    throw new QueryExecException("Snippet must be a variable: " + argSubject);
+            }
+        } else {
+            hitNode = argSubject.getArg();
+        }
+
+        if (hitNode == null) {
+            return IterLib.noResults(execCxt);
+        }
+
+        // Find the SearchExecution in the execution context
+        // We scan context symbols for any searchExecution entry
+        SearchExecution se = findSearchExecution(execCxt);
+        if (se == null) {
+            log.warn("luc:match used without a preceding luc:query in the same query");
+            return IterLib.noResults(execCxt);
+        }
+
+        // Get search hits (already computed by luc:query)
+        List<SearchHit> allHits = se.getSearchHits(10000);
+
+        // Build result bindings
+        Var hitVar = Var.isVar(hitNode) ? Var.alloc(hitNode) : null;
+        Var fieldVar = fieldNode != null ? Var.alloc(fieldNode) : null;
+        Var valueVar = valueNode != null ? Var.alloc(valueNode) : null;
+        Var snippetVar = snippetNode != null ? Var.alloc(snippetNode) : null;
+
+        List<Binding> bindings = new ArrayList<>();
+
+        for (SearchHit sh : allHits) {
+            // If ?hit is already bound, filter to matching hits
+            if (hitVar == null) {
+                // ?hit is bound — check if it matches this hit's ID
+                if (!hitNode.equals(sh.getHitId())) continue;
+            }
+
+            List<FieldMatch> fieldMatches = sh.getFieldMatches();
+            if (fieldMatches.isEmpty()) {
+                // No field matches — emit a row with unbound field/value/snippet
+                // only if ?hit is a variable (to ensure join works)
+                if (hitVar != null) {
+                    BindingBuilder builder = Binding.builder(binding);
+                    builder.add(hitVar, sh.getHitId());
+                    bindings.add(builder.build());
+                }
+            } else {
+                for (FieldMatch fm : fieldMatches) {
+                    BindingBuilder builder = Binding.builder(binding);
+                    if (hitVar != null) builder.add(hitVar, sh.getHitId());
+                    if (fieldVar != null && fm.getFieldIRI() != null) builder.add(fieldVar, fm.getFieldIRI());
+                    if (valueVar != null && fm.getValue() != null) builder.add(valueVar, fm.getValue());
+                    if (snippetVar != null && fm.getSnippet() != null) builder.add(snippetVar, fm.getSnippet());
+                    bindings.add(builder.build());
+                }
+            }
+        }
+
+        return QueryIterPlainWrapper.create(bindings.iterator(), execCxt);
+    }
+
+    /**
+     * Find a SearchExecution in the execution context.
+     * Scans for any symbol matching the searchExecution pattern.
+     */
+    private SearchExecution findSearchExecution(ExecutionContext execCxt) {
+        // Look for any SearchExecution stored by luc:query or luc:facet
+        String prefix = TextQuery.NS + "searchExecution/";
+        // The context doesn't have a list-all-keys method, so we check
+        // a well-known symbol pattern. SearchExecution stores under
+        // "urn:jena:lucene:index#searchExecution/<key>"
+        // We need to find it. Use the context's internal map.
+        org.apache.jena.sparql.util.Context ctx = execCxt.getContext();
+        for (Symbol sym : ctx.keys()) {
+            if (sym.getSymbol().startsWith(prefix)) {
+                Object obj = ctx.get(sym);
+                if (obj instanceof SearchExecution) {
+                    return (SearchExecution) obj;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextQuery.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextQuery.java
@@ -77,6 +77,12 @@ public class TextQuery
                     return new TextFacetPF() ;
                 }
             });
+            PropertyFunctionRegistry.get().put(IndexVocab.pfMatch, new PropertyFunctionFactory() {
+                @Override
+                public PropertyFunction create(String uri) {
+                    return new TextMatchPF() ;
+                }
+            });
 
             JenaSystem.logLifecycle("TextQuery.init - finish") ;
             // Register indirections.

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
@@ -36,6 +36,7 @@ public class IndexVocab {
     // Property function URIs
     public static final String pfQuery = NS + "query";
     public static final String pfFacet = NS + "facet";
+    public static final String pfMatch = NS + "match";
 
     // Types
     public static final Resource IndexProfile   = Vocab.resource(NS, "IndexProfile");

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -105,6 +105,9 @@ import org.junit.runners.Suite.SuiteClasses;
     // Multi-valued field support
     , TestShaclLucQueryRawValueOnMultiValuedField.class
 
+    // luc:match property function
+    , TestTextMatchPF.class
+
     // Demo data validation
     , TestDemoDataParsing.class
     , TestDemoMiningScenarios.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
@@ -669,7 +669,7 @@ public class TestDemoMiningScenarios {
     public void testCombinedQueryAndFacet() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?entity ?score ?f ?v ?c WHERE {\n" +
-            "  { (?entity ?score) luc:query (\"default\" \"iron ore\" 20) }\n" +
+            "  { (?hit ?entity ?score) luc:query (\"default\" \"iron ore\" 20) }\n" +
             "  UNION\n" +
             "  { (?f ?v ?c) luc:facet (\"default\" \"iron ore\" '[\"" + FP + "state\"]' 10) }\n" +
             "}";
@@ -734,7 +734,7 @@ public class TestDemoMiningScenarios {
         StringBuilder sb = new StringBuilder();
         sb.append("PREFIX luc: <urn:jena:lucene:index#>\n");
         sb.append("SELECT ?s WHERE {\n");
-        sb.append("  (?s ?score) luc:query (\"default\" \"").append(queryText).append("\"");
+        sb.append("  (?hit ?s ?score) luc:query (\"default\" \"").append(queryText).append("\"");
         if (filter != null) {
             sb.append(" '").append(filter).append("'");
         }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
@@ -210,7 +210,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('[\"urn:jena:lucene:field#label\"]' 'Pilbara') .\n" +
+            "  (?hit ?s ?score) luc:query ('[\"urn:jena:lucene:field#label\"]' 'Pilbara') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -236,7 +236,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('[\"urn:jena:lucene:field#label\"]' 'GSWA') .\n" +
+            "  (?hit ?s ?score) luc:query ('[\"urn:jena:lucene:field#label\"]' 'GSWA') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -288,7 +288,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "') .\n" +
+            "  (?hit ?s ?score) luc:query ('[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
@@ -148,7 +148,7 @@ public class TestShaclEntityPerDocument {
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <" + NS + ">\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('default' 'machine learning') .\n" +
+            "  (?hit ?s ?score) luc:query ('default' 'machine learning') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
@@ -114,7 +114,7 @@ public class TestShaclLucQueryRawValueOnMultiValuedField {
     public void testLucQueryReturnsMatchedRawValueForMultiValuedField() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?matchRaw WHERE {\n" +
-            "  (?s ?score ?matchRaw) luc:query ('[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" 10)\n" +
+            "  (?hit ?s ?score ?matchRaw) luc:query ('[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
@@ -191,7 +191,7 @@ public class TestShaclPathSupport {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('default' 'machine') .\n" +
+            "  (?hit ?s ?score) luc:query ('default' 'machine') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -241,7 +241,7 @@ public class TestShaclPathSupport {
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <" + NS + ">\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('default' 'machine') .\n" +
+            "  (?hit ?s ?score) luc:query ('default' 'machine') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -301,7 +301,7 @@ public class TestShaclPathSupport {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query ('default' 'learning OR physics OR deep' '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#authorName\"},\"Jane Smith\"]}') .\n" +
+            "  (?hit ?s ?score) luc:query ('default' 'learning OR physics OR deep' '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#authorName\"},\"Jane Smith\"]}') .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.*;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the luc:match property function.
+ */
+public class TestTextMatchPF {
+
+    private static final String NS = "http://example.org/";
+    private static final String FIELD_IRI_PREFIX = "urn:jena:lucene:field#";
+    private static final Node BOOK_CLASS = NodeFactory.createURI(NS + "Book");
+    private static final Node TITLE_PRED = NodeFactory.createURI(NS + "title");
+    private static final Node CATEGORY_PRED = NodeFactory.createURI(NS + "category");
+
+    private Dataset dataset;
+
+    @Before
+    public void setUp() {
+        TextQuery.init();
+
+        FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, false, true,
+            Collections.singleton(TITLE_PRED));
+
+        FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
+            true, true, true, false, true, false,
+            Collections.singleton(CATEGORY_PRED));
+
+        IndexProfile bookProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "BookShape"),
+            Collections.singleton(BOOK_CLASS),
+            "uri", "docType",
+            Arrays.asList(titleField, categoryField));
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+
+        ByteBuffersDirectory dir = new ByteBuffersDirectory();
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(dir, config);
+
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), textIndex, mapping);
+
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+
+        loadTestData();
+    }
+
+    private void loadTestData() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            addBook(model, "doc1", "Introduction to Machine Learning", NS + "category/technology");
+            addBook(model, "doc2", "Deep Learning Neural Networks", NS + "category/technology");
+            addBook(model, "doc3", "Quantum Physics Explained", NS + "category/science");
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private void addBook(Model model, String id, String title, String categoryUri) {
+        Resource book = ResourceFactory.createResource(NS + id);
+        model.add(book, RDF.type, ResourceFactory.createResource(NS + "Book"));
+        model.add(book, ResourceFactory.createProperty(NS + "title"), title);
+        model.add(book, ResourceFactory.createProperty(NS + "category"), ResourceFactory.createResource(categoryUri));
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    @Test
+    public void testMatchReturnsSingleFieldForSingleFieldQuery() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?hit ?s ?field ?value WHERE {\n" +
+            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10) .\n" +
+            "  (?hit ?field ?value) luc:match () .\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            int count = 0;
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                assertNotNull("?hit should be bound", sol.get("hit"));
+                assertNotNull("?field should be bound", sol.get("field"));
+                assertEquals("Field should be title IRI",
+                    FIELD_IRI_PREFIX + "title", sol.getResource("field").getURI());
+                assertNotNull("?value should be bound", sol.get("value"));
+                count++;
+            }
+            assertTrue("Should have match results", count > 0);
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testMatchJoinsWithQueryByHitId() {
+        // Verify that ?hit from luc:query joins correctly with luc:match
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s ?field WHERE {\n" +
+            "  (?hit ?s ?score) luc:query ('default' \"machine\" 10) .\n" +
+            "  (?hit ?field ?value) luc:match () .\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            Set<String> entities = new HashSet<>();
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                entities.add(sol.getResource("s").getURI());
+                assertNotNull("?field should be bound", sol.get("field"));
+            }
+            assertTrue("Should find doc1 (Machine Learning)", entities.contains(NS + "doc1"));
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testMatchWithOptional() {
+        // Use OPTIONAL so hits without field matches still appear
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?hit ?s ?field WHERE {\n" +
+            "  (?hit ?s ?score) luc:query ('default' \"learning\" 10) .\n" +
+            "  OPTIONAL { (?hit ?field ?value) luc:match () . }\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            int count = 0;
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                assertNotNull("?hit should be bound", sol.get("hit"));
+                assertNotNull("?s should be bound", sol.get("s"));
+                count++;
+            }
+            assertTrue("Should have results", count > 0);
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testMatchFieldValueIsCorrectType() {
+        // For TEXT fields, ?value should be a literal
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?value WHERE {\n" +
+            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" 10) .\n" +
+            "  (?hit ?field ?value) luc:match () .\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            assertTrue("Should have results", rs.hasNext());
+            QuerySolution sol = rs.next();
+            assertTrue("Value for TEXT field should be a literal", sol.get("value").isLiteral());
+            assertTrue("Value should contain 'Machine'",
+                sol.getLiteral("value").getString().contains("Machine"));
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testMatchNoResultsWithoutQuery() {
+        // luc:match without a preceding luc:query should return no results
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?hit ?field WHERE {\n" +
+            "  (?hit ?field ?value) luc:match () .\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            assertFalse("luc:match without luc:query should return no results", rs.hasNext());
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testHitIdIsBlankNode() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?hit WHERE {\n" +
+            "  (?hit ?s ?score) luc:query ('default' \"learning\" 10) .\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            assertTrue("Should have results", rs.hasNext());
+            QuerySolution sol = rs.next();
+            assertTrue("?hit should be a blank node (anonymous resource)",
+                sol.get("hit").isAnon());
+        } finally {
+            dataset.end();
+        }
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -131,7 +131,7 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithoutFilters() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?s ?score) luc:query (\"default\" \"learning\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -156,7 +156,7 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithCqlEqualFilter() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?s ?score) luc:query (\"default\" \"learning\" " +
+            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" " +
             "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' 20)\n" +
             "}";
 
@@ -183,7 +183,7 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithCqlAndFilter() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query (\"default\" \"learning\" " +
+            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" " +
             "    '{\"op\":\"and\",\"args\":[" +
             "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}," +
             "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#author\"},\"http://example.org/author/Smith\"]}" +
@@ -213,7 +213,7 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithCqlNoMatches() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?s ?score) luc:query (\"default\" \"learning\" " +
+            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" " +
             "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/nonexistent\"]}' 20)\n" +
             "}";
 
@@ -233,7 +233,7 @@ public class TestTextQueryPFFilters {
         // Search only the "title" field via its IRI (JSON array)
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
+            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -258,7 +258,7 @@ public class TestTextQueryPFFilters {
         // Search multiple fields via JSON array of IRIs
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
+            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -278,11 +278,12 @@ public class TestTextQueryPFFilters {
     }
 
     @Test
-    public void testLucQueryFieldBinding() {
-        // Search a single field and check that ?field is bound to the field IRI
+    public void testLucMatchFieldBinding() {
+        // Search a single field and check that luc:match returns ?field bound to the field IRI
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
-            "SELECT ?s ?score ?lit ?totalHits ?g ?field WHERE {\n" +
-            "  (?s ?score ?lit ?totalHits ?g ?field) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
+            "SELECT ?hit ?s ?score ?field ?value WHERE {\n" +
+            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10) .\n" +
+            "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -292,9 +293,9 @@ public class TestTextQueryPFFilters {
                 int count = 0;
                 while (rs.hasNext()) {
                     QuerySolution sol = rs.next();
-                    assertNotNull("?field should be bound for single-field search", sol.get("field"));
+                    assertNotNull("?field should be bound via luc:match", sol.get("field"));
                     assertTrue("?field should be a URI", sol.get("field").isURIResource());
-                    assertEquals("Field IRI should end with field name",
+                    assertEquals("Field IRI should match title",
                         "urn:jena:lucene:field#title", sol.getResource("field").getURI());
                     count++;
                 }
@@ -310,7 +311,7 @@ public class TestTextQueryPFFilters {
         // ?lit should be populated with the stored value from the matched field
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score ?lit WHERE {\n" +
-            "  (?s ?score ?lit) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" 10)\n" +
+            "  (?hit ?s ?score ?lit) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -335,11 +336,12 @@ public class TestTextQueryPFFilters {
     }
 
     @Test
-    public void testLucQueryFieldBindingDefaultUnbound() {
-        // With "default" (multi-field), ?field should be unbound
+    public void testLucMatchWithDefaultFieldSpec() {
+        // With "default", luc:match should still return field matches
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
-            "SELECT ?s ?score ?lit ?totalHits ?g ?field WHERE {\n" +
-            "  (?s ?score ?lit ?totalHits ?g ?field) luc:query (\"default\" \"learning\" 10)\n" +
+            "SELECT ?hit ?s ?field ?value WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" 10) .\n" +
+            "  OPTIONAL { (?hit ?field ?value) luc:match () . }\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -349,8 +351,8 @@ public class TestTextQueryPFFilters {
                 int count = 0;
                 while (rs.hasNext()) {
                     QuerySolution sol = rs.next();
-                    // "default" resolves to a single field "title" (only defaultSearch field),
-                    // so ?field will be bound in this test config
+                    // "default" resolves to "title" (only defaultSearch field in this config),
+                    // so luc:match should bind ?field
                     count++;
                 }
                 assertTrue("Should find results", count > 0);
@@ -365,7 +367,7 @@ public class TestTextQueryPFFilters {
         // Search specific field (by IRI) with CQL filter
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" " +
+            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" " +
             "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' 20)\n" +
             "}";
 


### PR DESCRIPTION
## Summary
- Adds `luc:match` SPARQL property function that joins with `luc:query` via shared `?hit` blank node, returning per-hit field-level match details
- New `luc:query` subject shape: `(?hit ?entity ?score ?match ?totalHits ?graph)` — `?hit` is a query-scoped blank node identifier
- Uses Lucene's `NamedMatches` API (`NamedMatches.wrapQuery()` + `Weight.matches()`) for field attribution without re-scoring
- New classes: `SearchHit`, `FieldMatch`, `TextMatchPF`
- Extended `ShaclTextIndexLucene` with `buildNamedQuery()`, `searchWithHitIds()`, `computeFieldMatches()`
- Extended `SearchExecution` shared state pattern for `luc:match`

## Test plan
- [x] 6 new `TestTextMatchPF` tests (single field, join, OPTIONAL, value type, no-query, blank node)
- [x] All 500 jena-text tests pass (0 failures)
- [x] All existing SHACL-mode tests updated for new subject shape

Closes #48