### PR TITLE
Make SHACL text query/facet args fixed-arity and refresh the demo/docs

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -124,10 +124,12 @@ it finds entities that link *to* the report.
 | `11-hierarchical-facets.rq` | Hierarchical facets using Lucene taxonomy |
 | `12-range-facets.rq` | Numeric range facets on `year` and `depth` (INT fields) |
 | `13-mixed-facets.rq` | Mixed flat (state) and range (year) facets in one query |
-| `14-nested-identifier-hierarchy.rq` | Nested identifier hierarchy facets |
+| `14-nested-identifier-hierarchy.rq` | Nested identifier hierarchy facets (`company` / `anumber` / `mnumber`) |
 | `15-nested-identifier-prefix-search.rq` | Prefix search over nested identifier text |
 | `16-sort-by-year-desc.rq` | Sort reports by `year` descending via field-IRI sort JSON |
 | `17-sort-boreholes-by-depth-asc.rq` | Sort boreholes by `depth` ascending via field-IRI sort JSON |
+| `18-nested-identifier-company-drilldown.rq` | Drill down identifier values under `identifierType = company` |
+| `19-nested-identifier-exact-pair.rq` | Correlated exact filter on `identifierType = company` + `identifierValueExact` |
 
 ### Expected results for path queries
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -124,6 +124,10 @@ it finds entities that link *to* the report.
 | `11-hierarchical-facets.rq` | Hierarchical facets using Lucene taxonomy |
 | `12-range-facets.rq` | Numeric range facets on `year` and `depth` (INT fields) |
 | `13-mixed-facets.rq` | Mixed flat (state) and range (year) facets in one query |
+| `14-nested-identifier-hierarchy.rq` | Nested identifier hierarchy facets |
+| `15-nested-identifier-prefix-search.rq` | Prefix search over nested identifier text |
+| `16-sort-by-year-desc.rq` | Sort reports by `year` descending via field-IRI sort JSON |
+| `17-sort-boreholes-by-depth-asc.rq` | Sort boreholes by `depth` ascending via field-IRI sort JSON |
 
 ### Expected results for path queries
 

--- a/demo/Taskfile.yml
+++ b/demo/Taskfile.yml
@@ -84,6 +84,8 @@ tasks:
           - queries/15-nested-identifier-prefix-search.rq
           - queries/16-sort-by-year-desc.rq
           - queries/17-sort-boreholes-by-depth-asc.rq
+          - queries/18-nested-identifier-company-drilldown.rq
+          - queries/19-nested-identifier-exact-pair.rq
         cmd: |
           echo "=== {{.ITEM}} ==="
           curl -s -X POST "{{.SERVER_URL}}/mining/query" \

--- a/demo/Taskfile.yml
+++ b/demo/Taskfile.yml
@@ -80,6 +80,10 @@ tasks:
           - queries/11-hierarchical-facets.rq
           - queries/12-range-facets.rq
           - queries/13-mixed-facets.rq
+          - queries/14-nested-identifier-hierarchy.rq
+          - queries/15-nested-identifier-prefix-search.rq
+          - queries/16-sort-by-year-desc.rq
+          - queries/17-sort-boreholes-by-depth-asc.rq
         cmd: |
           echo "=== {{.ITEM}} ==="
           curl -s -X POST "{{.SERVER_URL}}/mining/query" \

--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -996,7 +996,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
                 this.fieldIRIs,
                 this.buildHierarchyParentClauses()
             );
-            const filterArg = cqlFilter ? `'${cqlFilter}'` : "'null'";
+            const filterArg = cqlFilter ? `'${cqlFilter}'` : "''";
             const facetRequests = this.facetFields.map(f => {
                 // For hierarchy dimensions, use the first level's field IRI
                 const hier = this.hierarchyDimensions.get(f);
@@ -1010,7 +1010,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
             return `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?totalHits) luc:query ('default' '${searchField}' '${escaped}' ${filterArg} 'null' ${this.limit}) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' '${searchField}' '${escaped}' ${filterArg} '' ${this.limit}) }
     UNION
     { (?field ?value ?low ?high ?count) luc:facet ('default' '${searchField}' '${escaped}' '${facetFieldsJson}' ${filterArg} ${this.maxFacetValues} 0) }
 }`;
@@ -1022,7 +1022,7 @@ WHERE {
             return `${SPARQL_PREFIXES}
 SELECT DISTINCT ?identifier
 WHERE {
-    (?hit ?entity ?score) luc:query ('default' '${fieldSpec}' '${escaped}' 'null' 'null' 8) .
+    (?hit ?entity ?score) luc:query ('default' '${fieldSpec}' '${escaped}' '' '' 8) .
     ?entity ex:identifier ?identifier .
 }
 ORDER BY LCASE(STR(?identifier))
@@ -1772,9 +1772,9 @@ function statsApp() {
                 const statsQuery = `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?totalHits) luc:query ('default' 'default' '*' 'null' 'null' 0) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' 'default' '*' '' '' 0) }
     UNION
-    { (?field ?value ?low ?high ?count) luc:facet ('default' 'default' '*' '${facetFieldsJson}' 'null' 0 0) }
+    { (?field ?value ?low ?high ?count) luc:facet ('default' 'default' '*' '${facetFieldsJson}' '' 0 0) }
 }`;
                 const statsData = await this.runSparql(endpoint, statsQuery);
                 const statsMs = performance.now() - t0;

--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -11,6 +11,7 @@ const RESULT_LIMITS = [10, 100, 1000, 5000, 9999];
 const DEFAULT_LIMIT = 10;
 const FACET_LIMITS = [10, 25, 50, 100, 500];
 const DEFAULT_FACET_LIMIT = 10;
+const DEFAULT_SORT_DIRECTION = 'asc';
 
 // ---------------------------------------------------------------------------
 // RDF namespace constants
@@ -62,6 +63,28 @@ function resolveFieldName(fieldUri, fieldIRIs) {
         if (shortName(iri) === fragment) return name;
     }
     return fragment;
+}
+
+function buildSortSpec(sortField, sortDirection, fieldIRIs) {
+    if (!sortField) return '';
+    const fieldIri = (fieldIRIs && fieldIRIs[sortField]) || sortField;
+    return JSON.stringify({
+        field: fieldIri,
+        order: sortDirection || DEFAULT_SORT_DIRECTION,
+    });
+}
+
+function parseSortParam(sortParam, fieldIRIs) {
+    if (!sortParam) {
+        return { field: '', direction: DEFAULT_SORT_DIRECTION };
+    }
+    const idx = sortParam.lastIndexOf(':');
+    const rawField = idx >= 0 ? sortParam.substring(0, idx) : sortParam;
+    const rawDirection = idx >= 0 ? sortParam.substring(idx + 1) : DEFAULT_SORT_DIRECTION;
+    return {
+        field: resolveFieldName(rawField, fieldIRIs),
+        direction: rawDirection === 'desc' ? 'desc' : DEFAULT_SORT_DIRECTION,
+    };
 }
 
 function renderJsonTree(obj, indent) {
@@ -302,9 +325,11 @@ function extractConfig(store) {
 
     const shapes = [];
     const facetFields = [];
+    const sortableFields = [];
     const fieldIRIs = {};
     const predicateToFacet = {};
     const seenFacets = new Set();
+    const seenSortable = new Set();
     const hierarchyDimensions = new Map();
 
     for (const shapeNode of shapeNodes) {
@@ -347,6 +372,16 @@ function extractConfig(store) {
             });
 
             if (fieldIRI) fieldIRIs[fieldName] = fieldIRI;
+
+            if (sortable && !seenSortable.has(fieldName)) {
+                seenSortable.add(fieldName);
+                sortableFields.push({
+                    name: fieldName,
+                    iri: fieldIRI || fieldName,
+                    fieldType: fieldTypeShort,
+                    isNumeric,
+                });
+            }
 
             if (facetable && !seenFacets.has(fieldName)) {
                 seenFacets.add(fieldName);
@@ -401,6 +436,7 @@ function extractConfig(store) {
         maxFacetHits,
         shapes,
         facetFields,
+        sortableFields,
         fieldIRIs,
         predicateToFacet,
         hierarchyDimensions,
@@ -482,6 +518,9 @@ function searchApp() {
         resultLimits: RESULT_LIMITS,
         maxFacetValues: DEFAULT_FACET_LIMIT,
         facetLimits: FACET_LIMITS,
+        sortableFields: [],
+        sortField: '',
+        sortDirection: DEFAULT_SORT_DIRECTION,
         selected: {},
         facetFields: [],
         fieldIRIs: {},
@@ -549,6 +588,7 @@ function searchApp() {
 
             this.endpoint = config.endpoint;
             this.facetFields = config.facetFields;
+            this.sortableFields = config.sortableFields || [];
             this.fieldIRIs = config.fieldIRIs;
             this.predicateToFacet = config.predicateToFacet;
             this.hierarchyDimensions = config.hierarchyDimensions || new Map();
@@ -702,6 +742,10 @@ function searchApp() {
             const params = new URLSearchParams();
             if (this.q.trim()) params.set('q', this.q.trim());
             if (this.identifier.trim()) params.set('id', this.identifier.trim());
+            if (this.sortField) {
+                const sortIri = this.fieldIRIs[this.sortField] || this.sortField;
+                params.set('sort', `${sortIri}:${this.sortDirection}`);
+            }
             const cql = buildCqlFilter(
                 this.selected,
                 this.spatialBbox,
@@ -719,6 +763,9 @@ function searchApp() {
             const params = new URLSearchParams(window.location.search);
             this.q = params.get('q') || '';
             this.identifier = params.get('id') || '';
+            const sort = parseSortParam(params.get('sort'), this.fieldIRIs);
+            this.sortField = sort.field;
+            this.sortDirection = sort.direction;
             const { selected, bbox, polygon } = parseCqlFilter(params.get('filter'), this.fieldIRIs);
             this.hierarchySelected = {};
             for (const f of this.facetFields) {
@@ -791,6 +838,11 @@ function searchApp() {
         hasActiveFilters() {
             return this.spatialBbox != null || this.spatialPolygon != null ||
                 this.facetFields.some(f => (this.selected[f] || []).length > 0);
+        },
+
+        sortLabel() {
+            if (!this.sortField) return 'relevance';
+            return `${this.sortField} ${this.sortDirection === 'desc' ? 'desc' : 'asc'}`;
         },
 
         isSelected(field, value) {
@@ -997,6 +1049,8 @@ SELECT ?field ?value ?low ?high ?count WHERE {
                 this.buildHierarchyParentClauses()
             );
             const filterArg = cqlFilter ? `'${cqlFilter}'` : "''";
+            const sortSpec = buildSortSpec(this.sortField, this.sortDirection, this.fieldIRIs);
+            const sortArg = sortSpec ? `'${escapeSparql(sortSpec)}'` : "''";
             const facetRequests = this.facetFields.map(f => {
                 // For hierarchy dimensions, use the first level's field IRI
                 const hier = this.hierarchyDimensions.get(f);
@@ -1010,7 +1064,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
             return `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?totalHits) luc:query ('default' '${searchField}' '${escaped}' ${filterArg} '' ${this.limit}) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' '${searchField}' '${escaped}' ${filterArg} ${sortArg} ${this.limit}) }
     UNION
     { (?field ?value ?low ?high ?count) luc:facet ('default' '${searchField}' '${escaped}' '${facetFieldsJson}' ${filterArg} ${this.maxFacetValues} 0) }
 }`;
@@ -1118,7 +1172,7 @@ WHERE {
             return merged;
         },
 
-        parseEntityDetails(data, scores) {
+        parseEntityDetails(data, scores, orderedUris) {
             const entities = {};
             for (const row of (data.results?.bindings || [])) {
                 const uri = row.entity.value;
@@ -1231,6 +1285,10 @@ WHERE {
                 }
             }
 
+            if (orderedUris && orderedUris.length > 0) {
+                const rank = new Map(orderedUris.map((uri, idx) => [uri, idx]));
+                return cards.sort((a, b) => (rank.get(a.uri) ?? Number.MAX_SAFE_INTEGER) - (rank.get(b.uri) ?? Number.MAX_SAFE_INTEGER));
+            }
             return cards.sort((a, b) => b.score - a.score);
         },
 
@@ -1266,6 +1324,9 @@ WHERE {
             }
             if (filters.length > 0) {
                 parts.push('filtered by ' + filters.join(' AND '));
+            }
+            if (this.sortField) {
+                parts.push('sorted by ' + escapeHtml(this.sortLabel()));
             }
 
             let result = parts.join(' ') + ' \u2014 ';
@@ -1335,7 +1396,7 @@ WHERE {
                     const detailMs = performance.now() - t0;
                     this.logQuery(`Details: ${uris.length} entities`, detailQuery, detailMs);
 
-                    this.cards = this.parseEntityDetails(detailData, scores);
+                    this.cards = this.parseEntityDetails(detailData, scores, uris);
                 } else {
                     this.cards = [];
                 }

--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -332,82 +332,72 @@ function extractConfig(store) {
     const seenSortable = new Set();
     const hierarchyDimensions = new Map();
 
-    for (const shapeNode of shapeNodes) {
-        const targetClass = getObject(store, shapeNode, SH + 'targetClass');
-        const shape = {
-            name: shortName(shapeNode.value),
-            targetClass: targetClass ? shortName(targetClass.value) : '?',
-            fields: [],
-        };
+    function registerField(shape, propNode, { includeFacetField = true, includePredicateMapping = true } = {}) {
+        const fieldName = getLiteral(store, propNode, IDX + 'fieldName');
+        const fieldType = getObject(store, propNode, IDX + 'fieldType');
+        const pathNode = getObject(store, propNode, SH + 'path');
+        if (!fieldName || !fieldType) return;
 
-        const propNodes = getObjects(store, shapeNode, SH + 'property');
-        for (const propNode of propNodes) {
-            const fieldName = getLiteral(store, propNode, IDX + 'fieldName');
-            const fieldType = getObject(store, propNode, IDX + 'fieldType');
-            const pathNode = getObject(store, propNode, SH + 'path');
-            if (!fieldName || !fieldType) continue;
+        const facetable = getLiteral(store, propNode, IDX + 'facetable') === 'true';
+        const multiValued = getLiteral(store, propNode, IDX + 'multiValued') === 'true';
+        const defaultSearch = getLiteral(store, propNode, IDX + 'defaultSearch') === 'true';
+        const sortable = getLiteral(store, propNode, IDX + 'sortable') === 'true';
+        const pathStr = pathNode ? pathToString(store, pathNode) : '?';
 
-            const facetable = getLiteral(store, propNode, IDX + 'facetable') === 'true';
-            const multiValued = getLiteral(store, propNode, IDX + 'multiValued') === 'true';
-            const defaultSearch = getLiteral(store, propNode, IDX + 'defaultSearch') === 'true';
-            const sortable = getLiteral(store, propNode, IDX + 'sortable') === 'true';
-            const pathStr = pathNode ? pathToString(store, pathNode) : '?';
+        const fieldIRI = propNode.termType === 'NamedNode' ? propNode.value : null;
 
-            const fieldIRI = propNode.termType === 'NamedNode' ? propNode.value : null;
+        const fieldTypeShort = shortName(fieldType.value);
+        const typeStr = fieldType.value.toLowerCase();
+        const isNumeric = typeStr.includes('int') || typeStr.includes('long') || typeStr.includes('double');
 
-            const fieldTypeShort = shortName(fieldType.value);
-            const typeStr = fieldType.value.toLowerCase();
-            const isNumeric = typeStr.includes('int') || typeStr.includes('long') || typeStr.includes('double');
+        shape.fields.push({
+            name: fieldName,
+            iri: fieldIRI,
+            path: pathStr,
+            fieldType: fieldTypeShort,
+            facetable,
+            multiValued,
+            defaultSearch,
+            sortable,
+            isNumeric,
+        });
 
-            shape.fields.push({
+        if (fieldIRI) fieldIRIs[fieldName] = fieldIRI;
+
+        if (sortable && !seenSortable.has(fieldName)) {
+            seenSortable.add(fieldName);
+            sortableFields.push({
                 name: fieldName,
-                iri: fieldIRI,
-                path: pathStr,
+                iri: fieldIRI || fieldName,
                 fieldType: fieldTypeShort,
-                facetable,
-                multiValued,
-                defaultSearch,
-                sortable,
                 isNumeric,
             });
+        }
 
-            if (fieldIRI) fieldIRIs[fieldName] = fieldIRI;
+        if (includeFacetField && facetable && !seenFacets.has(fieldName)) {
+            seenFacets.add(fieldName);
+            facetFields.push(fieldName);
+        }
 
-            if (sortable && !seenSortable.has(fieldName)) {
-                seenSortable.add(fieldName);
-                sortableFields.push({
-                    name: fieldName,
-                    iri: fieldIRI || fieldName,
-                    fieldType: fieldTypeShort,
-                    isNumeric,
-                });
-            }
-
-            if (facetable && !seenFacets.has(fieldName)) {
-                seenFacets.add(fieldName);
-                facetFields.push(fieldName);
-            }
-
-            if (facetable && pathNode) {
-                if (pathNode.termType === 'NamedNode') {
-                    predicateToFacet[shortName(pathNode.value)] = fieldName;
-                } else {
-                    // Sequence path: map first predicate to this facet field
-                    const first = getObject(store, pathNode, RDF + 'first');
-                    if (first && first.termType === 'NamedNode') {
-                        predicateToFacet[shortName(first.value)] = fieldName;
-                    }
-                    // Inverse path: map the inverted predicate
-                    const inv = getObject(store, pathNode, SH + 'inversePath');
-                    if (inv && inv.termType === 'NamedNode') {
-                        predicateToFacet[shortName(inv.value)] = fieldName;
-                    }
+        if (includePredicateMapping && facetable && pathNode) {
+            if (pathNode.termType === 'NamedNode') {
+                predicateToFacet[shortName(pathNode.value)] = fieldName;
+            } else {
+                // Sequence path: map first predicate to this facet field
+                const first = getObject(store, pathNode, RDF + 'first');
+                if (first && first.termType === 'NamedNode') {
+                    predicateToFacet[shortName(first.value)] = fieldName;
+                }
+                // Inverse path: map the inverted predicate
+                const inv = getObject(store, pathNode, SH + 'inversePath');
+                if (inv && inv.termType === 'NamedNode') {
+                    predicateToFacet[shortName(inv.value)] = fieldName;
                 }
             }
         }
+    }
 
-        // Parse idx:facetHierarchy — RDF lists of field IRIs defining hierarchy levels
-        const hierNodes = getObjects(store, shapeNode, IDX + 'facetHierarchy');
+    function registerHierarchies(hierNodes, label = null) {
         for (const hierNode of hierNodes) {
             const levelNodes = walkList(store, hierNode);
             const levels = levelNodes
@@ -419,12 +409,45 @@ function extractConfig(store) {
                 .filter(l => l.name);
             if (levels.length >= 2) {
                 const dimName = levels.map(l => l.name).join('_');
+                if (label) levels.label = label;
                 if (!seenFacets.has(dimName)) {
                     seenFacets.add(dimName);
                     facetFields.push(dimName);
                     hierarchyDimensions.set(dimName, levels);
                 }
             }
+        }
+    }
+
+    for (const shapeNode of shapeNodes) {
+        const targetClass = getObject(store, shapeNode, SH + 'targetClass');
+        const shape = {
+            name: shortName(shapeNode.value),
+            targetClass: targetClass ? shortName(targetClass.value) : '?',
+            fields: [],
+        };
+
+        const propNodes = getObjects(store, shapeNode, SH + 'property');
+        for (const propNode of propNodes) {
+            registerField(shape, propNode);
+        }
+
+        registerHierarchies(getObjects(store, shapeNode, IDX + 'facetHierarchy'));
+
+        const nestedNodes = getObjects(store, shapeNode, IDX + 'nested');
+        for (const nestedNode of nestedNodes) {
+            const joinPathNode = getObject(store, nestedNode, IDX + 'joinPath');
+            let nestedLabel = null;
+            if (joinPathNode && joinPathNode.termType === 'NamedNode') {
+                nestedLabel = shortName(joinPathNode.value);
+                if (nestedLabel === 'identifier') nestedLabel = 'identifiers';
+            }
+            for (const nestedPropNode of getObjects(store, nestedNode, IDX + 'property')) {
+                // Track nested field IRIs for filtering and drill-down, but keep the sidebar
+                // focused on the hierarchy dimension rather than duplicating flat child fields.
+                registerField(shape, nestedPropNode, { includeFacetField: false, includePredicateMapping: false });
+            }
+            registerHierarchies(getObjects(store, nestedNode, IDX + 'facetHierarchy'), nestedLabel);
         }
 
         shapes.push(shape);
@@ -767,10 +790,12 @@ function searchApp() {
             this.sortField = sort.field;
             this.sortDirection = sort.direction;
             const { selected, bbox, polygon } = parseCqlFilter(params.get('filter'), this.fieldIRIs);
-            this.hierarchySelected = {};
-            for (const f of this.facetFields) {
+            const fieldNames = new Set([...this.facetFields, ...Object.keys(selected)]);
+            this.selected = {};
+            for (const f of fieldNames) {
                 this.selected[f] = selected[f] || [];
             }
+            this.hierarchySelected = this.inferHierarchySelections(this.selected);
             this.spatialBbox = bbox;
             this.spatialPolygon = polygon;
         },
@@ -825,7 +850,7 @@ function searchApp() {
         },
 
         async clearFilters() {
-            for (const f of this.facetFields) {
+            for (const f of Object.keys(this.selected)) {
                 this.selected[f] = [];
             }
             this.hierarchySelected = {};
@@ -837,12 +862,19 @@ function searchApp() {
 
         hasActiveFilters() {
             return this.spatialBbox != null || this.spatialPolygon != null ||
-                this.facetFields.some(f => (this.selected[f] || []).length > 0);
+                Object.values(this.selected).some(values => (values || []).length > 0) ||
+                Object.values(this.hierarchySelected || {}).some(parents =>
+                    Object.values(parents || {}).some(values => (values || []).length > 0));
         },
 
         sortLabel() {
             if (!this.sortField) return 'relevance';
             return `${this.sortField} ${this.sortDirection === 'desc' ? 'desc' : 'asc'}`;
+        },
+
+        facetLabel(fieldName) {
+            const hierarchy = this.hierarchyDimensions.get(fieldName);
+            return hierarchy?.label || fieldName;
         },
 
         isSelected(field, value) {
@@ -885,14 +917,32 @@ function searchApp() {
             return (this.hierarchyChildren[dim] && this.hierarchyChildren[dim][parentValue]) || [];
         },
 
+        inferHierarchySelections(selected) {
+            const inferred = {};
+            for (const [dim, levels] of this.hierarchyDimensions.entries()) {
+                if (!levels || levels.length < 2) continue;
+                const parentField = levels[0].name;
+                const childField = levels[1].name;
+                const parents = selected[parentField] || [];
+                const children = selected[childField] || [];
+                if (parents.length === 0 || children.length === 0) continue;
+                inferred[dim] = {};
+                for (const parentValue of parents) {
+                    inferred[dim][parentValue] = [...children];
+                }
+            }
+            return inferred;
+        },
+
         isHierarchyChildSelected(dim, value) {
             const childField = this.getHierarchyChildFieldName(dim);
             return childField ? this.isSelected(childField, value) : false;
         },
 
-        buildHierarchyParentClauses() {
+        buildHierarchyParentClauses(excludedDim = null) {
             const clauses = [];
             for (const [dim, parents] of Object.entries(this.hierarchySelected || {})) {
+                if (excludedDim && dim === excludedDim) continue;
                 const parentLevel = this.getHierarchyParentLevel(dim);
                 if (!parentLevel) continue;
                 for (const [parentValue, childValues] of Object.entries(parents || {})) {
@@ -904,6 +954,89 @@ function searchApp() {
                 }
             }
             return clauses;
+        },
+
+        async ensureHierarchyChildren(dim, parentValue) {
+            if (!this.hierarchyLoading[dim]) this.hierarchyLoading[dim] = {};
+            this.hierarchyLoading[dim][parentValue] = true;
+
+            try {
+                const levels = this.hierarchyDimensions.get(dim);
+                if (!levels || levels.length < 2) return;
+
+                // Request facets on the child level's IRI from config.ttl,
+                // with a CQL filter constrained by the selected parent value.
+                const parentLevel = levels[0];
+                const childLevel = levels[1];
+                const parentLevelIRI = parentLevel.iri;
+                const childLevelIRI = childLevel.iri;
+
+                const term = this.identifier.trim() || this.q.trim() || '*';
+                    const searchField = this.identifier.trim() ? this.identifierFieldSelector() : 'default';
+                const escaped = escapeSparql(term);
+
+                const hierFilter = JSON.stringify({
+                    op: '=',
+                    args: [{ property: parentLevelIRI }, parentValue],
+                });
+                const selectedWithoutCurrentHierarchy = { ...this.selected };
+                delete selectedWithoutCurrentHierarchy[parentLevel.name];
+                delete selectedWithoutCurrentHierarchy[childLevel.name];
+
+                const existingCql = buildCqlFilter(
+                    selectedWithoutCurrentHierarchy,
+                    this.spatialBbox,
+                    this.spatialPolygon,
+                    this.fieldIRIs,
+                    this.buildHierarchyParentClauses(dim)
+                );
+                let combinedFilter;
+                if (existingCql) {
+                    const existing = JSON.parse(existingCql);
+                    combinedFilter = JSON.stringify({
+                        op: 'and',
+                        args: [existing, JSON.parse(hierFilter)],
+                    });
+                } else {
+                    combinedFilter = hierFilter;
+                }
+
+                const query = `${SPARQL_PREFIXES}
+SELECT ?field ?value ?low ?high ?count WHERE {
+    (?field ?value ?low ?high ?count) luc:facet ('default' '${searchField}' '${escaped}' '${JSON.stringify([childLevelIRI])}' '${combinedFilter}' ${this.maxFacetValues} 0)
+}`;
+                const data = await this.runSparql(query);
+                const children = [];
+                for (const row of (data.results?.bindings || [])) {
+                    if (row.value && row.count) {
+                        const childVal = row.value.value;
+                        const childIsUri = row.value.type === 'uri' || /^https?:\/\//.test(childVal);
+                        children.push({
+                            value: childVal,
+                            label: childIsUri ? shortName(childVal) : childVal,
+                            count: parseInt(row.count.value, 10),
+                        });
+                    }
+                }
+                children.sort((a, b) => b.count - a.count);
+                if (!this.hierarchyChildren[dim]) this.hierarchyChildren[dim] = {};
+                this.hierarchyChildren[dim][parentValue] = children;
+            } catch (e) {
+                console.error('Hierarchy drill-down failed:', e);
+            } finally {
+                this.hierarchyLoading[dim][parentValue] = false;
+            }
+        },
+
+        async restoreHierarchySelections() {
+            for (const [dim, parents] of Object.entries(this.hierarchySelected || {})) {
+                if (!this.hierarchyOpen[dim]) this.hierarchyOpen[dim] = {};
+                for (const [parentValue, childValues] of Object.entries(parents || {})) {
+                    if (!childValues || childValues.length === 0) continue;
+                    this.hierarchyOpen[dim][parentValue] = true;
+                    await this.ensureHierarchyChildren(dim, parentValue);
+                }
+            }
         },
 
         async toggleHierarchyChild(dim, parentValue, value) {
@@ -936,70 +1069,7 @@ function searchApp() {
 
             // Fetch children on first open
             if (!isOpen && !this.getHierarchyChildren(dim, parentValue).length) {
-                if (!this.hierarchyLoading[dim]) this.hierarchyLoading[dim] = {};
-                this.hierarchyLoading[dim][parentValue] = true;
-
-                try {
-                    const levels = this.hierarchyDimensions.get(dim);
-                    if (!levels || levels.length < 2) return;
-
-                    // Request facets on the child level's IRI from config.ttl,
-                    // with a CQL filter constrained by the selected parent value.
-                    const parentLevelIRI = levels[0].iri;
-                    const childLevelIRI = levels[1].iri;
-
-                    const term = this.identifier.trim() || this.q.trim() || '*';
-                    const searchField = this.identifier.trim() ? this.identifierFieldSpec() : 'default';
-                    const escaped = escapeSparql(term);
-
-                    // Build CQL filter: combine existing filters with hierarchy parent = value
-                    const hierFilter = JSON.stringify({
-                        op: '=',
-                        args: [{ property: parentLevelIRI }, parentValue],
-                    });
-                    const existingCql = buildCqlFilter(
-                        this.selected,
-                        this.spatialBbox,
-                        this.spatialPolygon,
-                        this.fieldIRIs,
-                        this.buildHierarchyParentClauses()
-                    );
-                    let combinedFilter;
-                    if (existingCql) {
-                        const existing = JSON.parse(existingCql);
-                        combinedFilter = JSON.stringify({
-                            op: 'and',
-                            args: [existing, JSON.parse(hierFilter)],
-                        });
-                    } else {
-                        combinedFilter = hierFilter;
-                    }
-
-                    const query = `${SPARQL_PREFIXES}
-SELECT ?field ?value ?low ?high ?count WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ('default' '${searchField}' '${escaped}' '${JSON.stringify([childLevelIRI])}' '${combinedFilter}' ${this.maxFacetValues} 0)
-}`;
-                    const data = await this.runSparql(query);
-                    const children = [];
-                    for (const row of (data.results?.bindings || [])) {
-                        if (row.value && row.count) {
-                            const childVal = row.value.value;
-                            const childIsUri = row.value.type === 'uri' || /^https?:\/\//.test(childVal);
-                            children.push({
-                                value: childVal,
-                                label: childIsUri ? shortName(childVal) : childVal,
-                                count: parseInt(row.count.value, 10),
-                            });
-                        }
-                    }
-                    children.sort((a, b) => b.count - a.count);
-                    if (!this.hierarchyChildren[dim]) this.hierarchyChildren[dim] = {};
-                    this.hierarchyChildren[dim][parentValue] = children;
-                } catch (e) {
-                    console.error('Hierarchy drill-down failed:', e);
-                } finally {
-                    this.hierarchyLoading[dim][parentValue] = false;
-                }
+                await this.ensureHierarchyChildren(dim, parentValue);
             }
         },
 
@@ -1014,8 +1084,16 @@ SELECT ?field ?value ?low ?high ?count WHERE {
             return null;
         },
 
-        identifierFieldSpec() {
-            return this.fieldIRIs.identifier || 'urn:jena:lucene:field#identifier';
+        identifierFieldSpecs() {
+            const fields = [
+                this.fieldIRIs.identifier || 'urn:jena:lucene:field#identifier',
+                this.fieldIRIs.identifierValueText || 'urn:jena:lucene:field#identifierValueText',
+            ];
+            return [...new Set(fields)];
+        },
+
+        identifierFieldSelector() {
+            return JSON.stringify(this.identifierFieldSpecs());
         },
 
         // --- SPARQL execution ---
@@ -1039,7 +1117,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
         buildSearchQuery() {
             const identifier = this.identifier.trim();
             const term = identifier || this.q.trim() || '*';
-            const searchField = identifier ? JSON.stringify([this.identifierFieldSpec()]) : 'default';
+            const searchField = identifier ? this.identifierFieldSelector() : 'default';
             const escaped = escapeSparql(term);
             const cqlFilter = buildCqlFilter(
                 this.selected,
@@ -1072,7 +1150,7 @@ WHERE {
 
         buildIdentifierSuggestionQuery(identifier) {
             const escaped = escapeSparql(identifier);
-            const fieldSpec = JSON.stringify([this.identifierFieldSpec()]);
+            const fieldSpec = this.identifierFieldSelector();
             return `${SPARQL_PREFIXES}
 SELECT DISTINCT ?identifier
 WHERE {
@@ -1248,8 +1326,24 @@ WHERE {
                         }
                         continue;
                     }
+                    if (pred === 'year' || pred === 'depth') {
+                        card.rows.push({
+                            property: pred,
+                            values: values.map(pv => ({
+                                value: pv.raw,
+                                displayValue: pv.display,
+                                facetField: null,
+                                isActive: false,
+                                clickable: false,
+                                mapUri: null,
+                                tooltip: '',
+                                cssClass: 'prop-chip-neutral',
+                            })),
+                        });
+                        continue;
+                    }
                     const facetField = this.predicateToFacet[pred] || null;
-                    // Skip non-facetable literal values (e.g., depth, year, score)
+                    // Skip non-facetable literal values that do not add much to the card.
                     if (!facetField && !values.some(v => v.isUri)) continue;
                     const rowValues = [];
                     for (const pv of values) {
@@ -1402,6 +1496,7 @@ WHERE {
                 }
 
                 this.updateMap();
+                await this.restoreHierarchySelections();
                 const totalSec = (performance.now() - loadStart) / 1000;
                 this.description = this.buildDescription(hits.length, totalHits, totalSec);
             } catch (e) {

--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -925,7 +925,7 @@ function searchApp() {
 
                     const query = `${SPARQL_PREFIXES}
 SELECT ?field ?value ?low ?high ?count WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ('${searchField}' '${escaped}' '${JSON.stringify([childLevelIRI])}' '${combinedFilter}' ${this.maxFacetValues})
+    (?field ?value ?low ?high ?count) luc:facet ('default' '${searchField}' '${escaped}' '${JSON.stringify([childLevelIRI])}' '${combinedFilter}' ${this.maxFacetValues} 0)
 }`;
                     const data = await this.runSparql(query);
                     const children = [];
@@ -987,7 +987,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
         buildSearchQuery() {
             const identifier = this.identifier.trim();
             const term = identifier || this.q.trim() || '*';
-            const searchField = identifier ? this.identifierFieldSpec() : 'default';
+            const searchField = identifier ? JSON.stringify([this.identifierFieldSpec()]) : 'default';
             const escaped = escapeSparql(term);
             const cqlFilter = buildCqlFilter(
                 this.selected,
@@ -996,7 +996,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
                 this.fieldIRIs,
                 this.buildHierarchyParentClauses()
             );
-            const filterArg = cqlFilter ? ` '${cqlFilter}'` : '';
+            const filterArg = cqlFilter ? `'${cqlFilter}'` : "'null'";
             const facetRequests = this.facetFields.map(f => {
                 // For hierarchy dimensions, use the first level's field IRI
                 const hier = this.hierarchyDimensions.get(f);
@@ -1010,19 +1010,19 @@ SELECT ?field ?value ?low ?high ?count WHERE {
             return `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?_lit ?totalHits) luc:query ('${searchField}' '${escaped}'${filterArg} ${this.limit}) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' '${searchField}' '${escaped}' ${filterArg} 'null' ${this.limit}) }
     UNION
-    { (?field ?value ?low ?high ?count) luc:facet ('${searchField}' '${escaped}' '${facetFieldsJson}'${filterArg} ${this.maxFacetValues}) }
+    { (?field ?value ?low ?high ?count) luc:facet ('default' '${searchField}' '${escaped}' '${facetFieldsJson}' ${filterArg} ${this.maxFacetValues} 0) }
 }`;
         },
 
         buildIdentifierSuggestionQuery(identifier) {
             const escaped = escapeSparql(identifier);
-            const fieldSpec = this.identifierFieldSpec();
+            const fieldSpec = JSON.stringify([this.identifierFieldSpec()]);
             return `${SPARQL_PREFIXES}
 SELECT DISTINCT ?identifier
 WHERE {
-    (?hit ?entity ?score) luc:query ('${fieldSpec}' '${escaped}' 8) .
+    (?hit ?entity ?score) luc:query ('default' '${fieldSpec}' '${escaped}' 'null' 'null' 8) .
     ?entity ex:identifier ?identifier .
 }
 ORDER BY LCASE(STR(?identifier))
@@ -1772,9 +1772,9 @@ function statsApp() {
                 const statsQuery = `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?_lit ?totalHits) luc:query ('default' '*' 0) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' 'default' '*' 'null' 'null' 0) }
     UNION
-    { (?field ?value ?low ?high ?count) luc:facet ('default' '*' '${facetFieldsJson}' 0) }
+    { (?field ?value ?low ?high ?count) luc:facet ('default' 'default' '*' '${facetFieldsJson}' 'null' 0 0) }
 }`;
                 const statsData = await this.runSparql(endpoint, statsQuery);
                 const statsMs = performance.now() - t0;

--- a/demo/app-static/index.html
+++ b/demo/app-static/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/n3@1.22.3/browser/n3.min.js"></script>
   <script src="app-config.js?v=3"></script>
-  <script src="app.js?v=3"></script>
+  <script src="app.js?v=4"></script>
   <script>
     document.addEventListener('alpine:init', () => {
       Alpine.store('app', { showLog: true, showMap: true, highlightUri: null });
@@ -126,6 +126,22 @@
                     <template x-for="n in facetLimits" :key="n">
                       <option :value="n" x-text="n.toLocaleString()"></option>
                     </template>
+                  </select>
+                </div>
+                <div class="limit-control">
+                  <label class="limit-label">Sort</label>
+                  <select class="limit-select" x-model="sortField" @change="search()">
+                    <option value="">Relevance</option>
+                    <template x-for="f in sortableFields" :key="f.iri">
+                      <option :value="f.name" x-text="f.name"></option>
+                    </template>
+                  </select>
+                </div>
+                <div class="limit-control" x-show="sortField">
+                  <label class="limit-label">Order</label>
+                  <select class="limit-select" x-model="sortDirection" @change="search()">
+                    <option value="asc">asc</option>
+                    <option value="desc">desc</option>
                   </select>
                 </div>
               </div>

--- a/demo/app-static/index.html
+++ b/demo/app-static/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/n3@1.22.3/browser/n3.min.js"></script>
   <script src="app-config.js?v=3"></script>
-  <script src="app.js?v=4"></script>
+  <script src="app.js?v=6"></script>
   <script>
     document.addEventListener('alpine:init', () => {
       Alpine.store('app', { showLog: true, showMap: true, highlightUri: null });
@@ -174,7 +174,7 @@
                 <div>
                   <template x-if="(facets[fieldName] || []).length > 0">
                     <details class="facet-group" open>
-                      <summary class="facet-group-label" x-text="fieldName" :title="fieldIRIs[fieldName] || fieldName"></summary>
+                      <summary class="facet-group-label" x-text="facetLabel(fieldName)" :title="fieldIRIs[fieldName] || fieldName"></summary>
 
                       <!-- Hierarchy facets: expandable tree -->
                       <template x-if="isHierarchy(fieldName)">

--- a/demo/lucene_sparq_one_page.html
+++ b/demo/lucene_sparq_one_page.html
@@ -2,232 +2,493 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Jena SHACL luc:* One-Page Reference</title>
+<title>Jena luc: property functions - one-page explainer</title>
 <style>
+  @page { size: A3 landscape; margin: 8mm; }
   :root {
-    --bg: #f6f3ea;
-    --paper: #fffdf8;
-    --ink: #1f2430;
-    --muted: #5f6b7a;
-    --rule: #d8d2c3;
-    --accent: #a14a16;
-    --accent-2: #0f5f74;
-    --mono-bg: #f3efe5;
+    --ink: #1a1a1a;
+    --muted: #6b6b6b;
+    --rule: #d0d0d0;
+    --orange: #b94700;
+    --blue: #2a5d9f;
+    --green: #2e7d4f;
+    --purple: #6a1b9a;
+    --bg: #fafaf7;
   }
   * { box-sizing: border-box; }
-  body {
+  html, body {
     margin: 0;
-    font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+    padding: 0;
+    font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
     color: var(--ink);
-    background:
-      radial-gradient(circle at top right, #f0dcc7 0, transparent 26rem),
-      linear-gradient(180deg, #f8f4ec 0, var(--bg) 100%);
+    background: var(--bg);
   }
-  main {
-    max-width: 1080px;
+  .stage {
+    width: 1540px;
     margin: 0 auto;
-    padding: 32px 20px 56px;
+    padding: 10px 16px 8px;
   }
-  h1, h2, h3 { margin: 0 0 12px; line-height: 1.1; }
-  h1 {
-    font-family: "IBM Plex Serif", Georgia, serif;
-    font-size: clamp(2rem, 4vw, 3.2rem);
-    letter-spacing: -0.03em;
+  header.top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    border-bottom: 2px solid var(--ink);
+    padding-bottom: 6px;
+    margin-bottom: 6px;
   }
-  h2 {
-    font-size: 1.25rem;
-    color: var(--accent);
-    margin-top: 28px;
+  header.top h1 {
+    font-size: 22px;
+    margin: 0;
+    font-weight: 800;
+    letter-spacing: -0.01em;
   }
-  p, li {
-    font-size: 0.98rem;
-    line-height: 1.55;
+  header.top h1 .luc {
+    color: var(--orange);
+    font-family: "JetBrains Mono", Consolas, monospace;
+    font-weight: 800;
+  }
+  header.top h1 .tag {
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--muted);
+    margin-left: 10px;
+  }
+  header.top .sub {
+    font-size: 10px;
+    color: var(--muted);
+    text-align: right;
+    line-height: 1.5;
+  }
+  header.top .sub code {
+    font-family: "JetBrains Mono", Consolas, monospace;
     color: var(--ink);
   }
-  .lede {
-    color: var(--muted);
-    max-width: 70ch;
-    margin: 10px 0 18px;
+  .bowtie {
+    position: relative;
+    width: 1540px;
+    height: 920px;
+    margin: 0 auto;
   }
-  .grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 16px;
-    margin-top: 18px;
+  .bowtie svg.leaders {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 1540px;
+    height: 920px;
+    pointer-events: none;
+    z-index: 2;
   }
-  .card {
-    background: var(--paper);
-    border: 1px solid var(--rule);
-    border-radius: 16px;
-    padding: 18px;
-    box-shadow: 0 12px 24px rgba(31, 36, 48, 0.05);
-  }
-  .card h3 {
-    font-size: 1rem;
-    color: var(--accent-2);
-    margin-bottom: 10px;
-  }
-  code, pre {
-    font-family: "JetBrains Mono", "SFMono-Regular", monospace;
-  }
-  code {
-    background: var(--mono-bg);
-    padding: 0.08rem 0.32rem;
-    border-radius: 6px;
-  }
-  pre {
-    margin: 12px 0 0;
-    padding: 14px;
-    overflow: auto;
-    border-radius: 12px;
-    border: 1px solid var(--rule);
-    background: #fbf8f1;
-    line-height: 1.45;
-    font-size: 0.9rem;
-  }
-  table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-top: 10px;
-    background: var(--paper);
-    border: 1px solid var(--rule);
-    border-radius: 12px;
-    overflow: hidden;
-  }
-  th, td {
+  .code {
+    position: absolute;
+    left: 430px;
+    top: 20px;
+    width: 680px;
+    font-family: "JetBrains Mono", "SF Mono", Consolas, monospace;
+    font-size: 11.5px;
+    line-height: 20px;
+    background: #fbfaf5;
+    border: 1px dashed #cdc4a7;
+    border-radius: 3px;
+    padding: 10px 14px;
+    white-space: pre;
     text-align: left;
-    padding: 10px 12px;
-    border-bottom: 1px solid var(--rule);
-    vertical-align: top;
-    font-size: 0.95rem;
+    color: #2a2a2a;
+    z-index: 1;
   }
-  th {
-    background: #f1eadc;
-    color: var(--accent);
+  .code .kw  { color: var(--orange); font-weight: 700; }
+  .code .pf  { color: var(--orange); font-weight: 700; }
+  .code .str { color: #8a5a00; }
+  .code .json{ color: var(--blue); }
+  .code .num { color: var(--purple); }
+  .code .var { color: var(--green); font-weight: 700; }
+  .code .cmt { color: #9a9a9a; font-style: italic; }
+  .code .brc { color: #888; }
+  .cal {
+    position: absolute;
+    width: max-content;
+    max-width: 520px;
+    height: 20px;
+    background: #ffffff;
+    border: 1px solid #e3decf;
+    border-left: 3px solid var(--orange);
+    border-radius: 2px;
+    padding: 0 8px;
+    font-size: 9.5px;
+    line-height: 18px;
+    white-space: nowrap;
+    z-index: 3;
   }
-  tr:last-child td { border-bottom: 0; }
-  .note {
-    margin-top: 12px;
-    padding: 12px 14px;
-    border-left: 4px solid var(--accent);
-    background: #fff7ea;
+  .cal.b { border-left-color: var(--blue); }
+  .cal.g { border-left-color: var(--green); }
+  .cal.p { border-left-color: var(--purple); }
+  .cal.L {
+    left: 20px;
+    width: 400px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .cal.h40 {
+    height: 40px;
+    padding: 2px 8px;
+    line-height: 14px;
+    white-space: normal;
+  }
+  .cal .lbl {
+    font-family: "JetBrains Mono", Consolas, monospace;
+    font-weight: 800;
+    color: var(--green);
+    margin-right: 5px;
+  }
+  .cal.R .lbl { color: var(--orange); }
+  .cal.b.R .lbl { color: var(--blue); }
+  .cal.p.R .lbl { color: var(--purple); }
+  .cal .desc { color: #3a3a3a; }
+  .cal.R .desc { color: #7e451d; }
+  .cal.b.R .desc { color: #2a5d9f; }
+  .cal.p.R .desc { color: var(--purple); }
+  .cal.pred {
+    min-width: 420px;
+    max-width: 520px;
+  }
+  .cal code {
+    font-family: "JetBrains Mono", Consolas, monospace;
+    font-size: 8.5px;
+    background: #f4f1e7;
+    padding: 0 3px;
+    border-radius: 2px;
+  }
+  .sync-star {
+    color: #c69200;
+    font-weight: 800;
+    margin-right: 4px;
+    font-size: 14px;
+    line-height: 1;
+    vertical-align: -1px;
+  }
+  .code .sync-star {
+    display: inline-block;
+    width: 18px;
+    margin-left: -22px;
+    margin-right: 4px;
+    text-align: center;
+  }
+  .legend-note {
+    position: absolute;
+    top: 18px;
+    right: 20px;
+    width: 315px;
+    background: #fffdf6;
+    border: 1px solid #e3decf;
+    border-left: 4px solid #c69200;
+    border-radius: 2px;
+    padding: 8px 10px;
+    font-size: 10px;
+    line-height: 1.35;
+    color: #5a4a19;
+    z-index: 4;
+  }
+  .toggle-wrap {
+    position: absolute;
+    top: 18px;
+    left: 20px;
+    width: 180px;
+    z-index: 4;
+  }
+  .toggle-callouts {
+    appearance: none;
+    width: 100%;
+    min-height: 34px;
+    border: 1px solid #b8ae93;
+    background: linear-gradient(180deg, #fffdf7 0%, #f2ead6 100%);
+    box-shadow: 0 1px 0 rgba(255,255,255,0.85) inset;
+    color: #5c5131;
+    border-radius: 6px;
+    padding: 7px 12px;
+    font-size: 11px;
+    line-height: 1.2;
+    text-align: center;
+    cursor: pointer;
+  }
+  .toggle-callouts .title {
+    font-family: "JetBrains Mono", Consolas, monospace;
+    font-weight: 800;
+    font-size: 11px;
+    color: #6a5b2a;
+  }
+  .toggle-callouts:hover {
+    background: linear-gradient(180deg, #fff7e8 0%, #eadfbe 100%);
+  }
+  .toggle-callouts:active {
+    background: linear-gradient(180deg, #eadfbe 0%, #fff7e8 100%);
+  }
+  .legend-note .title {
+    display: block;
+    font-family: "JetBrains Mono", Consolas, monospace;
+    font-weight: 800;
+    color: #8a6600;
+    margin-bottom: 4px;
+  }
+  .bowtie.hide-callouts .leaders,
+  .bowtie.hide-callouts .cal,
+  .bowtie.hide-callouts .legend-note,
+  .bowtie.hide-callouts .sync-star {
+    display: none;
+  }
+  footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 10px;
     color: var(--muted);
-    border-radius: 10px;
+    border-top: 1px solid var(--rule);
+    padding-top: 6px;
+    margin-top: 8px;
+  }
+  footer code {
+    font-family: "JetBrains Mono", monospace;
+    color: var(--ink);
+  }
+  footer .legend {
+    display: flex;
+    gap: 22px;
+  }
+  footer .legend span .sw {
+    display: inline-block;
+    width: 11px;
+    height: 11px;
+    margin-right: 4px;
+    vertical-align: -1px;
+    border-radius: 2px;
   }
 </style>
 </head>
 <body>
-<main>
-  <h1>Jena SHACL <code>luc:*</code> One-Page Reference</h1>
-  <p class="lede">
-    Current API surface for SHACL-mode search. This page reflects the fixed-position signatures on
-    <code>main</code>: explicit <code>indexSelector</code>, explicit <code>fieldSpec</code>, no
-    <code>?match</code> on <code>luc:query</code>, and field IRIs for all public field references.
-  </p>
+<div class="stage">
 
-  <div class="grid">
-    <section class="card">
-      <h3><code>luc:query</code></h3>
-      <pre>(?hit ?entity ?score ?totalHits)
-  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)</pre>
-      <p>Use <code>""</code> for an unused <code>cqlFilter</code> or <code>sortSpec</code>.</p>
-    </section>
+<header class="top">
+  <h1>
+    <span class="luc">luc:query</span> &nbsp;&middot;&nbsp;
+    <span class="luc">luc:match</span> &nbsp;&middot;&nbsp;
+    <span class="luc">luc:facet</span>
+    <span class="tag">- Jena SHACL-mode text search, one-page explainer</span>
+  </h1>
+  <div class="sub">
+    <code>PREFIX luc: &lt;urn:jena:lucene:index#&gt;</code>
+    &nbsp;<code>PREFIX field: &lt;urn:jena:lucene:field#&gt;</code><br>
+    IRIs abbreviated below for readability (<code>urn:title</code>, <code>urn:year</code>, <code>urn:sourceGraph</code>)
+  </div>
+</header>
 
-    <section class="card">
-      <h3><code>luc:match</code></h3>
-      <pre>(?hit ?field ?value ?snippet) luc:match ()</pre>
-      <p>Per-hit match detail lives here. This is the only match-detail API.</p>
-    </section>
-
-    <section class="card">
-      <h3><code>luc:facet</code></h3>
-      <pre>(?field ?value ?low ?high ?count)
-  luc:facet (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)</pre>
-      <p>The active supported subject form is the 5-slot form above. Flat facet rows bind <code>?value</code> and leave <code>?low</code> / <code>?high</code> unbound.</p>
-    </section>
+<div class="bowtie">
+  <div class="toggle-wrap">
+    <button type="button" class="toggle-callouts" id="toggle-callouts">
+      <span class="title">Hide Callouts</span>
+    </button>
   </div>
 
-  <h2>Argument Rules</h2>
-  <table>
-    <thead>
-      <tr><th>Concept</th><th>Rule</th></tr>
-    </thead>
-    <tbody>
-      <tr><td><code>indexSelector</code></td><td>String literal. Usually <code>"default"</code>, but can also be a configured <code>text:indexId</code> or index resource IRI.</td></tr>
-      <tr><td><code>fieldSpec</code></td><td>Either <code>"default"</code> or a JSON array of field IRIs.</td></tr>
-      <tr><td>Field references</td><td>Always field IRIs in <code>fieldSpec</code>, CQL <code>property</code>, sort specs, and facet arrays.</td></tr>
-      <tr><td>Graph filtering</td><td>Target model uses reserved synthetic field <code>urn:jena:lucene:field#sourceGraph</code>, not a dedicated <code>?graph</code> slot.</td></tr>
-      <tr><td>Arity</td><td>No heuristic parsing. <code>luc:query</code> takes exactly 6 object args. <code>luc:facet</code> takes exactly 7 object args.</td></tr>
-      <tr><td>Highlight</td><td>Reserved for later. Not part of the active supported <code>luc:query</code> signature yet.</td></tr>
-    </tbody>
-  </table>
+<div class="code"><span class="cmt"># Typical combined shape - hits + per-field match  UNION  facets</span>
+<span class="kw">SELECT</span> * <span class="kw">WHERE</span> <span class="brc">{</span>
+  <span class="brc">{</span>
+    <span class="brc">(</span>
+        <span class="var">?hit</span>
+        <span class="var">?entity</span>
+        <span class="var">?score</span>
+        <span class="var">?totalHits</span>
+    <span class="brc">)</span> <span class="pf" id="pf-query">luc:query</span> <span class="brc">(</span>
+        <span class="sync-star">★</span><span class="str" id="rq-indexSelector">"primary"</span>
+        <span class="str" id="rq-fieldSpec">'["urn:title", "urn:description"]'</span>
+        <span class="sync-star">★</span><span class="str" id="rq-queryString">"machine learning"</span>
+        <span class="sync-star">★</span><span class="str" id="rq-cqlFilter">""</span>
+        <span class="json" id="rq-sortSpec">'{"field":"urn:year","order":"desc"}'</span>
+        <span class="num" id="rq-limit">20</span>
+    <span class="brc">)</span> .
+    <span class="brc">(</span>
+        <span class="var">?hit</span>
+        <span class="var">?field</span>
+        <span class="var">?value</span>
+        <span class="var">?snippet</span>
+    <span class="brc">)</span> <span class="pf" id="pf-match">luc:match</span> <span class="brc">( )</span> .
+  <span class="brc">}</span>
+  <span class="kw">UNION</span>
+  <span class="brc">{</span>
+    <span class="brc">(</span>
+        <span class="var">?field</span>
+        <span class="var">?value</span>
+        <span class="var">?value_low</span>
+        <span class="var">?value_high</span>
+        <span class="var">?count</span>
+    <span class="brc">)</span> <span class="pf" id="pf-facet">luc:facet</span> <span class="brc">(</span>
+        <span class="sync-star">★</span><span class="str" id="rf-indexSelector">"primary"</span>
+        <span class="str" id="rf-fieldSpec">"default"</span>
+        <span class="sync-star">★</span><span class="str" id="rf-queryString">"machine learning"</span>
+        <span class="json" id="rf-facetFields">'["urn:category", {"field":"urn:year", "ranges":[null, 2020, 2022, 2024, null]}]'</span>
+        <span class="sync-star">★</span><span class="str" id="rf-cqlFilter">""</span>
+        <span class="num" id="rf-maxValues">10</span>
+        <span class="num" id="rf-minCount">2</span>
+    <span class="brc">)</span> .
+  <span class="brc">}</span>
+<span class="brc">}</span></div>
 
-  <h2>Examples</h2>
-  <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
-
-SELECT ?entity ?score WHERE {
-  (?hit ?entity ?score)
-    luc:query ("default" "default" "learning" "" "" 20) .
-}</pre>
-
-  <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
-
-SELECT ?entity ?score WHERE {
-  (?hit ?entity ?score)
-    luc:query (
-      "default"
-      '["urn:jena:lucene:field#title"]'
-      "copper"
-      ""
-      '{"field":"urn:jena:lucene:field#year","order":"desc"}'
-      10
-    ) .
-}</pre>
-
-  <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
-
-SELECT ?entity ?field ?value WHERE {
-  (?hit ?entity ?score)
-    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
-  (?hit ?field ?value) luc:match () .
-}</pre>
-
-  <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
-
-SELECT ?field ?value ?low ?high ?count WHERE {
-  (?field ?value ?low ?high ?count)
-    luc:facet (
-      "default"
-      "default"
-      "*"
-      '["urn:jena:lucene:field#state", {"field":"urn:jena:lucene:field#year","ranges":[null,2000,2010,2020,null]}]'
-      ""
-      20
-      0
-    ) .
-}</pre>
-
-  <h2>Sort Syntax</h2>
-  <p>Sort specs are JSON and use field IRIs in the public API.</p>
-  <pre>{"field":"urn:jena:lucene:field#year","order":"desc"}</pre>
-  <pre>[
-  {"field":"urn:jena:lucene:field#year","order":"desc"},
-  {"field":"urn:jena:lucene:field#title"}
-]</pre>
-
-  <h2>Graph Filtering</h2>
-  <p>
-    Target model: graph restriction is a normal CQL filter on a reserved synthetic field,
-    not a special result binding.
-  </p>
-  <pre>{"op":"=","args":[{"property":"urn:jena:lucene:field#sourceGraph"},"http://example.org/graph/A"]}</pre>
-
-  <div class="note">
-    Shared execution is keyed by resolved index identity, field spec, query string, CQL filter, and
-    sort spec. Matching <code>luc:query</code>, <code>luc:facet</code>, and <code>luc:match</code>
-    calls reuse one Lucene search.
+  <div class="legend-note">
+    <span class="title"><span class="sync-star">★</span>Shared Search Inputs</span>
+    These marked inputs normally stay aligned across <code>luc:query</code> and <code>luc:facet</code> so the facet buckets describe the same search as the hit query. Graph scoping is a normal CQL filter on a reserved synthetic field such as <code>urn:sourceGraph</code>.
   </div>
-</main>
+
+  <svg class="leaders" viewBox="0 0 1540 920" preserveAspectRatio="none">
+    <g stroke-width="1.3" fill="none">
+      <line x1="420" y1="120" x2="480" y2="120" stroke="#2e7d4f"/><circle cx="480" cy="120" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="140" x2="480" y2="140" stroke="#2e7d4f"/><circle cx="480" cy="140" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="160" x2="480" y2="160" stroke="#2e7d4f"/><circle cx="480" cy="160" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="180" x2="480" y2="180" stroke="#2e7d4f"/><circle cx="480" cy="180" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="380" x2="480" y2="380" stroke="#2e7d4f"/><circle cx="480" cy="380" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="400" x2="480" y2="400" stroke="#2e7d4f"/><circle cx="480" cy="400" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="420" x2="480" y2="420" stroke="#2e7d4f"/><circle cx="480" cy="420" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="440" x2="480" y2="440" stroke="#2e7d4f"/><circle cx="480" cy="440" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="560" x2="480" y2="560" stroke="#2e7d4f"/><circle cx="480" cy="560" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="580" x2="480" y2="580" stroke="#2e7d4f"/><circle cx="480" cy="580" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="600" x2="480" y2="600" stroke="#2e7d4f"/><circle cx="480" cy="600" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="620" x2="480" y2="620" stroke="#2e7d4f"/><circle cx="480" cy="620" r="2.2" fill="#2e7d4f"/>
+      <line x1="420" y1="640" x2="480" y2="640" stroke="#2e7d4f"/><circle cx="480" cy="640" r="2.2" fill="#2e7d4f"/>
+
+      <line class="rhs-link" data-target="pf-query" x1="620" y1="200" x2="670" y2="200" stroke="#b94700"/><circle class="rhs-dot" data-target="pf-query" cx="620" cy="200" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rq-indexSelector" x1="620" y1="220" x2="670" y2="220" stroke="#b94700"/><circle class="rhs-dot" data-target="rq-indexSelector" cx="620" cy="220" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rq-fieldSpec" x1="710" y1="240" x2="760" y2="240" stroke="#b94700"/><circle class="rhs-dot" data-target="rq-fieldSpec" cx="710" cy="240" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rq-queryString" x1="620" y1="260" x2="670" y2="260" stroke="#b94700"/><circle class="rhs-dot" data-target="rq-queryString" cx="620" cy="260" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rq-cqlFilter" x1="540" y1="280" x2="590" y2="280" stroke="#2a5d9f"/><circle class="rhs-dot" data-target="rq-cqlFilter" cx="540" cy="280" r="2.2" fill="#2a5d9f"/>
+      <line class="rhs-link" data-target="rq-sortSpec" x1="760" y1="300" x2="810" y2="300" stroke="#2a5d9f"/><circle class="rhs-dot" data-target="rq-sortSpec" cx="760" cy="300" r="2.2" fill="#2a5d9f"/>
+      <line class="rhs-link" data-target="rq-limit" x1="540" y1="320" x2="590" y2="320" stroke="#6a1b9a"/><circle class="rhs-dot" data-target="rq-limit" cx="540" cy="320" r="2.2" fill="#6a1b9a"/>
+      <line class="rhs-link" data-target="pf-match" x1="620" y1="460" x2="670" y2="460" stroke="#b94700"/><circle class="rhs-dot" data-target="pf-match" cx="620" cy="460" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="pf-facet" x1="620" y1="660" x2="670" y2="660" stroke="#b94700"/><circle class="rhs-dot" data-target="pf-facet" cx="620" cy="660" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rf-indexSelector" x1="620" y1="680" x2="670" y2="680" stroke="#b94700"/><circle class="rhs-dot" data-target="rf-indexSelector" cx="620" cy="680" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rf-fieldSpec" x1="540" y1="700" x2="590" y2="700" stroke="#b94700"/><circle class="rhs-dot" data-target="rf-fieldSpec" cx="540" cy="700" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rf-queryString" x1="620" y1="720" x2="670" y2="720" stroke="#b94700"/><circle class="rhs-dot" data-target="rf-queryString" cx="620" cy="720" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rf-facetFields" x1="815" y1="740" x2="865" y2="740" stroke="#b94700"/><circle class="rhs-dot" data-target="rf-facetFields" cx="815" cy="740" r="2.2" fill="#b94700"/>
+      <line class="rhs-link" data-target="rf-cqlFilter" x1="540" y1="760" x2="590" y2="760" stroke="#2a5d9f"/><circle class="rhs-dot" data-target="rf-cqlFilter" cx="540" cy="760" r="2.2" fill="#2a5d9f"/>
+      <line class="rhs-link" data-target="rf-maxValues" x1="540" y1="780" x2="590" y2="780" stroke="#6a1b9a"/><circle class="rhs-dot" data-target="rf-maxValues" cx="540" cy="780" r="2.2" fill="#6a1b9a"/>
+      <line class="rhs-link" data-target="rf-minCount" x1="540" y1="800" x2="590" y2="800" stroke="#6a1b9a"/><circle class="rhs-dot" data-target="rf-minCount" cx="540" cy="800" r="2.2" fill="#6a1b9a"/>
+    </g>
+  </svg>
+
+  <div class="cal L g" style="top:110px;"><span class="lbl">?hit</span><span class="desc">blank-node join key for <code>luc:match</code> (required)</span></div>
+  <div class="cal L g" style="top:130px;"><span class="lbl">?entity</span><span class="desc">matched entity IRI</span></div>
+  <div class="cal L g" style="top:150px;"><span class="lbl">?score</span><span class="desc">Lucene relevance score (<code>xsd:float</code>)</span></div>
+  <div class="cal L g" style="top:170px;"><span class="lbl">?totalHits</span><span class="desc">total hits before <code>limit</code> - only computed when projected</span></div>
+
+  <div class="cal L g" style="top:370px;"><span class="lbl">?hit</span><span class="desc">same blank-node as <code>luc:query</code> - this is the join</span></div>
+  <div class="cal L g" style="top:390px;"><span class="lbl">?field</span><span class="desc">field IRI that matched</span></div>
+  <div class="cal L g" style="top:410px;"><span class="lbl">?value</span><span class="desc">stored value - KEYWORD&rarr;IRI, TEXT&rarr;string, numeric&rarr;typed literal</span></div>
+  <div class="cal L g" style="top:430px;"><span class="lbl">?snippet</span><span class="desc">reserved slot for future highlight output; may be unbound for now</span></div>
+
+  <div class="cal L g" style="top:550px;"><span class="lbl">?field</span><span class="desc">facet field IRI</span></div>
+  <div class="cal L g" style="top:570px;"><span class="lbl">?value</span><span class="desc">flat or hierarchical value - unbound on range-bucket rows</span></div>
+  <div class="cal L g" style="top:590px;"><span class="lbl">?value_low</span><span class="desc">range lower bound - inclusive; unbound on flat rows</span></div>
+  <div class="cal L g" style="top:610px;"><span class="lbl">?value_high</span><span class="desc">range upper bound - exclusive; unbound on flat rows</span></div>
+  <div class="cal L g" style="top:630px;"><span class="lbl">?count</span><span class="desc">document count (<code>xsd:long</code>)</span></div>
+
+  <div class="cal R pred rhs-cal" data-target="pf-query" style="top:190px;"><span class="lbl">luc:query</span><span class="desc">runs the Lucene search and binds hit-level metadata for matching documents</span></div>
+  <div class="cal R rhs-cal" data-target="rq-indexSelector" style="top:210px;"><span class="lbl">indexSelector</span><span class="desc">required first arg - configured <code>text:indexId</code> or index IRI</span></div>
+  <div class="cal R rhs-cal" data-target="rq-fieldSpec" style="top:230px;"><span class="lbl">fieldSpec</span><span class="desc"><code>"default"</code> or a JSON array of field IRIs to scope the search</span></div>
+  <div class="cal R rhs-cal" data-target="rq-queryString" style="top:250px;"><span class="lbl">queryString</span><span class="desc">Lucene classic parser text</span></div>
+  <div class="cal R b rhs-cal" data-target="rq-cqlFilter" style="top:270px;"><span class="lbl">cqlFilter</span><span class="desc">CQL2-JSON object, or <code>""</code> when intentionally absent</span></div>
+  <div class="cal R b rhs-cal" data-target="rq-sortSpec" style="top:290px;"><span class="lbl">sortSpec</span><span class="desc">JSON sort object or array using field IRIs, or <code>""</code></span></div>
+  <div class="cal R p rhs-cal" data-target="rq-limit" style="top:310px;"><span class="lbl">limit</span><span class="desc">integer literal cap; lexical forms like <code>"10"</code> are accepted; negative = unlimited</span></div>
+
+  <div class="cal R pred rhs-cal" data-target="pf-match" style="top:450px;"><span class="lbl">luc:match</span><span class="desc">the only per-hit match-detail API; object is always <code>()</code></span></div>
+
+  <div class="cal R pred rhs-cal" data-target="pf-facet" style="top:650px;"><span class="lbl">luc:facet</span><span class="desc">runs the same search shape but returns aggregated facet buckets instead of individual hits</span></div>
+  <div class="cal R rhs-cal" data-target="rf-indexSelector" style="top:670px;"><span class="lbl">indexSelector</span><span class="desc">same selector model as <code>luc:query</code></span></div>
+  <div class="cal R rhs-cal" data-target="rf-fieldSpec" style="top:690px;"><span class="lbl">fieldSpec</span><span class="desc">search scope for the facet search; may differ from the hit query</span></div>
+  <div class="cal R rhs-cal" data-target="rf-queryString" style="top:710px;"><span class="lbl">queryString</span><span class="desc">same query text; use <code>"*"</code> to facet across every indexed document</span></div>
+  <div class="cal R rhs-cal" data-target="rf-facetFields" style="top:730px;"><span class="lbl">facetFields</span><span class="desc">field IRIs and/or range objects; <code>null</code> inside ranges means an open end</span></div>
+  <div class="cal R b rhs-cal" data-target="rf-cqlFilter" style="top:750px;"><span class="lbl">cqlFilter</span><span class="desc">same empty-string sentinel as <code>luc:query</code>; graph scoping belongs here via <code>urn:sourceGraph</code></span></div>
+  <div class="cal R p rhs-cal" data-target="rf-maxValues" style="top:770px;"><span class="lbl">maxValues</span><span class="desc">per-field cap on returned values; <code>0</code> = all</span></div>
+  <div class="cal R p rhs-cal" data-target="rf-minCount" style="top:790px;"><span class="lbl">minCount</span><span class="desc">drop long-tail values below this count</span></div>
+
+</div>
+
+<script>
+  (function () {
+    function alignRightLeaders() {
+      const bowtie = document.querySelector('.bowtie');
+      if (!bowtie) return;
+
+      const bowtieRect = bowtie.getBoundingClientRect();
+      const baseGapToDot = 12;
+      const baseGapToBox = 72;
+      const maxRight = bowtie.clientWidth - 18;
+
+      document.querySelectorAll('.rhs-cal').forEach((callout) => {
+        const targetId = callout.getAttribute('data-target');
+        const target = targetId ? document.getElementById(targetId) : null;
+        if (!target) return;
+
+        const targetRect = target.getBoundingClientRect();
+        const targetText = (target.textContent || '').trim();
+        const bracketBump = /[\]\)]$/.test(targetText) ? 10 : 0;
+        const predicateBump = /^(pf-query|pf-facet)$/.test(targetId) ? 22 : 0;
+        const desiredLeft = Math.round(targetRect.right - bowtieRect.left + baseGapToBox + bracketBump + predicateBump);
+        const maxLeft = maxRight - callout.offsetWidth;
+        callout.style.left = Math.min(desiredLeft, maxLeft) + 'px';
+      });
+
+      document.querySelectorAll('.rhs-link').forEach((line) => {
+        const targetId = line.getAttribute('data-target');
+        const target = targetId ? document.getElementById(targetId) : null;
+        if (!target) return;
+
+        const callout = document.querySelector('.rhs-cal[data-target="' + targetId + '"]');
+        const dot = document.querySelector('.rhs-dot[data-target="' + targetId + '"]');
+        if (!callout || !dot) return;
+
+        const targetRect = target.getBoundingClientRect();
+        const targetText = (target.textContent || '').trim();
+        const bracketBump = /[\]\)]$/.test(targetText) ? 10 : 0;
+        const predicateBump = /^(pf-query|pf-facet)$/.test(targetId) ? 22 : 0;
+        const x1 = Math.round(targetRect.right - bowtieRect.left + baseGapToDot + bracketBump + predicateBump);
+        const x2 = Math.round(callout.offsetLeft);
+
+        line.setAttribute('x1', String(x1));
+        line.setAttribute('x2', String(x2));
+        dot.setAttribute('cx', String(x1));
+      });
+    }
+
+    function setupToggle() {
+      const bowtie = document.querySelector('.bowtie');
+      const button = document.getElementById('toggle-callouts');
+      if (!bowtie || !button) return;
+
+      button.addEventListener('click', function () {
+        const hidden = bowtie.classList.toggle('hide-callouts');
+        const title = button.querySelector('.title');
+        if (title) title.textContent = hidden ? 'Show Callouts' : 'Hide Callouts';
+      });
+    }
+
+    window.addEventListener('load', alignRightLeaders);
+    window.addEventListener('load', setupToggle);
+    window.addEventListener('resize', alignRightLeaders);
+  }());
+</script>
+
+<footer>
+  <div class="legend">
+    <span><span class="sw" style="background:#fff3e0;border:1px solid #b94700;"></span>positional arg</span>
+    <span><span class="sw" style="background:#e7eff9;border:1px solid #2a5d9f;"></span>filter / sort arg</span>
+    <span><span class="sw" style="background:#f1e5fb;border:1px solid #6a1b9a;"></span>numeric arg</span>
+    <span><span class="sw" style="background:#e6f2ea;border:1px solid #2e7d4f;"></span>subject / bindings</span>
+  </div>
+  <div>
+    <strong>Fixed arity:</strong> <code>luc:query</code> takes 6 object args and <code>luc:facet</code> takes 7.
+    &nbsp;&middot;&nbsp;
+    <strong>Empty slots:</strong> use <code>""</code> for absent <code>cqlFilter</code> / <code>sortSpec</code>.
+    &nbsp;&middot;&nbsp;
+    <strong>Graph filtering:</strong> target model is a normal filter on <code>urn:sourceGraph</code>, not a dedicated result slot.
+    &nbsp;&middot;&nbsp;
+    <strong>Shared execution:</strong> matching selector + query + filter state across the PFs reuses one Lucene search.
+  </div>
+</footer>
+
+</div>
 </body>
 </html>

--- a/demo/lucene_sparq_one_page.html
+++ b/demo/lucene_sparq_one_page.html
@@ -131,7 +131,7 @@
       <h3><code>luc:query</code></h3>
       <pre>(?hit ?entity ?score ?totalHits)
   luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)</pre>
-      <p>Use <code>"null"</code> for an unused <code>cqlFilter</code> or <code>sortSpec</code>.</p>
+      <p>Use <code>""</code> for an unused <code>cqlFilter</code> or <code>sortSpec</code>.</p>
     </section>
 
     <section class="card">
@@ -144,7 +144,7 @@
       <h3><code>luc:facet</code></h3>
       <pre>(?field ?value ?low ?high ?count)
   luc:facet (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)</pre>
-      <p>The active supported subject form is the 5-slot form above.</p>
+      <p>The active supported subject form is the 5-slot form above. Flat facet rows bind <code>?value</code> and leave <code>?low</code> / <code>?high</code> unbound.</p>
     </section>
   </div>
 
@@ -168,7 +168,7 @@
 
 SELECT ?entity ?score WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" "default" "learning" "null" "null" 20) .
+    luc:query ("default" "default" "learning" "" "" 20) .
 }</pre>
 
   <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
@@ -179,7 +179,7 @@ SELECT ?entity ?score WHERE {
       "default"
       '["urn:jena:lucene:field#title"]'
       "copper"
-      "null"
+      ""
       '{"field":"urn:jena:lucene:field#year","order":"desc"}'
       10
     ) .
@@ -189,7 +189,7 @@ SELECT ?entity ?score WHERE {
 
 SELECT ?entity ?field ?value WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
   (?hit ?field ?value) luc:match () .
 }</pre>
 
@@ -202,7 +202,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
       "default"
       "*"
       '["urn:jena:lucene:field#state", {"field":"urn:jena:lucene:field#year","ranges":[null,2000,2010,2020,null]}]'
-      "null"
+      ""
       20
       0
     ) .

--- a/demo/lucene_sparq_one_page.html
+++ b/demo/lucene_sparq_one_page.html
@@ -1,3 +1,21 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/demo/lucene_sparq_one_page.html
+++ b/demo/lucene_sparq_one_page.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Jena SHACL luc:* One-Page Reference</title>
+<style>
+  :root {
+    --bg: #f6f3ea;
+    --paper: #fffdf8;
+    --ink: #1f2430;
+    --muted: #5f6b7a;
+    --rule: #d8d2c3;
+    --accent: #a14a16;
+    --accent-2: #0f5f74;
+    --mono-bg: #f3efe5;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+    color: var(--ink);
+    background:
+      radial-gradient(circle at top right, #f0dcc7 0, transparent 26rem),
+      linear-gradient(180deg, #f8f4ec 0, var(--bg) 100%);
+  }
+  main {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 32px 20px 56px;
+  }
+  h1, h2, h3 { margin: 0 0 12px; line-height: 1.1; }
+  h1 {
+    font-family: "IBM Plex Serif", Georgia, serif;
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    letter-spacing: -0.03em;
+  }
+  h2 {
+    font-size: 1.25rem;
+    color: var(--accent);
+    margin-top: 28px;
+  }
+  p, li {
+    font-size: 0.98rem;
+    line-height: 1.55;
+    color: var(--ink);
+  }
+  .lede {
+    color: var(--muted);
+    max-width: 70ch;
+    margin: 10px 0 18px;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+    margin-top: 18px;
+  }
+  .card {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-radius: 16px;
+    padding: 18px;
+    box-shadow: 0 12px 24px rgba(31, 36, 48, 0.05);
+  }
+  .card h3 {
+    font-size: 1rem;
+    color: var(--accent-2);
+    margin-bottom: 10px;
+  }
+  code, pre {
+    font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  }
+  code {
+    background: var(--mono-bg);
+    padding: 0.08rem 0.32rem;
+    border-radius: 6px;
+  }
+  pre {
+    margin: 12px 0 0;
+    padding: 14px;
+    overflow: auto;
+    border-radius: 12px;
+    border: 1px solid var(--rule);
+    background: #fbf8f1;
+    line-height: 1.45;
+    font-size: 0.9rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+  th, td {
+    text-align: left;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+    font-size: 0.95rem;
+  }
+  th {
+    background: #f1eadc;
+    color: var(--accent);
+  }
+  tr:last-child td { border-bottom: 0; }
+  .note {
+    margin-top: 12px;
+    padding: 12px 14px;
+    border-left: 4px solid var(--accent);
+    background: #fff7ea;
+    color: var(--muted);
+    border-radius: 10px;
+  }
+</style>
+</head>
+<body>
+<main>
+  <h1>Jena SHACL <code>luc:*</code> One-Page Reference</h1>
+  <p class="lede">
+    Current API surface for SHACL-mode search. This page reflects the fixed-position signatures on
+    <code>main</code>: explicit <code>indexSelector</code>, explicit <code>fieldSpec</code>, no
+    <code>?match</code> on <code>luc:query</code>, and field IRIs for all public field references.
+  </p>
+
+  <div class="grid">
+    <section class="card">
+      <h3><code>luc:query</code></h3>
+      <pre>(?hit ?entity ?score ?totalHits)
+  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)</pre>
+      <p>Use <code>"null"</code> for an unused <code>cqlFilter</code> or <code>sortSpec</code>.</p>
+    </section>
+
+    <section class="card">
+      <h3><code>luc:match</code></h3>
+      <pre>(?hit ?field ?value ?snippet) luc:match ()</pre>
+      <p>Per-hit match detail lives here. This is the only match-detail API.</p>
+    </section>
+
+    <section class="card">
+      <h3><code>luc:facet</code></h3>
+      <pre>(?field ?value ?low ?high ?count)
+  luc:facet (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)</pre>
+      <p>The active supported subject form is the 5-slot form above.</p>
+    </section>
+  </div>
+
+  <h2>Argument Rules</h2>
+  <table>
+    <thead>
+      <tr><th>Concept</th><th>Rule</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>indexSelector</code></td><td>String literal. Usually <code>"default"</code>, but can also be a configured <code>text:indexId</code> or index resource IRI.</td></tr>
+      <tr><td><code>fieldSpec</code></td><td>Either <code>"default"</code> or a JSON array of field IRIs.</td></tr>
+      <tr><td>Field references</td><td>Always field IRIs in <code>fieldSpec</code>, CQL <code>property</code>, sort specs, and facet arrays.</td></tr>
+      <tr><td>Graph filtering</td><td>Target model uses reserved synthetic field <code>urn:jena:lucene:field#sourceGraph</code>, not a dedicated <code>?graph</code> slot.</td></tr>
+      <tr><td>Arity</td><td>No heuristic parsing. <code>luc:query</code> takes exactly 6 object args. <code>luc:facet</code> takes exactly 7 object args.</td></tr>
+      <tr><td>Highlight</td><td>Reserved for later. Not part of the active supported <code>luc:query</code> signature yet.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Examples</h2>
+  <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
+
+SELECT ?entity ?score WHERE {
+  (?hit ?entity ?score)
+    luc:query ("default" "default" "learning" "null" "null" 20) .
+}</pre>
+
+  <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
+
+SELECT ?entity ?score WHERE {
+  (?hit ?entity ?score)
+    luc:query (
+      "default"
+      '["urn:jena:lucene:field#title"]'
+      "copper"
+      "null"
+      '{"field":"urn:jena:lucene:field#year","order":"desc"}'
+      10
+    ) .
+}</pre>
+
+  <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
+
+SELECT ?entity ?field ?value WHERE {
+  (?hit ?entity ?score)
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+  (?hit ?field ?value) luc:match () .
+}</pre>
+
+  <pre>PREFIX luc: &lt;urn:jena:lucene:index#&gt;
+
+SELECT ?field ?value ?low ?high ?count WHERE {
+  (?field ?value ?low ?high ?count)
+    luc:facet (
+      "default"
+      "default"
+      "*"
+      '["urn:jena:lucene:field#state", {"field":"urn:jena:lucene:field#year","ranges":[null,2000,2010,2020,null]}]'
+      "null"
+      20
+      0
+    ) .
+}</pre>
+
+  <h2>Sort Syntax</h2>
+  <p>Sort specs are JSON and use field IRIs in the public API.</p>
+  <pre>{"field":"urn:jena:lucene:field#year","order":"desc"}</pre>
+  <pre>[
+  {"field":"urn:jena:lucene:field#year","order":"desc"},
+  {"field":"urn:jena:lucene:field#title"}
+]</pre>
+
+  <h2>Graph Filtering</h2>
+  <p>
+    Target model: graph restriction is a normal CQL filter on a reserved synthetic field,
+    not a special result binding.
+  </p>
+  <pre>{"op":"=","args":[{"property":"urn:jena:lucene:field#sourceGraph"},"http://example.org/graph/A"]}</pre>
+
+  <div class="note">
+    Shared execution is keyed by resolved index identity, field spec, query string, CQL filter, and
+    sort spec. Matching <code>luc:query</code>, <code>luc:facet</code>, and <code>luc:match</code>
+    calls reuse one Lucene search.
+  </div>
+</main>
+</body>
+</html>

--- a/demo/test/config.ttl
+++ b/demo/test/config.ttl
@@ -29,12 +29,13 @@ PREFIX schema:  <https://schema.org/>
 
 :text_dataset rdf:type text:TextDataset ;
     text:dataset :base_dataset ;
-    text:index   :index .
+    text:indexes :index .
 
 :base_dataset rdf:type tdb2:DatasetTDB ;
     tdb2:location "DB" .
 
 :index rdf:type text:TextIndexShacl ;
+    text:indexId "default" ;
     text:directory <file:Lucene> ;
     text:shapes ( :MiningReportShape :BoreholeShape :SiteShape ) ;
     text:storeValues true ;

--- a/demo/test/data/mining.ttl
+++ b/demo/test/data/mining.ttl
@@ -118,8 +118,8 @@ ex:site-ok-tedi a ex:Site ;
 
 ## --- Boreholes ---
 ## The schema:identifier records model the qualified-value pattern behind issue #39.
-## This file intentionally mixes blank-node child records and named child resources;
-## the nested indexer treats both forms the same.
+## Each borehole carries three correlated blank-node identifier records:
+## company, anumber, and mnumber.
 
 ex:bh-mia-001 a ex:Borehole ;
     rdfs:label "MIA-DDH-001 Mount Isa Diamond Drill Hole" ;
@@ -129,8 +129,9 @@ ex:bh-mia-001 a ex:Borehole ;
     ex:state state:QLD ;
     ex:depth 450 ;
     schema:identifier
-        [ schema:propertyID "Company" ; schema:value "Glencore" ],
-        [ schema:propertyID "HoleNumber" ; schema:value "MIA-DDH-001" ] ;
+        [ schema:propertyID "company" ; schema:value "Glencore" ],
+        [ schema:propertyID "anumber" ; schema:value "A-9412" ],
+        [ schema:propertyID "mnumber" ; schema:value "MIA-DDH-001" ] ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT(-20.74 139.50)"^^geo:wktLiteral .
 
 ex:bh-mia-002 a ex:Borehole ;
@@ -140,7 +141,10 @@ ex:bh-mia-002 a ex:Borehole ;
     ex:commodity commodity:Lead, commodity:Zinc ;
     ex:state state:QLD ;
     ex:depth 320 ;
-    schema:identifier ex:bh-mia-002-company-id, ex:bh-mia-002-hole-id .
+    schema:identifier
+        [ schema:propertyID "company" ; schema:value "Glencore" ],
+        [ schema:propertyID "anumber" ; schema:value "A-9413" ],
+        [ schema:propertyID "mnumber" ; schema:value "MIA-DDH-002" ] .
 
 ex:bh-od-001 a ex:Borehole ;
     rdfs:label "OD-RC-001 Olympic Dam Reverse Circulation Hole" ;
@@ -149,7 +153,10 @@ ex:bh-od-001 a ex:Borehole ;
     ex:commodity commodity:Copper, commodity:Uranium ;
     ex:state state:SA ;
     ex:depth 280 ;
-    schema:identifier ex:bh-od-001-company-id, ex:bh-od-001-hole-id .
+    schema:identifier
+        [ schema:propertyID "company" ; schema:value "BHP" ],
+        [ schema:propertyID "anumber" ; schema:value "A-1208" ],
+        [ schema:propertyID "mnumber" ; schema:value "OD-RC-001" ] .
 
 ex:bh-bod-001 a ex:Borehole ;
     rdfs:label "BOD-DDH-001 Boddington Deep Diamond Hole" ;
@@ -158,7 +165,10 @@ ex:bh-bod-001 a ex:Borehole ;
     ex:commodity commodity:Gold ;
     ex:state state:WA ;
     ex:depth 600 ;
-    schema:identifier ex:bh-bod-001-company-id, ex:bh-bod-001-hole-id ;
+    schema:identifier
+        [ schema:propertyID "company" ; schema:value "Newmont" ],
+        [ schema:propertyID "anumber" ; schema:value "A-3301" ],
+        [ schema:propertyID "mnumber" ; schema:value "BOD-DDH-001" ] ;
     geo:asWKT "POINT(116.36 -32.78)"^^geo:wktLiteral .
 
 ex:bh-bh-001 a ex:Borehole ;
@@ -168,7 +178,10 @@ ex:bh-bh-001 a ex:Borehole ;
     ex:commodity commodity:Lead, commodity:Silver ;
     ex:state state:NSW ;
     ex:depth 210 ;
-    schema:identifier ex:bh-bh-001-company-id, ex:bh-bh-001-hole-id .
+    schema:identifier
+        [ schema:propertyID "company" ; schema:value "Legacy Co" ],
+        [ schema:propertyID "anumber" ; schema:value "A-4402" ],
+        [ schema:propertyID "mnumber" ; schema:value "BHM-DDH-001" ] .
 
 ex:bh-cad-001 a ex:Borehole ;
     rdfs:label "CAD-DDH-001 Cadia Deep Exploration Hole" ;
@@ -177,7 +190,10 @@ ex:bh-cad-001 a ex:Borehole ;
     ex:commodity commodity:Gold, commodity:Copper ;
     ex:state state:NSW ;
     ex:depth 850 ;
-    schema:identifier ex:bh-cad-001-company-id, ex:bh-cad-001-hole-id .
+    schema:identifier
+        [ schema:propertyID "company" ; schema:value "Newcrest" ],
+        [ schema:propertyID "anumber" ; schema:value "A-5507" ],
+        [ schema:propertyID "mnumber" ; schema:value "CAD-DDH-001" ] .
 
 ex:bh-pil-001 a ex:Borehole ;
     rdfs:label "PIL-RC-001 Pilbara Iron Ore Reverse Circulation" ;
@@ -186,21 +202,11 @@ ex:bh-pil-001 a ex:Borehole ;
     ex:commodity commodity:Iron-Ore ;
     ex:state state:WA ;
     ex:depth 150 ;
-    schema:identifier ex:bh-pil-001-company-id, ex:bh-pil-001-hole-id ;
+    schema:identifier
+        [ schema:propertyID "company" ; schema:value "Rio Tinto" ],
+        [ schema:propertyID "anumber" ; schema:value "A-6609" ],
+        [ schema:propertyID "mnumber" ; schema:value "PIL-RC-001" ] ;
     geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT(-22.35 118.60)"^^geo:wktLiteral .
-
-ex:bh-mia-002-company-id schema:propertyID "Company" ; schema:value "Glencore" .
-ex:bh-mia-002-hole-id    schema:propertyID "HoleNumber" ; schema:value "MIA-DDH-002" .
-ex:bh-od-001-company-id  schema:propertyID "Company" ; schema:value "BHP" .
-ex:bh-od-001-hole-id     schema:propertyID "HoleNumber" ; schema:value "OD-RC-001" .
-ex:bh-bod-001-company-id schema:propertyID "Company" ; schema:value "Newmont" .
-ex:bh-bod-001-hole-id    schema:propertyID "HoleNumber" ; schema:value "BOD-DDH-001" .
-ex:bh-bh-001-company-id  schema:propertyID "Company" ; schema:value "Legacy Co" .
-ex:bh-bh-001-hole-id     schema:propertyID "HoleNumber" ; schema:value "BHM-DDH-001" .
-ex:bh-cad-001-company-id schema:propertyID "Company" ; schema:value "Newcrest" .
-ex:bh-cad-001-hole-id    schema:propertyID "HoleNumber" ; schema:value "CAD-DDH-001" .
-ex:bh-pil-001-company-id schema:propertyID "Company" ; schema:value "Rio Tinto" .
-ex:bh-pil-001-hole-id    schema:propertyID "HoleNumber" ; schema:value "PIL-RC-001" .
 
 ## --- Authors ---
 ## Authors are separate entities linked to reports via ex:authoredBy (on reports)

--- a/demo/test/queries/01-basic-search.rq
+++ b/demo/test/queries/01-basic-search.rq
@@ -7,6 +7,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" "default" "copper" "null" "null" 10)
+    (?hit ?entity ?score) luc:query ("default" "default" "copper" "" "" 10)
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/01-basic-search.rq
+++ b/demo/test/queries/01-basic-search.rq
@@ -7,6 +7,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" "copper")
+    (?hit ?entity ?score) luc:query ("default" "default" "copper" "null" "null" 10)
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/02-filtered-search.rq
+++ b/demo/test/queries/02-filtered-search.rq
@@ -7,6 +7,13 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" "copper" '{"op":"=","args":[{"property":"state"},"QLD"]}')
+    (?hit ?entity ?score) luc:query (
+        "default"
+        "default"
+        "copper"
+        '{"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/QLD"]}'
+        "null"
+        10
+    )
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/02-filtered-search.rq
+++ b/demo/test/queries/02-filtered-search.rq
@@ -12,7 +12,7 @@ WHERE {
         "default"
         "copper"
         '{"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/QLD"]}'
-        "null"
+        ""
         10
     )
 }

--- a/demo/test/queries/03-facet-counts.rq
+++ b/demo/test/queries/03-facet-counts.rq
@@ -12,7 +12,7 @@ WHERE {
         "default"
         "copper"
         '["urn:jena:lucene:field#commodity", "urn:jena:lucene:field#state", "urn:jena:lucene:field#operator"]'
-        "null"
+        ""
         10
         0
     )

--- a/demo/test/queries/03-facet-counts.rq
+++ b/demo/test/queries/03-facet-counts.rq
@@ -7,6 +7,14 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "copper" '["commodity", "state", "operator"]' 10)
+    (?field ?value ?low ?high ?count) luc:facet (
+        "default"
+        "default"
+        "copper"
+        '["urn:jena:lucene:field#commodity", "urn:jena:lucene:field#state", "urn:jena:lucene:field#operator"]'
+        "null"
+        10
+        0
+    )
 }
 ORDER BY ?field DESC(?count)

--- a/demo/test/queries/04-facet-filtered.rq
+++ b/demo/test/queries/04-facet-filtered.rq
@@ -9,10 +9,12 @@ SELECT ?field ?value ?low ?high ?count
 WHERE {
     (?field ?value ?low ?high ?count) luc:facet (
         "default"
+        "default"
         "gold"
-        '["operator", "commodity"]'
-        '{"op":"=","args":[{"property":"state"},"WA"]}'
+        '["urn:jena:lucene:field#operator", "urn:jena:lucene:field#commodity"]'
+        '{"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/WA"]}'
         10
+        0
     )
 }
 ORDER BY ?field DESC(?count)

--- a/demo/test/queries/05-combined.rq
+++ b/demo/test/queries/05-combined.rq
@@ -8,7 +8,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score) luc:query ("default" "default" "iron ore" "null" "null" 10) }
+    { (?hit ?entity ?score) luc:query ("default" "default" "iron ore" "" "" 10) }
     UNION
-    { (?field ?value ?low ?high ?count) luc:facet ("default" "default" "iron ore" '["urn:jena:lucene:field#state", "urn:jena:lucene:field#status"]' "null" 10 0) }
+    { (?field ?value ?low ?high ?count) luc:facet ("default" "default" "iron ore" '["urn:jena:lucene:field#state", "urn:jena:lucene:field#status"]' "" 10 0) }
 }

--- a/demo/test/queries/05-combined.rq
+++ b/demo/test/queries/05-combined.rq
@@ -8,7 +8,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score) luc:query ("default" "iron ore") }
+    { (?hit ?entity ?score) luc:query ("default" "default" "iron ore" "null" "null" 10) }
     UNION
-    { (?field ?value ?low ?high ?count) luc:facet ("default" "iron ore" '["state", "status"]' 10) }
+    { (?field ?value ?low ?high ?count) luc:facet ("default" "default" "iron ore" '["urn:jena:lucene:field#state", "urn:jena:lucene:field#status"]' "null" 10 0) }
 }

--- a/demo/test/queries/06-sequence-path-facet.rq
+++ b/demo/test/queries/06-sequence-path-facet.rq
@@ -9,6 +9,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "*" '["authorName", "state"]' 10)
+    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#authorName", "urn:jena:lucene:field#state"]' "null" 10 0)
 }
 ORDER BY ?field DESC(?count)

--- a/demo/test/queries/06-sequence-path-facet.rq
+++ b/demo/test/queries/06-sequence-path-facet.rq
@@ -9,6 +9,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#authorName", "urn:jena:lucene:field#state"]' "null" 10 0)
+    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#authorName", "urn:jena:lucene:field#state"]' "" 10 0)
 }
 ORDER BY ?field DESC(?count)

--- a/demo/test/queries/07-filter-by-author.rq
+++ b/demo/test/queries/07-filter-by-author.rq
@@ -8,7 +8,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?entity ?score ?label
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" "default" "*" '{"op":"=","args":[{"property":"urn:jena:lucene:field#authorName"},"Dr Sarah Jones"]}' "null" 10) .
+    (?hit ?entity ?score) luc:query ("default" "default" "*" '{"op":"=","args":[{"property":"urn:jena:lucene:field#authorName"},"Dr Sarah Jones"]}' "" 10) .
     ?entity rdfs:label ?label .
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/07-filter-by-author.rq
+++ b/demo/test/queries/07-filter-by-author.rq
@@ -8,7 +8,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?entity ?score ?label
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" "*" '{"op":"=","args":[{"property":"authorName"},"Dr Sarah Jones"]}') .
+    (?hit ?entity ?score) luc:query ("default" "default" "*" '{"op":"=","args":[{"property":"urn:jena:lucene:field#authorName"},"Dr Sarah Jones"]}' "null" 10) .
     ?entity rdfs:label ?label .
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/08-spatial-bbox.rq
+++ b/demo/test/queries/08-spatial-bbox.rq
@@ -5,6 +5,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 SELECT ?entity ?score WHERE {
   (?hit ?entity ?score) luc:query ("default" "default" "*"
     '{"op":"s_intersects","args":[{"property":"urn:jena:lucene:field#location"},{"bbox":[112,-44,154,-10]}]}'
-    "null"
+    ""
     20)
 }

--- a/demo/test/queries/08-spatial-bbox.rq
+++ b/demo/test/queries/08-spatial-bbox.rq
@@ -3,7 +3,8 @@
 # bbox = [swLon, swLat, neLon, neLat] = [112, -44, 154, -10]
 PREFIX luc: <urn:jena:lucene:index#>
 SELECT ?entity ?score WHERE {
-  (?hit ?entity ?score) luc:query ("default" "*"
-    '{"op":"s_intersects","args":[{"property":"location"},{"bbox":[112,-44,154,-10]}]}'
+  (?hit ?entity ?score) luc:query ("default" "default" "*"
+    '{"op":"s_intersects","args":[{"property":"urn:jena:lucene:field#location"},{"bbox":[112,-44,154,-10]}]}'
+    "null"
     20)
 }

--- a/demo/test/queries/09-matchraw-multivalue.rq
+++ b/demo/test/queries/09-matchraw-multivalue.rq
@@ -1,14 +1,15 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
-# Demonstrates luc:query raw-value binding for a multi-valued identifier field.
+# Demonstrates luc:match value binding for a multi-valued identifier field.
 # The demo entity has identifiers "", "94130", and "DAG2011/00113216".
-# ?matchRaw should be bound to "94130" rather than the empty stored value.
+# ?matchRaw comes from luc:match rather than luc:query.
 
 PREFIX luc: <urn:jena:lucene:index#>
 PREFIX ex:  <http://example.org/mining/>
 
 SELECT ?entity ?score ?matchRaw ?identifier
 WHERE {
-    (?hit ?entity ?score ?matchRaw) luc:query ('["urn:jena:lucene:field#identifier"]' "94130" 10) .
+    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#identifier"]' "94130" "null" "null" 10) .
+    (?hit ?field ?matchRaw) luc:match () .
     ?entity ex:identifier ?identifier .
 }
 ORDER BY ?identifier

--- a/demo/test/queries/09-matchraw-multivalue.rq
+++ b/demo/test/queries/09-matchraw-multivalue.rq
@@ -8,7 +8,7 @@ PREFIX ex:  <http://example.org/mining/>
 
 SELECT ?entity ?score ?matchRaw ?identifier
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#identifier"]' "94130" "null" "null" 10) .
+    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#identifier"]' "94130" "" "" 10) .
     (?hit ?field ?matchRaw) luc:match () .
     ?entity ex:identifier ?identifier .
 }

--- a/demo/test/queries/10-match-field-details.rq
+++ b/demo/test/queries/10-match-field-details.rq
@@ -8,7 +8,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?entity ?score ?field ?value
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
     (?hit ?field ?value) luc:match () .
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/10-match-field-details.rq
+++ b/demo/test/queries/10-match-field-details.rq
@@ -8,7 +8,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?entity ?score ?field ?value
 WHERE {
-    (?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#label"]' "copper") .
+    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
     (?hit ?field ?value) luc:match () .
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/11-hierarchical-facets.rq
+++ b/demo/test/queries/11-hierarchical-facets.rq
@@ -6,6 +6,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "*" '["state_commodity"]' 10)
+    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#state"]' "null" 10 0)
 }
 ORDER BY ?field DESC(?count)

--- a/demo/test/queries/11-hierarchical-facets.rq
+++ b/demo/test/queries/11-hierarchical-facets.rq
@@ -6,6 +6,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#state"]' "null" 10 0)
+    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#state"]' "" 10 0)
 }
 ORDER BY ?field DESC(?count)

--- a/demo/test/queries/12-range-facets.rq
+++ b/demo/test/queries/12-range-facets.rq
@@ -1,7 +1,6 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-PREFIX luc: <http://jena.apache.org/text#>
-PREFIX field: <urn:jena:lucene:field#>
+PREFIX luc: <urn:jena:lucene:index#>
 
 # Range faceting for numeric fields (INT, LONG, DOUBLE)
 # Requires 5-slot subject form: (?field ?value ?low ?high ?count)
@@ -12,7 +11,14 @@ PREFIX field: <urn:jena:lucene:field#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-  (?s ?score) luc:query "*" .
-  (?field ?value ?low ?high ?count) luc:facet '{"facetFields":[{"field":"urn:jena:lucene:field#year","ranges":[null, 2000, 2020, null]}, {"field":"urn:jena:lucene:field#depth","ranges":[0, 200, 500, 1000]}]}' .
+  (?field ?value ?low ?high ?count) luc:facet (
+    "default"
+    "default"
+    "*"
+    '[{"field":"urn:jena:lucene:field#year","ranges":[null, 2000, 2020, null]}, {"field":"urn:jena:lucene:field#depth","ranges":[0, 200, 500, 1000]}]'
+    "null"
+    20
+    0
+  ) .
 }
 ORDER BY ?field ?low

--- a/demo/test/queries/12-range-facets.rq
+++ b/demo/test/queries/12-range-facets.rq
@@ -16,7 +16,7 @@ WHERE {
     "default"
     "*"
     '[{"field":"urn:jena:lucene:field#year","ranges":[null, 2000, 2020, null]}, {"field":"urn:jena:lucene:field#depth","ranges":[0, 200, 500, 1000]}]'
-    "null"
+    ""
     20
     0
   ) .

--- a/demo/test/queries/13-mixed-facets.rq
+++ b/demo/test/queries/13-mixed-facets.rq
@@ -4,7 +4,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 # Mixed flat and range facets in one query.
 # The 5-slot form (?field ?value ?low ?high ?count) is REQUIRED for range facets,
-# and works for flat facets too (where ?low and ?high will be null).
+# and works for flat facets too (where ?low and ?high will be unbound).
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
@@ -13,7 +13,7 @@ WHERE {
     "default"
     "copper"
     '["urn:jena:lucene:field#state", {"field":"urn:jena:lucene:field#year","ranges":[null, 2020, 2024, null]}]'
-    "null"
+    ""
     20
     0
   ) .

--- a/demo/test/queries/13-mixed-facets.rq
+++ b/demo/test/queries/13-mixed-facets.rq
@@ -1,7 +1,6 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-PREFIX luc: <http://jena.apache.org/text#>
-PREFIX field: <urn:jena:lucene:field#>
+PREFIX luc: <urn:jena:lucene:index#>
 
 # Mixed flat and range facets in one query.
 # The 5-slot form (?field ?value ?low ?high ?count) is REQUIRED for range facets,
@@ -9,7 +8,14 @@ PREFIX field: <urn:jena:lucene:field#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-  (?s ?score) luc:query "copper" .
-  (?field ?value ?low ?high ?count) luc:facet '{"facetFields":["urn:jena:lucene:field#state", {"field":"urn:jena:lucene:field#year","ranges":[null, 2020, 2024, null]}]}' .
+  (?field ?value ?low ?high ?count) luc:facet (
+    "default"
+    "default"
+    "copper"
+    '["urn:jena:lucene:field#state", {"field":"urn:jena:lucene:field#year","ranges":[null, 2020, 2024, null]}]'
+    "null"
+    20
+    0
+  ) .
 }
 ORDER BY ?field ?low ?value

--- a/demo/test/queries/14-nested-identifier-hierarchy.rq
+++ b/demo/test/queries/14-nested-identifier-hierarchy.rq
@@ -5,6 +5,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "*" '["identifierType_identifierValueExact"]' 20)
+    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#identifierType"]' "null" 20 0)
 }
 ORDER BY ?field DESC(?count) ?value

--- a/demo/test/queries/14-nested-identifier-hierarchy.rq
+++ b/demo/test/queries/14-nested-identifier-hierarchy.rq
@@ -5,6 +5,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?field ?value ?low ?high ?count
 WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#identifierType"]' "null" 20 0)
+    (?field ?value ?low ?high ?count) luc:facet ("default" "default" "*" '["urn:jena:lucene:field#identifierType"]' "" 20 0)
 }
 ORDER BY ?field DESC(?count) ?value

--- a/demo/test/queries/15-nested-identifier-prefix-search.rq
+++ b/demo/test/queries/15-nested-identifier-prefix-search.rq
@@ -5,6 +5,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?s ?score
 WHERE {
-    (?hit ?s ?score) luc:query ("default" '["urn:jena:lucene:field#identifierValueText"]' "bod" "null" "null" 10)
+    (?hit ?s ?score) luc:query ("default" '["urn:jena:lucene:field#identifierValueText"]' "bod" "" "" 10)
 }
 ORDER BY DESC(?score) ?s

--- a/demo/test/queries/15-nested-identifier-prefix-search.rq
+++ b/demo/test/queries/15-nested-identifier-prefix-search.rq
@@ -3,8 +3,8 @@
 
 PREFIX luc: <urn:jena:lucene:index#>
 
-SELECT ?s ?score ?lit
+SELECT ?s ?score
 WHERE {
-    (?hit ?s ?score ?lit) luc:query ('["urn:jena:lucene:field#identifierValueText"]' "bod" 10)
+    (?hit ?s ?score) luc:query ("default" '["urn:jena:lucene:field#identifierValueText"]' "bod" "null" "null" 10)
 }
 ORDER BY DESC(?score) ?s

--- a/demo/test/queries/16-sort-by-year-desc.rq
+++ b/demo/test/queries/16-sort-by-year-desc.rq
@@ -1,0 +1,19 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Sort mining reports by year descending using field-IRI sort syntax.
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/mining/>
+
+SELECT ?entity ?score ?year
+WHERE {
+    (?hit ?entity ?score) luc:query (
+        "default"
+        "default"
+        "*"
+        '{"op":"=","args":[{"property":"urn:jena:lucene:field#entityType"},"http://example.org/mining/MiningReport"]}'
+        '{"field":"urn:jena:lucene:field#year","order":"desc"}'
+        10
+    ) .
+    ?entity ex:year ?year .
+}
+

--- a/demo/test/queries/17-sort-boreholes-by-depth-asc.rq
+++ b/demo/test/queries/17-sort-boreholes-by-depth-asc.rq
@@ -1,0 +1,18 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Sort boreholes by depth ascending while still using normal query/facet field IRIs.
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/mining/>
+
+SELECT ?entity ?score ?depth
+WHERE {
+    (?hit ?entity ?score) luc:query (
+        "default"
+        "default"
+        "*"
+        '{"op":"=","args":[{"property":"urn:jena:lucene:field#entityType"},"http://example.org/mining/Borehole"]}'
+        '{"field":"urn:jena:lucene:field#depth","order":"asc"}'
+        10
+    ) .
+    ?entity ex:depth ?depth .
+}

--- a/demo/test/queries/18-nested-identifier-company-drilldown.rq
+++ b/demo/test/queries/18-nested-identifier-company-drilldown.rq
@@ -1,0 +1,18 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Nested identifier hierarchy drill-down under identifierType = company.
+
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?field ?value ?low ?high ?count
+WHERE {
+    (?field ?value ?low ?high ?count) luc:facet (
+        "default"
+        "default"
+        "*"
+        '["urn:jena:lucene:field#identifierValueExact"]'
+        '{"op":"=","args":[{"property":"urn:jena:lucene:field#identifierType"},"company"]}'
+        20
+        0
+    )
+}
+ORDER BY ?field DESC(?count) ?value

--- a/demo/test/queries/19-nested-identifier-exact-pair.rq
+++ b/demo/test/queries/19-nested-identifier-exact-pair.rq
@@ -1,0 +1,17 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Correlated exact filter on nested identifier type/value fields.
+
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?s ?score
+WHERE {
+    (?hit ?s ?score) luc:query (
+        "default"
+        "default"
+        "*"
+        '{"op":"and","args":[{"op":"=","args":[{"property":"urn:jena:lucene:field#identifierType"},"company"]},{"op":"=","args":[{"property":"urn:jena:lucene:field#identifierValueExact"},"Newmont"]}]}'
+        ""
+        10
+    )
+}
+ORDER BY DESC(?score) ?s

--- a/demo/test/tests.json
+++ b/demo/test/tests.json
@@ -26,6 +26,11 @@
   { "label": "\"gold\" reports only", "params": "?q=gold&filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/MiningReport\"]}", "minResults": 1 },
   { "label": "\"exploration\" in WA", "params": "?q=exploration&filter={\"op\":\"=\",\"args\":[{\"property\":\"state\"},\"http://example.org/mining/state/WA\"]}", "minResults": 1 },
 
+  { "group": "Sorting" },
+  { "label": "Reports sorted by year desc", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/MiningReport\"]}&sort=year:desc", "minResults": 5 },
+  { "label": "Boreholes sorted by depth asc", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Borehole\"]}&sort=depth:asc", "minResults": 5 },
+  { "label": "\"copper\" sorted by year asc", "params": "?q=copper&sort=year:asc", "minResults": 3 },
+
   { "group": "Entity Types" },
   { "label": "Sites only", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Site\"]}", "minResults": 5 },
   { "label": "Boreholes only", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Borehole\"]}", "minResults": 5 },

--- a/demo/test/tests.json
+++ b/demo/test/tests.json
@@ -43,6 +43,13 @@
   { "group": "Identifier Search" },
   { "label": "Identifier: 94130 (multi-valued demo record)", "params": "?id=94130", "minResults": 1 },
 
+  { "group": "Nested Identifier Hierarchy" },
+  { "label": "Boreholes only (identifier drill-down visible)", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Borehole\"]}", "minResults": 5, "scrollToText": "identifiers" },
+  { "label": "Drill-down: company identifiers", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Borehole\"]}&drillDown=identifierType_identifierValueExact:company", "minResults": 5, "scrollToText": "identifiers" },
+  { "label": "Drill-down: anumber identifiers", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Borehole\"]}&drillDown=identifierType_identifierValueExact:anumber", "minResults": 5, "scrollToText": "identifiers" },
+  { "label": "Drill-down: mnumber identifiers", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Borehole\"]}&drillDown=identifierType_identifierValueExact:mnumber", "minResults": 5, "scrollToText": "identifiers" },
+  { "label": "Exact pair: company = Newmont", "params": "?filter={\"op\":\"and\",\"args\":[{\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Borehole\"]},{\"op\":\"=\",\"args\":[{\"property\":\"identifierType\"},\"company\"]},{\"op\":\"=\",\"args\":[{\"property\":\"identifierValueExact\"},\"Newmont\"]}]}", "minResults": 1, "scrollToText": "identifiers" },
+
   { "group": "Spatial: Bbox Filter" },
   { "label": "Australia bbox (all spatial)", "params": "?filter={\"op\":\"s_intersects\",\"args\":[{\"property\":\"urn:jena:lucene:field#location\"},{\"bbox\":[112,-44,154,-10]}]}", "minResults": 10 },
   { "label": "Queensland bbox", "params": "?filter={\"op\":\"s_intersects\",\"args\":[{\"property\":\"urn:jena:lucene:field#location\"},{\"bbox\":[138,-29,154,-10]}]}", "minResults": 5 },

--- a/docs/01-user-guide.md
+++ b/docs/01-user-guide.md
@@ -64,7 +64,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" "default" "machine learning" "null" "null" 20) .
+    luc:query ("default" "default" "machine learning" "" "" 20) .
 }
 ORDER BY DESC(?score)
 ```
@@ -94,7 +94,7 @@ Example with filter:
     "default"
     "learning"
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
-    "null"
+    ""
     20
   ) .
 ```
@@ -107,7 +107,7 @@ Example with sort:
     "default"
     "default"
     "learning"
-    "null"
+    ""
     '{"field":"urn:jena:lucene:field#year","order":"desc"}'
     10
   ) .
@@ -116,8 +116,8 @@ Example with sort:
 Notes:
 
 - `fieldSpec` is `"default"` or a JSON array of field IRIs.
-- `cqlFilter` is a JSON object or `"null"`.
-- `sortSpec` is a JSON object/array or `"null"`.
+- `cqlFilter` is a JSON object or `""`.
+- `sortSpec` is a JSON object/array or `""`.
 - `?match` is not part of `luc:query`.
 
 ### Graph Scoping
@@ -137,7 +137,7 @@ Example target filter:
     "default"
     "*"
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#sourceGraph"},"http://example.org/graph/A"]}'
-    "null"
+    ""
     20
   ) .
 ```
@@ -159,7 +159,7 @@ Use it when you need to know which field matched:
 ```sparql
 SELECT ?entity ?field ?value WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
   (?hit ?field ?value) luc:match () .
 }
 ```
@@ -171,6 +171,8 @@ SELECT ?entity ?field ?value WHERE {
   luc:facet (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)
 ```
 
+Flat facets use the same 5-slot subject form. On flat facet rows, `?value` is bound and `?low` / `?high` are left unbound.
+
 Example:
 
 ```sparql
@@ -180,7 +182,7 @@ Example:
     "default"
     "learning"
     '["urn:jena:lucene:field#category"]'
-    "null"
+    ""
     10
     0
   ) .
@@ -195,7 +197,7 @@ Range facets:
     "default"
     "*"
     '[{"field":"urn:jena:lucene:field#year","ranges":[null,2000,2010,2020,null]}]'
-    "null"
+    ""
     20
     0
   ) .
@@ -222,7 +224,7 @@ The SHACL API is strict:
 - no argument-shape guessing
 - missing arguments fail fast
 
-Use `"null"` placeholders when a slot is intentionally unused.
+Use `""` placeholders when a slot is intentionally unused.
 
 ## Multiple Indexes
 
@@ -230,7 +232,7 @@ If you configure multiple indexes, use different `text:indexId` values and selec
 
 ```sparql
 (?hit ?entity ?score)
-  luc:query ("objects" "default" "gold" "null" "null" 20) .
+  luc:query ("objects" "default" "gold" "" "" 20) .
 ```
 
 The selector may also be the index resource IRI if the index was configured as a URI resource.

--- a/docs/01-user-guide.md
+++ b/docs/01-user-guide.md
@@ -1,403 +1,39 @@
-# User Guide: Faceted Search in Jena Text
+# User Guide
 
-## Overview
+This guide covers SHACL-mode text indexing and search.
 
-The `jena-text` module provides full-text search over RDF data using Apache Lucene. This fork adds **entity-per-document indexing with native faceted search** — the ability to get categorised counts alongside text search results, the same pattern used by e-commerce sites, library catalogues, and data portals.
+## Mental Model
 
-SHACL shapes define entity types with typed fields. Each entity matching a shape's `sh:targetClass` gets one Lucene document containing all its fields. Search uses `luc:query` (with CQL2-JSON filters) and `luc:facet` (for facet counts).
+Each entity matching a configured `sh:targetClass` becomes one Lucene document with typed fields.
 
-> **Note:** The upstream Jena `text:query` / `text:entityMap` (classic mode) is unchanged and still available. This documentation covers only the SHACL mode added by this fork.
+The main SHACL property functions are:
 
----
+- `luc:query` for hit search
+- `luc:match` for per-hit field/value details
+- `luc:facet` for aggregate counts
 
-## Getting Started
+## Quick Start
 
-### 1. Define your index configuration
+### 1. Configure a dataset
 
 ```turtle
-@prefix text:  <http://jena.apache.org/text#> .
-@prefix idx:   <urn:jena:lucene:index#> .
+@prefix text: <http://jena.apache.org/text#> .
+@prefix tdb2: <http://jena.apache.org/2016/tdb#> .
+
+<#ds> a text:TextDataset ;
+    text:dataset <#baseDs> ;
+    text:indexes <#index> .
+
+<#baseDs> a tdb2:DatasetTDB2 ;
+    tdb2:location "/path/to/tdb2" .
+```
+
+### 2. Define fields
+
+```turtle
+@prefix idx: <urn:jena:lucene:index#> .
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
 @prefix field: <urn:jena:lucene:field#> .
-@prefix sh:    <http://www.w3.org/ns/shacl#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix ex:    <http://example.org/> .
-
-<#index> a text:TextIndexLucene ;
-    text:directory "mem" ;
-    text:shapes ( <#BookShape> ) ;
-    text:storeValues true ;
-    .
-
-## Named field resources — their IRIs identify fields in SPARQL queries
-field:title
-    idx:fieldName "title" ;
-    idx:fieldType idx:TextField ;
-    idx:defaultSearch true ;
-    sh:path rdfs:label .
-
-field:category
-    idx:fieldName "category" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    idx:multiValued true ;
-    sh:path ex:category .
-
-field:author
-    idx:fieldName "author" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:author .
-
-field:authorName
-    idx:fieldName "authorName" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ( ex:writtenBy ex:name ) .  ## sequence path — indexes author name on the book
-
-field:year
-    idx:fieldName "year" ;
-    idx:fieldType idx:IntField ;
-    idx:facetable true ;
-    idx:sortable true ;
-    sh:path ex:year .
-
-<#BookShape>
-    sh:targetClass ex:Book ;
-    sh:property field:title ;
-    sh:property field:category ;
-    sh:property field:author ;
-    sh:property field:authorName ;
-    sh:property field:year .
-```
-
-Each field is a **named resource** with a stable, absolute IRI (e.g., `urn:jena:lucene:field#category`). This IRI is used in SPARQL queries to identify fields — in `luc:query` field specs, `luc:facet` facet field arrays, CQL2-JSON filter properties, and sort specs. The `idx:fieldName` property defines the internal Lucene field name and is not used in SPARQL.
-
-Fields defined as blank nodes get auto-generated IRIs (`urn:jena:lucene:field#{fieldName}`). Named resources are recommended — they enable field reuse across multiple shapes and support sequence/inverse paths for cross-entity indexing without forward chaining (see [Configuration Reference](03-configuration.md)).
-
-### 2. Load data
-
-Data is indexed automatically when triples are added to a text-indexed dataset:
-
-```sparql
-PREFIX ex: <http://example.org/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-
-INSERT DATA {
-    ex:book1 a ex:Book ;
-        rdfs:label "Introduction to Machine Learning" ;
-        ex:category "Technology" ;
-        ex:author "Smith" ;
-        ex:year 2024 .
-
-    ex:book2 a ex:Book ;
-        rdfs:label "Quantum Physics Basics" ;
-        ex:category "Science" ;
-        ex:author "Wilson" ;
-        ex:year 2023 .
-}
-```
-
-### 3. Search
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?s ?score WHERE {
-    (?hit ?s ?score) luc:query ("machine learning") .
-}
-```
-
-### 4. Get facet counts
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?field ?value ?count WHERE {
-    (?field ?value ?count) luc:facet ("default" "machine learning"
-        '["urn:jena:lucene:field#category", "urn:jena:lucene:field#author"]' 10) .
-}
-```
-
-Returns rows like:
-
-| ?field | ?value | ?count |
-|--------|--------|--------|
-| `<urn:jena:lucene:field#category>` | `"Technology"` | 3 |
-| `<urn:jena:lucene:field#category>` | `"Science"` | 1 |
-| `<urn:jena:lucene:field#author>` | `"Smith"` | 2 |
-| `<urn:jena:lucene:field#author>` | `"Jones"` | 1 |
-
-`?field` returns the field IRI (the named resource from config). For flat and hierarchical facets, `?value` returns the stored keyword value. Values that look like URIs are returned as IRIs; otherwise they are returned as string literals.
-
-The `facetFields` array requires field IRIs — the full IRI of each field resource as defined in the configuration.
-
-### 5. Range facets on numeric fields
-
-For numeric fields (INT, LONG, DOUBLE), set `idx:facetable true` on the field and use range objects in the facet fields array to get bucketed counts.
-
-Range-capable facet requests use the 5-slot subject form:
-
-```sparql
-(?field ?value ?low ?high ?count) luc:facet (...)
-```
-
-The legacy 3-slot form remains valid for flat and hierarchical facets only.
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?field ?value ?low ?high ?count WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "machine learning"
-        '[{"field":"urn:jena:lucene:field#year", "ranges":[2020, 2022, 2024, 2026]}]'
-        10) .
-}
-```
-
-Returns rows like:
-
-| ?field | ?value | ?low | ?high | ?count |
-|--------|--------|------|-------|--------|
-| `<urn:jena:lucene:field#year>` | — | `2020` | `2022` | 1 |
-| `<urn:jena:lucene:field#year>` | — | `2022` | `2024` | 1 |
-
-`?low` and `?high` are typed numeric literals matching the field type. Boundaries define contiguous `[low, high)` buckets. Use `null` for open-ended ranges: `[null, 2020, 2024, null]` produces `(-∞, 2020)`, `[2020, 2024)`, `[2024, +∞)`, with the missing bound left unbound.
-
-Mix flat and range facets in a single call by using the same 5-slot form. Flat rows bind `?value`; range rows bind `?low`/`?high`.
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?field ?value ?low ?high ?count WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ("default" "machine learning"
-        '["urn:jena:lucene:field#category", {"field":"urn:jena:lucene:field#year", "ranges":[2020, 2022, 2024, 2026]}]'
-        10) .
-}
-```
-
-### 6. Search with facet filtering
-Filters use CQL2-JSON syntax. The `property` value must be a field IRI:
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-# Only return results where category is "Technology"
-SELECT ?s ?score WHERE {
-    (?hit ?s ?score) luc:query ("default" "learning"
-        '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
-        20) .
-}
-```
-
-**Facets with filters applied:**
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-# Get author counts, but only for Technology books
-SELECT ?field ?value ?count WHERE {
-    (?field ?value ?count) luc:facet (
-        "default"
-        "learning"
-        '["urn:jena:lucene:field#author"]'
-        '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
-        10
-    ) .
-}
-```
-
-### 7. Get total hit count
-
-Add `?totalHits` as the 4th subject variable to get the total number of matching documents. This is useful for "Showing X of Y results" UI patterns:
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?s ?score ?totalHits WHERE {
-    (?s ?score ?_lit ?totalHits) luc:query ("learning" 10) .
-}
-```
-
-`?totalHits` is the same value on every row — read it from the first result. The count is computed efficiently using `IndexSearcher.count()` and only runs when the variable is present.
-
-### 8. Combine search and facets in one query
-
-When `luc:query` and `luc:facet` appear in the same query with matching parameters, they automatically share execution (one Lucene query, not two):
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?s ?score ?totalHits ?field ?value ?count WHERE {
-    { (?s ?score ?_lit ?totalHits) luc:query ("learning" 10) }
-    UNION
-    { (?field ?value ?count) luc:facet ("learning"
-        '["urn:jena:lucene:field#category"]' 10) }
-}
-```
-
----
-
-## Filter Semantics
-
-Filters use CQL2-JSON syntax. The `property` value is a field IRI.
-
-Single equality:
-
-```json
-{"op": "=", "args": [{"property": "urn:jena:lucene:field#category"}, "Technology"]}
-```
-
-Multiple values (OR within a field):
-
-```json
-{"op": "or", "args": [
-    {"op": "=", "args": [{"property": "urn:jena:lucene:field#category"}, "Technology"]},
-    {"op": "=", "args": [{"property": "urn:jena:lucene:field#category"}, "Science"]}
-]}
-```
-
-Multiple fields (AND across fields):
-
-```json
-{"op": "and", "args": [
-    {"op": "=", "args": [{"property": "urn:jena:lucene:field#category"}, "Technology"]},
-    {"op": "=", "args": [{"property": "urn:jena:lucene:field#author"}, "Smith"]}
-]}
-```
-
-See [SPARQL API Reference](02-sparql-api.md) for the full CQL2-JSON syntax.
-
----
-
-## Hierarchical Facets
-
-Hierarchical facets enable tree-structured drill-down navigation — for example, selecting a state to reveal commodity breakdowns within it.
-
-### Configuration
-
-Add `idx:facetHierarchy` to a shape with an ordered list of field resources (parent → child):
-
-```turtle
-field:state
-    idx:fieldName "state" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:state .
-
-field:commodity
-    idx:fieldName "commodity" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:commodity .
-
-<#SiteShape>
-    sh:targetClass ex:Site ;
-    sh:property field:state ;
-    sh:property field:commodity ;
-    idx:facetHierarchy ( field:state field:commodity ) .
-```
-
-### Workflow
-
-**Step 1: Get top-level facets** — request facets on the parent level field IRI:
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?field ?value ?count WHERE {
-    (?field ?value ?count) luc:facet ("default" "*"
-        '["urn:jena:lucene:field#state"]' 10) .
-}
-```
-
-Returns: `WA: 15`, `QLD: 12`, `NSW: 8`, ...
-
-**Step 2: Drill down** — filter on the parent value and request facets on the child field:
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?field ?value ?count WHERE {
-    (?field ?value ?count) luc:facet ("default" "*"
-        '["urn:jena:lucene:field#commodity"]'
-        '{"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/WA"]}'
-        10) .
-}
-```
-
-Returns: `Gold: 8`, `Iron: 4`, `Copper: 3`, ... (scoped to WA)
-
-The CQL `=` filter on a hierarchy parent field is automatically detected and converted to a Lucene taxonomy drill-down. No special syntax is needed — regular CQL filters "just work" with hierarchies.
-
-See [Configuration — Hierarchical Facets](03-configuration.md#hierarchical-facets) for full configuration details and [SPARQL API — Hierarchy Drill-Down](02-sparql-api.md#hierarchy-drill-down) for more query examples.
-
----
-
-## Key Options
-
-| Option | Where | Effect |
-|--------|-------|--------|
-| `maxValues` | `luc:facet` arg | Max facet values per field. `0` = return all values |
-| `minCount` | `luc:facet` arg | Exclude values with count below this threshold |
-| `text:maxFacetHits` | Assembler config | Limit internal Lucene search for facet collection. `0` = unlimited |
-| `text:storeValues` | Assembler config | Store literal values for retrieval in results |
-
----
-
-## Deploying with Fuseki
-
-### Prerequisites
-
-- Java 21+ (Java 25 recommended)
-- Maven 3.9+
-
-### Build the Fuseki Server
-
-```bash
-cd jena
-
-# Build jena-text and all dependencies first
-mvn clean install -pl jena-text -am -DskipTests
-
-# Build the Fuseki server (uber-jar including jena-text)
-mvn clean install -pl jena-fuseki2/jena-fuseki-server -am -DskipTests
-```
-
-### Create a Fuseki Configuration File
-
-Create `config.ttl` for a SHACL-mode text-indexed dataset:
-
-```turtle
-PREFIX fuseki:  <http://jena.apache.org/fuseki#>
-PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
-PREFIX text:    <http://jena.apache.org/text#>
-PREFIX idx:     <urn:jena:lucene:index#>
-PREFIX field:   <urn:jena:lucene:field#>
-PREFIX sh:      <http://www.w3.org/ns/shacl#>
-PREFIX ex:      <http://example.org/>
-
-[] rdf:type fuseki:Server ;
-   fuseki:services ( <#service> ) .
-
-<#service> rdf:type fuseki:Service ;
-    fuseki:name "ds" ;
-    fuseki:endpoint [ fuseki:operation fuseki:query ] ;
-    fuseki:endpoint [ fuseki:operation fuseki:update ] ;
-    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ] ;
-    fuseki:dataset <#text_dataset> .
-
-<#text_dataset> rdf:type text:TextDataset ;
-    text:dataset <#base_dataset> ;
-    text:index <#index> .
-
-<#base_dataset> rdf:type ja:MemoryDataset .
-
-<#index> rdf:type text:TextIndexLucene ;
-    text:directory "mem" ;
-    text:shapes ( <#BookShape> ) ;
-    text:storeValues true ;
-    .
 
 field:title
     idx:fieldName "title" ;
@@ -410,134 +46,206 @@ field:category
     idx:fieldType idx:KeywordField ;
     idx:facetable true ;
     sh:path ex:category .
+```
 
-field:author
-    idx:fieldName "author" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:author .
+### 3. Define a shape
 
+```turtle
 <#BookShape>
     sh:targetClass ex:Book ;
     sh:property field:title ;
-    sh:property field:category ;
-    sh:property field:author .
+    sh:property field:category .
 ```
 
-### Start the Server
+### 4. Query it
 
-```bash
-java -jar jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-*.jar \
-    --config config.ttl
+```sparql
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?entity ?score WHERE {
+  (?hit ?entity ?score)
+    luc:query ("default" "default" "machine learning" "null" "null" 20) .
+}
+ORDER BY DESC(?score)
 ```
 
-The server starts on `http://localhost:3030/`. Use `--port 3031` for an alternative port.
+## Query Model
 
-### Load Data
+Two selectors exist at query time:
 
-```bash
-curl -X POST "http://localhost:3030/ds" \
-    -H "Content-Type: application/sparql-update" \
-    -d '
-PREFIX ex: <http://example.org/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+- `indexSelector`: which index to use
+- `fieldSpec`: which fields inside that index to search
 
-INSERT DATA {
-    ex:book1 a ex:Book ; rdfs:label "Introduction to Machine Learning" ;
-        ex:category "Technology" ; ex:author "Smith" .
-    ex:book2 a ex:Book ; rdfs:label "Quantum Physics Basics" ;
-        ex:category "Science" ; ex:author "Wilson" .
-    ex:book3 a ex:Book ; rdfs:label "Deep Learning Neural Networks" ;
-        ex:category "Technology" ; ex:author "Jones" .
-}'
+These are separate on purpose.
+
+### `luc:query`
+
+```sparql
+(?hit ?entity ?score ?totalHits)
+  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
 ```
 
-### Test Queries
+Example with filter:
 
-```bash
-# Search
-curl -s -X POST "http://localhost:3030/ds" \
-    -H "Content-Type: application/sparql-query" \
-    -H "Accept: application/json" \
-    -d 'PREFIX luc: <urn:jena:lucene:index#>
-SELECT ?s ?score WHERE {
-  (?hit ?s ?score) luc:query ("learning") .
-} ORDER BY DESC(?score)'
-
-# Facets
-curl -s -X POST "http://localhost:3030/ds" \
-    -H "Content-Type: application/sparql-query" \
-    -H "Accept: application/json" \
-    -d 'PREFIX luc: <urn:jena:lucene:index#>
-SELECT ?f ?v ?c WHERE {
-  (?f ?v ?c) luc:facet ("learning" '\''["urn:jena:lucene:field#category", "urn:jena:lucene:field#author"]'\'' 10)
-} ORDER BY ?f DESC(?c)'
-
-# Search with CQL2-JSON filter
-curl -s -X POST "http://localhost:3030/ds" \
-    -H "Content-Type: application/sparql-query" \
-    -H "Accept: application/json" \
-    -d 'PREFIX luc: <urn:jena:lucene:index#>
-SELECT ?s ?score WHERE {
-  (?hit ?s ?score) luc:query ("default" "learning" '\''{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'\'' 20)
-} ORDER BY DESC(?score)'
+```sparql
+(?hit ?entity ?score ?totalHits)
+  luc:query (
+    "default"
+    "default"
+    "learning"
+    '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
+    "null"
+    20
+  ) .
 ```
 
-**Note:** With unnamed endpoints (as in the config above), all operations go to `/ds`. Do not use `/ds/query` or `/ds/update` — those require named endpoints in the config.
+Example with sort:
 
----
+```sparql
+(?hit ?entity ?score)
+  luc:query (
+    "default"
+    "default"
+    "learning"
+    "null"
+    '{"field":"urn:jena:lucene:field#year","order":"desc"}'
+    10
+  ) .
+```
+
+Notes:
+
+- `fieldSpec` is `"default"` or a JSON array of field IRIs.
+- `cqlFilter` is a JSON object or `"null"`.
+- `sortSpec` is a JSON object/array or `"null"`.
+- `?match` is not part of `luc:query`.
+
+### Graph Scoping
+
+Target model:
+
+- graph scoping is treated as a normal doc-level filter
+- there is no dedicated `?graph` slot in the public SHACL query signature
+- the reserved synthetic field IRI is `urn:jena:lucene:field#sourceGraph`
+
+Example target filter:
+
+```sparql
+(?hit ?entity ?score)
+  luc:query (
+    "default"
+    "default"
+    "*"
+    '{"op":"=","args":[{"property":"urn:jena:lucene:field#sourceGraph"},"http://example.org/graph/A"]}'
+    "null"
+    20
+  ) .
+```
+
+Intended semantics:
+
+- `sourceGraph` is multi-valued
+- it records every graph touched while indexing the entity document
+- strict graph partitioning should still be handled at index time when needed
+
+### `luc:match`
+
+```sparql
+(?hit ?field ?value ?snippet) luc:match ()
+```
+
+Use it when you need to know which field matched:
+
+```sparql
+SELECT ?entity ?field ?value WHERE {
+  (?hit ?entity ?score)
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+  (?hit ?field ?value) luc:match () .
+}
+```
+
+### `luc:facet`
+
+```sparql
+(?field ?value ?low ?high ?count)
+  luc:facet (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)
+```
+
+Example:
+
+```sparql
+(?field ?value ?low ?high ?count)
+  luc:facet (
+    "default"
+    "default"
+    "learning"
+    '["urn:jena:lucene:field#category"]'
+    "null"
+    10
+    0
+  ) .
+```
+
+Range facets:
+
+```sparql
+(?field ?value ?low ?high ?count)
+  luc:facet (
+    "default"
+    "default"
+    "*"
+    '[{"field":"urn:jena:lucene:field#year","ranges":[null,2000,2010,2020,null]}]'
+    "null"
+    20
+    0
+  ) .
+```
+
+## Field Identity
+
+External SPARQL always uses field IRIs:
+
+- query `fieldSpec`
+- facet `facetFields`
+- CQL `property`
+- sort `"field"`
+- returned `?field` bindings from `luc:match` and `luc:facet`
+
+`idx:fieldName` is still important, but only as the internal Lucene field key.
+
+## Fixed Arity
+
+The SHACL API is strict:
+
+- `luc:query` object arity is exactly 6
+- `luc:facet` object arity is exactly 7
+- no argument-shape guessing
+- missing arguments fail fast
+
+Use `"null"` placeholders when a slot is intentionally unused.
+
+## Multiple Indexes
+
+If you configure multiple indexes, use different `text:indexId` values and select one explicitly:
+
+```sparql
+(?hit ?entity ?score)
+  luc:query ("objects" "default" "gold" "null" "null" 20) .
+```
+
+The selector may also be the index resource IRI if the index was configured as a URI resource.
 
 ## Troubleshooting
 
-### Named Graph Data Not Indexed
+Common causes of failures:
 
-If data is loaded into named graphs (e.g. N-Quads), the SHACL indexer reads from a combined view of all graphs (`MultiUnion` of default + named). This works automatically. For SPARQL queries to also see named graph data, add `tdb2:unionDefaultGraph true` to the TDB2 dataset config:
+- Wrong object arity.
+- Using field names instead of field IRIs.
+- Using an index selector that is not registered.
+- Sorting on a non-sortable field.
+- Requesting a field IRI that does not exist in the selected index.
 
-```turtle
-:base_dataset rdf:type tdb2:DatasetTDB ;
-    tdb2:location "DB" ;
-    tdb2:unionDefaultGraph true .
-```
+If a query suddenly stops working after this change, check the first two object arguments first:
 
-### No Search Results
-
-1. **Verify data is loaded:**
-   ```sparql
-   SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }
-   ```
-2. **Check that entities have the correct `rdf:type`** — SHACL mode only indexes entities matching a shape's `sh:targetClass`
-3. **Verify `text:storeValues true`** is set in the assembler config
-
-### No Facet Results
-
-1. **Check that fields have `idx:facetable true`** in the shape definition — this applies to KEYWORD flat/hierarchical facets and numeric range facets
-2. **Verify field IRIs match** — the `luc:facet` JSON array requires field IRIs (the full IRI of each field resource)
-3. **Use the 5-slot subject form for any range facet request** — `(?field ?value ?low ?high ?count) luc:facet (...)`
-4. **Rebuild the index** if faceting or sorting was enabled after data was loaded — facet/sort DocValues are built at write time
-
-### "No Fuseki dispatch" Error
-
-Using `/ds/query` or `/ds/update` with unnamed endpoints will fail. Either:
-- Use `/ds` for all operations (content type determines the operation), or
-- Add named endpoints in the config:
-  ```turtle
-  fuseki:endpoint [
-      fuseki:operation fuseki:query ;
-      fuseki:name "query"    # enables /ds/query
-  ] ;
-  ```
-
-### Common Errors
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| `text:shapes and text:entityMap are mutually exclusive` | Both specified on the same index | Use one or the other |
-| `TextIndexException: no shapes defined` | `text:shapes` list is empty | Add at least one shape resource |
-| No facet data for a field | Field not marked `idx:facetable true`, wrong `luc:facet` subject form for a range request, or index not rebuilt | Check config, query shape, and reindex |
-| Port already in use | Another process on port 3030 | Use `--port 3031` or stop the other process |
-
-### Performance Issues
-
-- Set `text:maxFacetHits` in the assembler config to limit facet collection scope for large indexes
-- Use `maxValues` and `minCount` arguments in `luc:facet` to reduce result size
-- See [Architecture — Performance Characteristics](04-architecture.md#performance-characteristics) for tuning guidance
+1. `indexSelector`
+2. `fieldSpec`

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -1,527 +1,352 @@
 # SPARQL API Reference
 
-All property functions use the `luc:` namespace (`urn:jena:lucene:index#`).
-
-> **Note:** The upstream Jena `text:query` property function is unchanged and still available for classic mode (`text:entityMap`). See the [Apache Jena documentation](https://jena.apache.org/documentation/query/text-query.html) for its syntax. This reference covers only the SHACL mode property functions.
-
----
-
-## luc:query — Text Search with Filters
-
-Supports field-scoped queries, CQL2-JSON filter arguments, sort pushdown, and faceted navigation.
-
-### Syntax
-
-```
-(?hit ?entity ?score ?match ?totalHits ?graph) luc:query (fieldSpec queryString filter? sort? limit? highlight?)
-```
-
-### Arguments (positional, left to right)
-
-| Position | Type | Required | Description |
-|----------|------|----------|-------------|
-| fieldSpec | String literal | No | Which indexed fields to search (see below). Default: `"default"` |
-| queryString | String literal | Yes | Lucene query string |
-| filter | JSON object literal | No | CQL filter: `'{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'` |
-| sort | JSON literal | No | Sort spec: `'{"field":"urn:jena:lucene:field#year","order":"desc"}'` |
-| limit | Integer | No | Max results. Negative = no limit |
-| highlight | String literal | No | Highlight options: `"highlight:m:3\|z:128\|s:→\|e:←\|f:÷"` |
-
-### Field specification
-
-The `fieldSpec` argument controls which Lucene fields are searched. It accepts either `"default"` or a JSON array of field IRIs.
-
-| Value | Meaning |
-|-------|---------|
-| `"default"` | Search all fields marked `idx:defaultSearch true` in the index configuration |
-| `'["urn:jena:lucene:field#title"]'` | Search a single specific field (JSON array with one IRI) |
-| `'["urn:jena:lucene:field#title","urn:jena:lucene:field#description"]'` | Search multiple specific fields (JSON array of IRIs) |
-| *(omitted)* | Same as `"default"` |
-
-Field IRIs correspond to the named resource IRIs in the SHACL index configuration. They are validated at query time — an unknown IRI produces an error.
-
-### Return bindings
-
-| Variable | Required | Type | Description |
-|----------|----------|------|-------------|
-| ?hit | Yes | Blank node | Query-scoped hit identifier for joining with `luc:match` |
-| ?entity | No | IRI | Matched entity |
-| ?score | No | float | Lucene relevance score |
-| ?match | No | IRI or literal | Stored value for the first matched field. KEYWORD fields return an IRI, TEXT fields return a string literal, numeric fields return typed literals |
-| ?totalHits | No | xsd:integer | Total matching documents (same value on every row) |
-| ?graph | No | IRI | Named graph of the match |
-
-The `?hit` binding is a blank node (e.g. `_:hit0`, `_:hit1`) scoped to the query execution. It serves as a join key with `luc:match` to retrieve per-field match details. Each hit gets a unique blank node.
-
-The `?totalHits` binding returns the total number of documents matching the query and filters, regardless of the `limit` parameter. This is useful for displaying "Showing X of Y results" in search UIs. The value is computed efficiently using `IndexSearcher.count()` and is only evaluated when the variable is present in the subject.
-
-The `?match` binding returns the stored value from the first matched field. For full per-field match details (which fields matched, their values), use `luc:match`.
-
-> **Note:** All fields must be defined as named resources (with IRIs) in the SHACL index configuration. Blank node field definitions are not supported.
-
-### Examples
+All SHACL-mode property functions use the `luc:` namespace:
 
 ```sparql
 PREFIX luc: <urn:jena:lucene:index#>
-PREFIX field: <urn:jena:lucene:field#>
-
-# Simple search (all default fields)
-(?hit ?entity ?score) luc:query ("machine learning") .
-
-# Search with explicit "default"
-(?hit ?entity ?score) luc:query ("default" "machine learning") .
-
-# Search a specific field (JSON array with one IRI)
-(?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning") .
-
-# Search multiple fields (JSON array of IRIs)
-(?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title", "urn:jena:lucene:field#description"]' "machine learning") .
-
-# Search with limit
-(?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning" 20) .
-
-# Search with total hit count
-(?hit ?entity ?score ?match ?totalHits) luc:query ("machine learning" 20) .
-
-# Search with CQL filter (only Technology books)
-(?hit ?entity ?score) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
-
-# Search with filter and total hit count
-(?hit ?entity ?score ?_match ?totalHits) luc:query ("default" "learning" '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
-
-# Search with sort (by field IRI)
-(?hit ?entity ?score) luc:query ("default" "learning" '{"field":"urn:jena:lucene:field#year","order":"desc"}' 10) .
-
-# Search with per-field match details (join with luc:match)
-(?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "machine learning") .
-(?hit ?field ?value) luc:match () .
 ```
 
-### Filter JSON format (CQL2-JSON)
+Classic `text:query` remains available upstream and is not covered here.
 
-Filters use CQL2-JSON syntax. The `property` value is a field IRI:
+> Note
+> The graph-scoping model described here is the target API model. Real indexing/query support for the synthetic graph field is deferred.
+
+## Overview
+
+Public API rules:
+
+- Index selection is explicit and always the first object argument.
+- Field references are always field IRIs, never `idx:fieldName`.
+- `luc:query` returns `?hit`; per-hit match detail comes from `luc:match`.
+- `luc:query` no longer returns `?match`.
+- Parsing is fixed-position and fixed-arity. There is no shape-based argument inference.
+- Use `"null"` as the placeholder for an unused `cqlFilter` or `sortSpec`.
+- Highlight is reserved for later and is not part of the active supported `luc:query` signature.
+
+## luc:query
+
+### Syntax
+
+```sparql
+(?hit ?entity ?score ?totalHits)
+  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
+```
+
+Subject arity may be 1 to 4:
+
+- `?hit`
+- `?hit ?entity`
+- `?hit ?entity ?score`
+- `?hit ?entity ?score ?totalHits`
+
+Object arity is always exactly 6.
+
+### Arguments
+
+| Position | Name | Type | Required | Notes |
+|---|---|---|---|---|
+| 1 | `indexSelector` | string literal | Yes | Usually `"default"`; may also be a configured index id or index IRI |
+| 2 | `fieldSpec` | string literal | Yes | `"default"` or a JSON array of field IRIs |
+| 3 | `queryString` | string literal | Yes | Lucene query string |
+| 4 | `cqlFilter` | string literal | Yes | CQL2-JSON object, or `"null"` |
+| 5 | `sortSpec` | string literal | Yes | JSON sort object/array, or `"null"` |
+| 6 | `limit` | integer literal | Yes | Negative means unlimited |
+
+### `fieldSpec`
+
+Supported values:
+
+- `"default"`
+- `'["urn:jena:lucene:field#title"]'`
+- `'["urn:jena:lucene:field#title","urn:jena:lucene:field#description"]'`
+
+Unknown field IRIs fail fast.
+
+### Return bindings
+
+| Variable | Type | Meaning |
+|---|---|---|
+| `?hit` | blank node | Query-scoped join key for `luc:match` |
+| `?entity` | IRI | Matched entity |
+| `?score` | float | Lucene relevance score |
+| `?totalHits` | `xsd:integer` | Total matching hits before limit |
+
+`?match` is not part of `luc:query`.
+
+### Examples
+
+Search all default-search fields:
+
+```sparql
+(?hit ?entity ?score)
+  luc:query ("default" "default" "machine learning" "null" "null" 20) .
+```
+
+Search a specific field IRI:
+
+```sparql
+(?hit ?entity ?score)
+  luc:query (
+    "default"
+    '["urn:jena:lucene:field#title"]'
+    "machine learning"
+    "null"
+    "null"
+    20
+  ) .
+```
+
+Search with a CQL filter:
+
+```sparql
+(?hit ?entity ?score ?totalHits)
+  luc:query (
+    "default"
+    "default"
+    "learning"
+    '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
+    "null"
+    20
+  ) .
+```
+
+Search with sort:
+
+```sparql
+(?hit ?entity ?score)
+  luc:query (
+    "default"
+    "default"
+    "learning"
+    "null"
+    '{"field":"urn:jena:lucene:field#year","order":"desc"}'
+    10
+  ) .
+```
+
+Multi-sort:
+
+```sparql
+(?hit ?entity ?score)
+  luc:query (
+    "default"
+    "default"
+    "learning"
+    "null"
+    '[{"field":"urn:jena:lucene:field#year","order":"desc"},{"field":"urn:jena:lucene:field#title"}]'
+    10
+  ) .
+```
+
+## luc:match
+
+### Syntax
+
+```sparql
+(?hit ?field ?value ?snippet) luc:match ()
+```
+
+The object is always `()`.
+
+### Purpose
+
+`luc:match` is the only per-hit match-detail API. It joins to `luc:query` through `?hit` and returns one row per matched field.
+
+### Return bindings
+
+| Variable | Type | Meaning |
+|---|---|---|
+| `?hit` | blank node | Join key from `luc:query` |
+| `?field` | IRI | Field IRI that matched |
+| `?value` | IRI or literal | Stored field value |
+| `?snippet` | literal | Reserved for later highlighting support |
+
+### Example
+
+```sparql
+SELECT ?entity ?score ?field ?value WHERE {
+  (?hit ?entity ?score)
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+  (?hit ?field ?value) luc:match () .
+}
+```
+
+## luc:facet
+
+### Syntax
+
+```sparql
+(?field ?value ?low ?high ?count)
+  luc:facet (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)
+```
+
+The active supported subject form is the 5-slot form above.
+
+Object arity is always exactly 7.
+
+### Arguments
+
+| Position | Name | Type | Required | Notes |
+|---|---|---|---|---|
+| 1 | `indexSelector` | string literal | Yes | Usually `"default"` |
+| 2 | `fieldSpec` | string literal | Yes | `"default"` or JSON array of field IRIs for search scoping |
+| 3 | `queryString` | string literal | Yes | Lucene query string |
+| 4 | `facetFields` | string literal | Yes | JSON array of field IRIs and/or range facet objects |
+| 5 | `cqlFilter` | string literal | Yes | CQL2-JSON object, or `"null"` |
+| 6 | `maxValues` | integer literal | Yes | `0` means all values |
+| 7 | `minCount` | integer literal | Yes | Minimum count threshold |
+
+### `facetFields`
+
+Flat facet targets use field IRIs:
 
 ```json
-{"op": "=", "args": [{"property": "urn:jena:lucene:field#category"}, "Technology"]}
+["urn:jena:lucene:field#category","urn:jena:lucene:field#author"]
 ```
 
-- `"="` — exact match on KEYWORD fields
-- `"and"` / `"or"` — boolean combinators
-- `"s_intersects"` — spatial intersection (LATLON fields)
-- Numeric comparisons (`">"`, `"<"`, `">="`, `"<="`) for INT/LONG/DOUBLE fields
+Range facets use objects:
 
----
-
-## luc:match — Per-Hit Field Match Details
-
-Returns per-field match information for each hit from a preceding `luc:query`. Joins with `luc:query` via the shared `?hit` blank node.
-
-### Syntax
-
-```
-(?hit ?field ?value) luc:match ()
+```json
+[
+  {"field":"urn:jena:lucene:field#year","ranges":[null,2020,2023,null]}
+]
 ```
 
-The object is always an empty list `()`.
+Mixed flat + range requests are allowed in the same array.
 
-### Return bindings
+Wildcard:
 
-| Variable | Required | Type | Description |
-|----------|----------|------|-------------|
-| ?hit | Yes | Blank node | Join key — must match `?hit` from `luc:query` |
-| ?field | No | IRI | Field IRI identifying which field matched (e.g. `urn:jena:lucene:field#title`) |
-| ?value | No | IRI or literal | Stored value for the matched field. KEYWORD fields return IRIs, TEXT fields return string literals, numeric fields return typed literals |
-
-`luc:match` produces one row per matched field per hit. If a document matched on two fields (e.g. both `title` and `description`), two rows are returned for that hit.
-
-### How it works
-
-`luc:match` uses Lucene's `NamedMatches` API to determine which fields contributed to each hit. During the initial `luc:query` search, each per-field sub-query is wrapped with `NamedMatches.wrapQuery(fieldIri, fieldQuery)`. After search, `Weight.matches()` is called per hit to extract field-level match details without re-scoring.
-
-### Requirements
-
-- `luc:match` must appear in the same SPARQL query as a `luc:query` — it reads from `luc:query`'s shared `SearchExecution` state
-- Without a preceding `luc:query`, `luc:match` returns no results
-- The `?hit` variable must be shared between `luc:query` and `luc:match` for the join to work
+- `"*"` expands to all flat and hierarchical facetable fields
+- it does not expand numeric range facets
 
 ### Examples
 
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-# Get field match details for each hit
-SELECT ?entity ?field ?value WHERE {
-    (?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title"]' "learning") .
-    (?hit ?field ?value) luc:match () .
-}
-
-# Multi-field search with field attribution
-SELECT ?entity ?score ?field ?value WHERE {
-    (?hit ?entity ?score) luc:query ('["urn:jena:lucene:field#title", "urn:jena:lucene:field#description"]' "machine learning") .
-    (?hit ?field ?value) luc:match () .
-}
-
-# OPTIONAL match — hits still returned even without field details
-SELECT ?entity ?score ?field ?value WHERE {
-    (?hit ?entity ?score) luc:query ("default" "learning") .
-    OPTIONAL { (?hit ?field ?value) luc:match () . }
-}
-```
-
----
-
-## luc:facet — Facet Counts
-### Syntax
-
-```
-(?field ?value ?count) luc:facet (fieldSpec queryString facetFields filter? maxValues? minCount?)
-(?field ?value ?low ?high ?count) luc:facet (fieldSpec queryString facetFields filter? maxValues? minCount?)
-```
-
-### Arguments (positional, left to right)
-
-| Position | Type | Required | Description |
-|----------|------|----------|-------------|
-| fieldSpec | String literal | No | Which indexed fields to scope the text query (same as luc:query). Default: `"default"` |
-| queryString | String literal | Yes | Lucene query string |
-| facetFields | JSON array literal | Yes | Field IRIs and/or range specs to facet on (see below) |
-| filter | JSON object literal | No | CQL filter (same format as luc:query) |
-| maxValues | Integer | No | Max facet values per field. Default: 10. `0` = all values |
-| minCount | Integer | No | Exclude values with count below this. Default: 0 |
-
-### Facet fields array
-
-The `facetFields` JSON array accepts two element types, which can be mixed freely:
-
-| Element type | Format | Use case |
-|-------------|--------|----------|
-| **String** | `"urn:jena:lucene:field#category"` | Flat facet on a KEYWORD field, or hierarchical facet on a hierarchy level field |
-| **Range object** | `{"field": "urn:jena:lucene:field#year", "ranges": [2020, 2022, 2024, 2026]}` | Bucketed counts on a numeric field (INT, LONG, DOUBLE) |
-
-**Range object properties:**
-
-| Property | Type | Required | Description |
-|----------|------|----------|-------------|
-| `field` | String | Yes | Field IRI of a numeric field (INT, LONG, or DOUBLE) |
-| `ranges` | Array of numbers/nulls | Yes | Bucket boundaries (bin edges). Adjacent pairs define `[low, high)` buckets |
-
-**Boundary semantics:** Boundaries are contiguous, lower-inclusive, upper-exclusive (`[low, high)`). For example, `[2020, 2022, 2024, 2026]` produces three buckets: `[2020, 2022)`, `[2022, 2024)`, `[2024, 2026)`.
-
-**Open-ended ranges:** Use `null` at the start or end to create unbounded buckets:
-- `[null, 2020, 2024, null]` → `(-∞, 2020)`, `[2020, 2024)`, `[2024, +∞)`
-
-**Wildcard behaviour:** The `"*"` wildcard expands to all flat and hierarchical facetable fields. It does not include numeric fields, since range facets require explicit boundaries.
-
-**Validation:**
-
-- Requesting a numeric field (INT/LONG/DOUBLE) as a bare string produces an error — numeric fields require range boundaries
-- Range objects targeting non-numeric fields produce an error
-- Non-null boundaries must be strictly increasing
-- `null` is only valid at the start and/or end of the boundary array
-
-### Subject forms
-
-Use the subject form that matches the request:
-
-- `(?field ?value ?count)` for flat and hierarchical facets only
-- `(?field ?value ?low ?high ?count)` for any request that includes a range object
-
-Rules:
-
-- the legacy 3-slot form remains valid for flat and hierarchical facets
-- the 5-slot form is required for range-only and mixed flat+range requests
-- the 5-slot form also works for flat-only requests
-
-### Return bindings
-
-| Variable | Required | Type | Description |
-|----------|----------|------|-------------|
-| ?field | Yes | IRI | Field IRI identifying the facet field |
-| ?value | No | IRI or literal | Flat or hierarchical facet value. For KEYWORD fields, values that look like URIs are returned as IRIs; otherwise as string literals |
-| ?low | No | typed numeric literal | Lower bound of a range bucket. Unbound for flat/hierarchical facets and open-ended low bounds |
-| ?high | No | typed numeric literal | Upper bound of a range bucket. Unbound for flat/hierarchical facets and open-ended high bounds |
-| ?count | No | xsd:long | Number of matching documents |
-
-### Examples
+Flat facets:
 
 ```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-# Basic facet counts
-(?f ?v ?c) luc:facet ("default" "learning" '["urn:jena:lucene:field#category"]' 10) .
-
-# Multiple facet fields
-(?f ?v ?c) luc:facet ("default" "learning" '["urn:jena:lucene:field#category", "urn:jena:lucene:field#author"]' 10) .
-
-# With CQL filter applied
-(?f ?v ?c) luc:facet ("default" "learning" '["urn:jena:lucene:field#author"]' '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 10) .
-
-# Return all facet values (maxValues=0)
-(?f ?v ?c) luc:facet ("default" "learning" '["urn:jena:lucene:field#category"]' 0) .
-
-# With minCount threshold (exclude rare values)
-(?f ?v ?c) luc:facet ("default" "learning" '["urn:jena:lucene:field#author"]' 10 2) .
-
-# Combine maxValues=0 with minCount
-(?f ?v ?c) luc:facet ("default" "learning" '["urn:jena:lucene:field#author"]' 0 2) .
+(?field ?value ?low ?high ?count)
+  luc:facet (
+    "default"
+    "default"
+    "learning"
+    '["urn:jena:lucene:field#category"]'
+    "null"
+    10
+    0
+  ) .
 ```
 
-### Range Facets
-
-Range facets provide bucketed counts for numeric fields. Mark the field `idx:facetable true` in the configuration, then include a range object in the `facetFields` array.
+Filtered facets:
 
 ```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-# Range facets on year field
-(?f ?v ?low ?high ?c) luc:facet ("default" "learning"
-    '[{"field":"urn:jena:lucene:field#year", "ranges":[2020, 2022, 2024, 2026]}]'
-    10) .
-```
-
-Returns:
-
-| ?field | ?value | ?low | ?high | ?count |
-|--------|--------|------|-------|--------|
-| `<urn:jena:lucene:field#year>` | — | `"2020"^^xsd:integer` | `"2022"^^xsd:integer` | 35 |
-| `<urn:jena:lucene:field#year>` | — | `"2022"^^xsd:integer` | `"2024"^^xsd:integer` | 28 |
-| `<urn:jena:lucene:field#year>` | — | `"2024"^^xsd:integer` | `"2026"^^xsd:integer` | 18 |
-
-**Mixed flat and range facets** in a single call:
-
-```sparql
-# Category facets + year range buckets in one request
-(?f ?v ?low ?high ?c) luc:facet ("default" "learning"
-    '["urn:jena:lucene:field#category", {"field":"urn:jena:lucene:field#year", "ranges":[2020, 2022, 2024, 2026]}]'
-    10) .
-```
-
-Flat rows bind `?value` and leave `?low` / `?high` unbound. Range rows bind `?low` / `?high` and leave `?value` unbound.
-
-**Open-ended ranges** with `null` boundaries:
-
-```sparql
-# Include "before 2020" and "2026+" buckets
-(?f ?v ?low ?high ?c) luc:facet ("default" "learning"
-    '[{"field":"urn:jena:lucene:field#year", "ranges":[null, 2020, 2022, 2024, 2026, null]}]'
-    10) .
-```
-
-Open-ended buckets leave the missing bound unbound:
-
-- `(-∞, 2020)` => `?low` unbound, `?high = "2020"^^xsd:integer`
-- `[2026, +∞)` => `?low = "2026"^^xsd:integer`, `?high` unbound
-
-**With CQL filters:**
-
-```sparql
-# Year ranges for Technology books only
-(?f ?v ?low ?high ?c) luc:facet ("default" "learning"
-    '[{"field":"urn:jena:lucene:field#year", "ranges":[2020, 2022, 2024, 2026]}]'
+(?field ?value ?low ?high ?count)
+  luc:facet (
+    "default"
+    "default"
+    "learning"
+    '["urn:jena:lucene:field#author"]'
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
-    10) .
+    10
+    0
+  ) .
 ```
 
-**Date fields:** Lucene has no native date type. Store dates as epoch milliseconds in a LONG field (`idx:fieldType idx:LongField ; idx:facetable true`). Range boundaries are then epoch millis values:
+Range facets:
 
 ```sparql
-# Date range facets (epoch millis for 2020-01-01, 2022-01-01, 2024-01-01, 2026-01-01)
-(?f ?v ?low ?high ?c) luc:facet ("default" "*"
-    '[{"field":"urn:jena:lucene:field#publishDate", "ranges":[1577836800000, 1640995200000, 1704067200000, 1767225600000]}]'
-    10) .
+(?field ?value ?low ?high ?count)
+  luc:facet (
+    "default"
+    "default"
+    "*"
+    '[{"field":"urn:jena:lucene:field#year","ranges":[null,2000,2010,2020,null]}]'
+    "null"
+    20
+    0
+  ) .
 ```
 
-### Hierarchical vs Range Facets for Dates
+## CQL2-JSON Filters
 
-Dates can be faceted using either approach, serving different navigation patterns:
+The `property` entry is always a field IRI.
 
-| Approach | Fields | Facet type | Navigation pattern |
-|----------|--------|------------|-------------------|
-| **Hierarchical** | Separate KEYWORD fields per level (e.g. `field:year`, `field:month`, `field:day`) | Taxonomy drill-down | "Drill into 2024 → March → 15th" |
-| **Range** | Single LONG field with epoch millis | Numeric bucketing | "How many per 2-year band?" |
+Exact match:
 
-Both approaches can coexist on the same underlying data — they use different Lucene fields and different facet mechanisms. A hierarchical date facet uses KEYWORD fields indexed via the taxonomy, while a range date facet uses a single numeric LONG field with numeric docvalues. There is no conflict because they are separate fields, even if they derive from the same RDF property.
+```json
+{"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/WA"]}
+```
 
-You cannot use both hierarchical and range faceting on the *same* Lucene field — hierarchical requires KEYWORD/taxonomy data while range requires numeric doc values.
+Conjunction:
 
-### Hierarchy Drill-Down
-
-When hierarchical facets are configured (see [Configuration — Hierarchical Facets](03-configuration.md#hierarchical-facets)), drill-down is triggered by combining a CQL `=` filter on a parent level field with a `facetFields` request on the child level field.
-
-**Top-level counts** — request facets on a hierarchy level field IRI. It auto-resolves to the dimension:
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-# Get top-level state counts (returns state values with counts)
-SELECT ?field ?value ?count WHERE {
-    (?field ?value ?count) luc:facet ("default" "*"
-        '["urn:jena:lucene:field#state"]' 10) .
+```json
+{
+  "op":"and",
+  "args":[
+    {"op":"=","args":[{"property":"urn:jena:lucene:field#commodity"},"http://example.org/mining/commodity/Gold"]},
+    {"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/WA"]}
+  ]
 }
 ```
 
-**Drill-down into children** — filter on the parent level and request facets on the child level:
+Spatial:
 
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-# Get commodity counts within WA (drill-down)
-SELECT ?field ?value ?count WHERE {
-    (?field ?value ?count) luc:facet ("default" "*"
-        '["urn:jena:lucene:field#commodity"]'
-        '{"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/WA"]}'
-        10) .
-}
+```json
+{"op":"s_intersects","args":[{"property":"urn:jena:lucene:field#location"},{"bbox":[112,-44,154,-10]}]}
 ```
 
-The system auto-detects that `field#state` and `field#commodity` belong to the same hierarchy. The CQL `=` filter on `field#state` becomes a taxonomy drill-down path, and the facet results return child-level (commodity) values scoped to that parent.
+## Graph Scoping
 
-**Combined with other filters** — hierarchy drill-down works alongside regular CQL filters:
+Target model:
 
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
+- graph scoping is a normal doc-level filter, not a dedicated `?graph` result slot
+- the public filter target is a reserved synthetic field IRI
+- the recommended reserved field is `urn:jena:lucene:field#sourceGraph`
+- it is intended to be a multi-valued KEYWORD field populated with every graph touched while indexing the entity document
 
-# Commodity counts within WA, restricted to Active status
-SELECT ?field ?value ?count WHERE {
-    (?field ?value ?count) luc:facet ("default" "*"
-        '["urn:jena:lucene:field#commodity"]'
-        '{"op":"and","args":[
-            {"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/WA"]},
-            {"op":"=","args":[{"property":"urn:jena:lucene:field#status"},"http://example.org/mining/status/Active"]}
-        ]}'
-        10) .
-}
+Example target filter:
+
+```json
+{"op":"=","args":[{"property":"urn:jena:lucene:field#sourceGraph"},"http://example.org/graph/A"]}
 ```
 
----
+This means:
 
-## Combining Search and Facets
+- query-time graph restriction behaves like any other CQL field filter
+- property-function signatures stay simple
+- graph provenance is doc-level, not per-match
 
-Search hits and facet counts are two fundamentally different result shapes — hits are entities with scores, facets are (field, value, count) aggregations. SPARQL's tabular result model requires care when combining them.
+Related deferred design:
 
-### Recommended: Separate queries
+- an index-time option may later restrict indexing to a configured graph set
+- when such restriction is used, `sourceGraph` naturally reflects only those indexed graphs
 
-Use one query for hits, another for facets. Each returns a clean result shape with no wasted rows.
+## Sort Specs
 
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
+Sort fields are field IRIs, not Lucene field names.
 
-# Query 1: search results
-SELECT ?entity ?score WHERE {
-    (?hit ?entity ?score) luc:query ("learning") .
-}
+Single sort:
 
-# Query 2: facet counts
-SELECT ?field ?value ?count WHERE {
-    (?field ?value ?count) luc:facet ("default" "learning"
-        '["urn:jena:lucene:field#category", "urn:jena:lucene:field#author"]' 10) .
-}
+```json
+{"field":"urn:jena:lucene:field#year","order":"desc"}
 ```
 
-This is the pattern used by search UIs (Elasticsearch, Solr) — one request for results, one for facets. Each result set has exactly the rows the consumer needs.
+Multi-sort:
 
-### Alternative: UNION in a single query
-
-If a single SPARQL request is preferred, use `UNION` to return both result sets without a cartesian product:
-
-```sparql
-PREFIX luc: <urn:jena:lucene:index#>
-
-SELECT ?entity ?score ?totalHits ?field ?value ?count WHERE {
-    { (?hit ?entity ?score ?_match ?totalHits) luc:query ("default" "learning" 10) . }
-    UNION
-    { (?field ?value ?count) luc:facet ("default" "learning"
-        '["urn:jena:lucene:field#category"]' 10) . }
-}
+```json
+[
+  {"field":"urn:jena:lucene:field#year","order":"desc"},
+  {"field":"urn:jena:lucene:field#title"}
+]
 ```
-
-This returns N + M rows (not N × M). Hit rows have facet variables unbound; facet rows have `?entity`, `?score`, `?totalHits` unbound. The consumer splits results by checking which columns are present. `?totalHits` appears on every hit row with the same value — read it from the first row. Both PFs share a single Lucene execution via `SearchExecution` (see below).
-
-If the facet branch requests range buckets, include `?low` and `?high` in the projection and use the 5-slot `luc:facet` subject form in that branch.
-
-### Avoid: Combined BGP (cartesian product)
-
-Placing both PFs in the same basic graph pattern produces a cartesian product:
-
-```sparql
-# WARNING: produces N × M rows
-SELECT ?entity ?score ?field ?value ?count WHERE {
-    (?hit ?entity ?score) luc:query ("learning") .
-    (?field ?value ?count) luc:facet ("default" "learning"
-        '["urn:jena:lucene:field#category"]' 10) .
-}
-```
-
-With 100 hits and 10 facet values, this returns 1,000 rows — every hit paired with every facet value. The shared execution avoids redundant Lucene work, but the result set still explodes. This is a consequence of SPARQL's join semantics: two patterns with no shared variables produce a cross join.
-
----
 
 ## Shared Execution
 
-When `luc:query`, `luc:facet`, and `luc:match` appear in the same SPARQL query (whether in a BGP, UNION, or subquery) with matching search parameters, they share a single Lucene execution internally. One Lucene query, one index reader snapshot, consistent results.
+`luc:query`, `luc:facet`, and `luc:match` share a single Lucene execution when these match:
 
-The shared search key is based on normalised search parameters — search field IRIs, query string, filters, and sort. Facet request details such as requested fields, range boundaries, `maxValues`, and `minCount` are applied after the shared search collection step.
+- resolved index identity
+- search field spec
+- query string
+- CQL filter
+- sort spec
 
-This optimisation is transparent. It reduces Lucene index access but does not change SPARQL result semantics — the cartesian product concern (above) is a SPARQL join issue, not a Lucene execution issue.
-
----
-
-## Lucene Query Syntax
-
-The query string argument in `luc:query` uses the standard Lucene query parser. Key syntax:
-
-| Syntax | Meaning | Example |
-|--------|---------|---------|
-| `word1 word2` | OR — matches either term | `"machine learning"` matches "machine" OR "learning" |
-| `word1 AND word2` | AND — matches both terms | `"machine AND learning"` |
-| `"exact phrase"` | Phrase match | `"\"machine learning\""` (escaped quotes in SPARQL string) |
-| `field:value` | Field-scoped query | `"title:learning"` |
-| `wild*` | Wildcard | `"learn*"` matches "learning", "learned", etc. |
-| `~` | Fuzzy match | `"learninh~"` matches "learning" |
-| `-term` | Exclusion | `"learning -neural"` |
-
-These are Lucene query parser conventions — not specific to Jena. Refer to the [Lucene Classic Query Parser documentation](https://lucene.apache.org/core/10_3_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html) for full syntax.
-
----
-
-## Java API
-
-For programmatic access via `ShaclTextIndexLucene`. The Java API accepts Lucene field names directly (these are the `idx:fieldName` values from the configuration):
-
-```java
-// Open facets (all documents)
-Map<String, List<FacetBucket>> counts =
-    textIndex.getFacetCounts(Arrays.asList("category"), 10);
-
-// Filtered by query
-Map<String, List<FacetBucket>> filtered =
-    textIndex.getFacetCounts("machine learning", Arrays.asList("category"), 10);
-
-// With minCount
-Map<String, List<FacetBucket>> rare =
-    textIndex.getFacetCounts("learning", Arrays.asList("author"), 10, 2);
-
-// With search fields scoping
-Map<String, List<FacetBucket>> scoped =
-    textIndex.getFacetCounts("learning", List.of("title"),
-        Arrays.asList("author"), 10);
-
-// Text query with field scoping
-List<TextHit> hits =
-    textIndex.queryByFields(List.of("title"), "learning", null, null, 20, null);
-
-// Count total matching documents (efficient — uses IndexSearcher.count())
-long total = textIndex.countQueryWithCql("learning", null, null);
-```
-
-For flat facets, programmatic results expose a field value plus count. For range facets, programmatic results follow the same model as SPARQL: explicit typed low/high bounds plus count, not a display label string.
-
-### Checking Facet Support
-
-```java
-if (textIndex.isFacetingEnabled()) {
-    // Facet methods are available
-}
-```
-
-`isFacetingEnabled()` returns `true` when the index has facetable fields configured, including numeric fields marked `idx:facetable true`.
+Facet-specific parameters such as requested facet fields, `maxValues`, and `minCount` are applied after the shared search step.

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -20,7 +20,7 @@ Public API rules:
 - `luc:query` returns `?hit`; per-hit match detail comes from `luc:match`.
 - `luc:query` no longer returns `?match`.
 - Parsing is fixed-position and fixed-arity. There is no shape-based argument inference.
-- Use `"null"` as the placeholder for an unused `cqlFilter` or `sortSpec`.
+- Use `""` as the placeholder for an unused `cqlFilter` or `sortSpec`.
 - Highlight is reserved for later and is not part of the active supported `luc:query` signature.
 
 ## luc:query
@@ -48,8 +48,8 @@ Object arity is always exactly 6.
 | 1 | `indexSelector` | string literal | Yes | Usually `"default"`; may also be a configured index id or index IRI |
 | 2 | `fieldSpec` | string literal | Yes | `"default"` or a JSON array of field IRIs |
 | 3 | `queryString` | string literal | Yes | Lucene query string |
-| 4 | `cqlFilter` | string literal | Yes | CQL2-JSON object, or `"null"` |
-| 5 | `sortSpec` | string literal | Yes | JSON sort object/array, or `"null"` |
+| 4 | `cqlFilter` | string literal | Yes | CQL2-JSON object, or `""` |
+| 5 | `sortSpec` | string literal | Yes | JSON sort object/array, or `""` |
 | 6 | `limit` | integer literal | Yes | Negative means unlimited |
 
 ### `fieldSpec`
@@ -79,7 +79,7 @@ Search all default-search fields:
 
 ```sparql
 (?hit ?entity ?score)
-  luc:query ("default" "default" "machine learning" "null" "null" 20) .
+  luc:query ("default" "default" "machine learning" "" "" 20) .
 ```
 
 Search a specific field IRI:
@@ -90,8 +90,8 @@ Search a specific field IRI:
     "default"
     '["urn:jena:lucene:field#title"]'
     "machine learning"
-    "null"
-    "null"
+    ""
+    ""
     20
   ) .
 ```
@@ -105,7 +105,7 @@ Search with a CQL filter:
     "default"
     "learning"
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
-    "null"
+    ""
     20
   ) .
 ```
@@ -118,7 +118,7 @@ Search with sort:
     "default"
     "default"
     "learning"
-    "null"
+    ""
     '{"field":"urn:jena:lucene:field#year","order":"desc"}'
     10
   ) .
@@ -132,7 +132,7 @@ Multi-sort:
     "default"
     "default"
     "learning"
-    "null"
+    ""
     '[{"field":"urn:jena:lucene:field#year","order":"desc"},{"field":"urn:jena:lucene:field#title"}]'
     10
   ) .
@@ -166,7 +166,7 @@ The object is always `()`.
 ```sparql
 SELECT ?entity ?score ?field ?value WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
   (?hit ?field ?value) luc:match () .
 }
 ```
@@ -181,6 +181,7 @@ SELECT ?entity ?score ?field ?value WHERE {
 ```
 
 The active supported subject form is the 5-slot form above.
+Flat facets use the same 5-slot form. On flat facet rows, `?value` is bound and `?low` / `?high` are left unbound.
 
 Object arity is always exactly 7.
 
@@ -192,7 +193,7 @@ Object arity is always exactly 7.
 | 2 | `fieldSpec` | string literal | Yes | `"default"` or JSON array of field IRIs for search scoping |
 | 3 | `queryString` | string literal | Yes | Lucene query string |
 | 4 | `facetFields` | string literal | Yes | JSON array of field IRIs and/or range facet objects |
-| 5 | `cqlFilter` | string literal | Yes | CQL2-JSON object, or `"null"` |
+| 5 | `cqlFilter` | string literal | Yes | CQL2-JSON object, or `""` |
 | 6 | `maxValues` | integer literal | Yes | `0` means all values |
 | 7 | `minCount` | integer literal | Yes | Minimum count threshold |
 
@@ -230,7 +231,7 @@ Flat facets:
     "default"
     "learning"
     '["urn:jena:lucene:field#category"]'
-    "null"
+    ""
     10
     0
   ) .
@@ -260,7 +261,7 @@ Range facets:
     "default"
     "*"
     '[{"field":"urn:jena:lucene:field#year","ranges":[null,2000,2010,2020,null]}]'
-    "null"
+    ""
     20
     0
   ) .

--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -1,10 +1,14 @@
 # Configuration Reference
 
-All configuration is done via Jena Assembler TTL files. The text index is configured as part of a `text:TextDataset`.
+This document covers SHACL-mode configuration for `text:TextDataset`.
 
-> **Note:** The upstream Jena classic mode (`text:entityMap` / `text:query`) is unchanged and still available. See the [Apache Jena documentation](https://jena.apache.org/documentation/query/text-query.html) for its configuration. This reference covers only the SHACL-based entity-per-document configuration.
+Classic `text:entityMap` / `text:query` configuration is unchanged upstream and is not covered here.
 
-## Dataset wrapper
+## Dataset Wrapper
+
+Use `text:indexes`, even for a single index.
+
+Single index:
 
 ```turtle
 @prefix text: <http://jena.apache.org/text#> .
@@ -12,74 +16,78 @@ All configuration is done via Jena Assembler TTL files. The text index is config
 
 <#ds> a text:TextDataset ;
     text:dataset <#baseDs> ;
-    text:index <#index> ;
-    .
+    text:indexes <#index> .
 
 <#baseDs> a tdb2:DatasetTDB2 ;
-    tdb2:location "/path/to/tdb2" ;
-    .
+    tdb2:location "/path/to/tdb2" .
 ```
 
----
-
-## Index Configuration
-
-Each entity (identified by `rdf:type` matching `sh:targetClass`) gets one Lucene document containing all its fields. Uses `luc:query` for search with filters and `luc:facet` for facet counts.
+Multiple indexes:
 
 ```turtle
-@prefix text:  <http://jena.apache.org/text#> .
-@prefix idx:   <urn:jena:lucene:index#> .
-@prefix sh:    <http://www.w3.org/ns/shacl#> .
+<#ds> a text:TextDataset ;
+    text:dataset <#baseDs> ;
+    text:indexes ( <#objectsIndex> <#ocrIndex> ) .
+```
+
+Notes:
+
+- `text:indexes` accepts either a single resource or an RDF list.
+- `text:index` is legacy and should be avoided in new configs.
+- Duplicate `text:indexId` values are rejected.
+
+## Index Resources
+
+```turtle
+@prefix text: <http://jena.apache.org/text#> .
+@prefix idx:  <urn:jena:lucene:index#> .
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
 
 <#index> a text:TextIndexLucene ;
+    text:indexId "default" ;
     text:directory "mem" ;
     text:shapes ( <#BookShape> <#ArticleShape> ) ;
     text:storeValues true ;
-    text:maxFacetHits 50000 ;                 # limit facet search (0 = unlimited)
-    .
+    text:maxFacetHits 50000 .
 ```
 
-### Index properties
+Important properties:
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `text:shapes` | RDF list | required* | List of shape resources |
-| `text:maxFacetHits` | integer | 0 | Max docs for facet collection. 0 = unlimited |
-| `text:storeValues` | boolean | false | Store literal values for retrieval |
+| Property | Meaning |
+|---|---|
+| `text:indexId` | Token id used by `indexSelector`, for example `"default"` or `"objects"` |
+| `text:directory` | Lucene storage location |
+| `text:shapes` | RDF list of SHACL shapes |
+| `text:storeValues` | Store values for `luc:match` and facet value binding |
+| `text:maxFacetHits` | Maximum documents considered during facet collection |
 
-*Mutually exclusive with `text:entityMap` (classic mode).
+If the index resource itself is a URI resource, that URI is also accepted as an `indexSelector`.
 
-### Shape definition
+## Shapes
 
-Each shape in the list defines a Lucene document profile:
+Each SHACL shape contributes one document profile.
 
 ```turtle
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix idx:  <urn:jena:lucene:index#> .
+@prefix field: <urn:jena:lucene:field#> .
+
 <#BookShape>
-    sh:targetClass ex:Book ;              # which rdf:type triggers this shape
-    idx:docIdField "uri" ;                # entity URI field name (default: "uri")
-    idx:discriminatorField "docType" ;    # type discriminator field (default: "docType")
-    sh:property [                         # field definitions via sh:property
-        idx:fieldName "title" ;
-        idx:fieldType idx:TextField ;
-        idx:defaultSearch true ;
-        idx:stored true ;
-        sh:path rdfs:label ;
-    ] ;
-    sh:property [
-        idx:fieldName "category" ;
-        idx:fieldType idx:KeywordField ;
-        idx:facetable true ;
-        idx:multiValued true ;
-        sh:path ex:category ;
-    ] .
+    sh:targetClass ex:Book ;
+    sh:property field:title ;
+    sh:property field:category ;
+    sh:property field:authorName .
 ```
 
-Alternatively, fields can be defined as **named resources** with absolute IRIs and referenced from shapes. This is the recommended pattern — named resources are used as field identifiers in SPARQL queries (`luc:query` field specs, `luc:facet` facet field arrays, CQL2-JSON filter properties, and sort specs), enable field reuse across shapes, and support complex paths:
+## Fields
+
+Named field resources are the recommended pattern.
 
 ```turtle
 @prefix field: <urn:jena:lucene:field#> .
+@prefix idx:   <urn:jena:lucene:index#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
 
-## Named field resources — IRIs used as field identifiers in SPARQL
 field:title
     idx:fieldName "title" ;
     idx:fieldType idx:TextField ;
@@ -92,292 +100,112 @@ field:category
     idx:facetable true ;
     sh:path ex:category .
 
-field:authorName
-    idx:fieldName "authorName" ;
+field:year
+    idx:fieldName "year" ;
+    idx:fieldType idx:IntField ;
+    idx:facetable true ;
+    idx:sortable true ;
+    sh:path ex:year .
+```
+
+Public API rule:
+
+- External SPARQL uses the field IRI, for example `urn:jena:lucene:field#title`.
+- Internal Lucene storage uses `idx:fieldName`.
+
+`idx:fieldName` is not a public query-time identifier.
+
+## Field Properties
+
+| Property | Meaning |
+|---|---|
+| `idx:fieldName` | Internal Lucene field name |
+| `idx:fieldType` | `idx:TextField`, `idx:KeywordField`, `idx:IntField`, `idx:LongField`, `idx:DoubleField`, `idx:LatLonField` |
+| `idx:facetable` | Enables faceting |
+| `idx:sortable` | Enables sort pushdown |
+| `idx:multiValued` | Allows multiple values |
+| `idx:defaultSearch` | Included when `fieldSpec` is `"default"` |
+| `idx:analyzer` | Index-time analyzer override |
+| `idx:queryAnalyzer` | Query-time analyzer override |
+| `sh:path` | Direct, sequence, inverse, or nested path |
+
+## Paths
+
+Direct path:
+
+```turtle
+sh:path rdfs:label .
+```
+
+Sequence path:
+
+```turtle
+sh:path ( ex:authoredBy ex:name ) .
+```
+
+Inverse path:
+
+```turtle
+sh:path [ sh:inversePath ex:authored ] .
+```
+
+## Multi-Index Notes
+
+Multiple indexes are useful when corpora differ materially:
+
+- different analyzers
+- different field sets
+- different update cadence
+- operational separation
+
+At query time:
+
+- `indexSelector` picks the index
+- `fieldSpec` is resolved against that selected index
+- sort and filter field IRIs must exist in that selected index
+
+## Sort Configuration
+
+Sort specs use field IRIs in SPARQL:
+
+```json
+{"field":"urn:jena:lucene:field#year","order":"desc"}
+```
+
+But the underlying Lucene field key still comes from `idx:fieldName`.
+
+## Example
+
+```turtle
+@prefix text: <http://jena.apache.org/text#> .
+@prefix idx:  <urn:jena:lucene:index#> .
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix field: <urn:jena:lucene:field#> .
+
+<#dataset> a text:TextDataset ;
+    text:dataset <#baseDs> ;
+    text:indexes <#index> .
+
+<#index> a text:TextIndexLucene ;
+    text:indexId "default" ;
+    text:directory "mem" ;
+    text:storeValues true ;
+    text:shapes ( <#BookShape> ) .
+
+field:title
+    idx:fieldName "title" ;
+    idx:fieldType idx:TextField ;
+    idx:defaultSearch true ;
+    sh:path rdfs:label .
+
+field:category
+    idx:fieldName "category" ;
     idx:fieldType idx:KeywordField ;
     idx:facetable true ;
-    sh:path ( ex:writtenBy ex:name ) .  ## sequence path
-
-field:referencedBy
-    idx:fieldName "referencedBy" ;
-    idx:fieldType idx:KeywordField ;
-    idx:multiValued true ;
-    sh:path [ sh:inversePath ex:references ] .  ## inverse path
+    sh:path ex:category .
 
 <#BookShape>
     sh:targetClass ex:Book ;
-    sh:property field:title ;
-    sh:property field:category ;
-    sh:property field:authorName ;
-    sh:property field:referencedBy .
-
-## Same fields reused on a different shape
-<#ArticleShape>
-    sh:targetClass ex:Article ;
     sh:property field:title ;
     sh:property field:category .
 ```
-
-> **Important:** Field resource IRIs must be absolute. Relative IRIs (e.g., `<#field-title>` via `PREFIX : <#>`) resolve to environment-dependent values that differ between Docker, local development, and the browser. Use an absolute prefix like `<urn:jena:lucene:field#>` or any other stable IRI scheme.
-
-### Path expressions
-
-Multiple path forms are supported:
-
-```turtle
-# Direct predicate
-sh:path rdfs:label ;
-
-# Alternative paths (field indexes multiple predicates)
-sh:path [ sh:alternativePath (rdfs:label skos:prefLabel dct:title) ] ;
-
-# Sequence path (traverse relationships — indexes the value at the end of the path)
-sh:path ( ex:authoredBy ex:name ) ;
-
-# Inverse path (follow a predicate in reverse)
-sh:path [ sh:inversePath ex:authored ] ;
-
-# Convenience shorthand (same as sh:path for single predicates)
-idx:path rdfs:label ;
-```
-
-Sequence and inverse paths enable cross-entity indexing without forward chaining. For example, a sequence path `( ex:authoredBy ex:name )` on a report shape indexes the author's name directly on the report's Lucene document, without materialising an `ex:authorName` triple in the graph.
-
-### Shape properties
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `sh:targetClass` | URI | required | RDF class that triggers this shape |
-| `idx:docIdField` | string | `"uri"` | Lucene field for entity URI |
-| `idx:discriminatorField` | string | `"docType"` | Lucene field for type discrimination |
-
-### Field properties
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `idx:fieldName` | string | required | Lucene field name |
-| `idx:fieldType` | Resource | `idx:TextField` | One of the field types below |
-| `idx:stored` | boolean | true | Store value for retrieval |
-| `idx:indexed` | boolean | true | Index for searching |
-| `idx:facetable` | boolean | false | Enable faceting: KEYWORD flat/taxonomy facets or numeric range facets |
-| `idx:sortable` | boolean | false | Enable sorting |
-| `idx:multiValued` | boolean | false | Allow multiple values per entity |
-| `idx:defaultSearch` | boolean | false | Use as default search field |
-| `idx:analyzer` | Resource | index default | Per-field analyzer |
-| `sh:path` | URI or blank node | required | RDF predicate(s) to index |
-
-### Field types
-
-| Type | Lucene fields | Stored as | Use case |
-|------|--------------|-----------|----------|
-| `idx:TextField` | `TextField` | analyzed text | Full-text search. Returns string literals in bindings |
-| `idx:KeywordField` | `StringField` | exact string | Facets, filters, exact match. Returns IRIs in `?literal` and `?value` bindings when the stored value looks like a URI |
-| `idx:IntField` | `IntPoint` | int | Numeric range queries, numeric range facets, numeric sorting. Range facets return typed `?low` / `?high` literals |
-| `idx:LongField` | `LongPoint` | long | Large numeric values, numeric range facets, numeric sorting. Range facets return typed `?low` / `?high` literals |
-| `idx:DoubleField` | `DoublePoint` | double | Floating point values, numeric range facets, numeric sorting. Range facets return typed `?low` / `?high` literals |
-| `idx:LatLonField` | `LatLonShape` | WKT geometry | Spatial filtering via CQL2-JSON `s_intersects`. See [Spatial Filtering](09-spatial.md) |
-
-When `idx:facetable true` is set on a `KeywordField`, a `SortedSetDocValuesFacetField` is added for flat facets. When `idx:sortable true` is set on a `KeywordField`, a `SortedDocValuesField` is added for sorting.
-
-For numeric fields (`INT`, `LONG`, `DOUBLE`), docvalues are written whenever either `idx:facetable true` or `idx:sortable true` is set. This supports:
-
-- range faceting on facetable numeric fields
-- sorting on sortable numeric fields
-- single-valued and multi-valued numeric fields via a common docvalues representation
-
-### Range facets on numeric fields
-
-Numeric fields (`INT`, `LONG`, `DOUBLE`) support range faceting via `luc:facet` when the field is marked `idx:facetable true`. Bucket boundaries are specified per query in the `facetFields` JSON array — no index-time bucket configuration is needed.
-
-Key points:
-
-- `idx:facetable true` is the public switch for numeric range faceting
-- `idx:sortable true` is only needed if the same numeric field must also be sortable
-- numeric range facets support both single-valued and multi-valued fields
-- mixed flat + range facet requests use the 5-slot `luc:facet` subject form
-
-For multi-valued numeric sorting, ascending order uses the field's minimum value and descending order uses the field's maximum value.
-
-See [SPARQL API — Range Facets](02-sparql-api.md#range-facets) for query syntax.
-
-**Date fields:** Lucene has no native date type. Store dates as epoch milliseconds using `idx:LongField`. Mark the field `idx:facetable true` for range faceting and `idx:sortable true` if you also need sort pushdown. Range facet boundaries are then epoch millis values. For hierarchical date navigation (year → month → day drill-down), use separate KEYWORD fields per level instead — see [Hierarchical vs Range Facets for Dates](02-sparql-api.md#hierarchical-vs-range-facets-for-dates).
-
-### Field IRIs
-
-Each field definition has an associated IRI that serves as its external identity. This IRI is used in SPARQL queries — as the `fieldSpec` in `luc:query`, in the `facetFields` JSON array for `luc:facet`, as the `property` value in CQL2-JSON filters, and as the `field` value in sort specs. The `idx:fieldName` property is the internal Lucene field name and is not accepted in these contexts.
-
-- **Named resource fields**: If the field is defined as a named resource (URI node) in the configuration, its IRI is used directly. Use an absolute IRI prefix to ensure portability.
-- **Blank node fields**: Fields defined on blank nodes (e.g., via `sh:property [ ... ]`) get an auto-generated IRI: `urn:jena:lucene:field#{fieldName}`.
-
-This IRI is deterministic and stable — it depends only on `idx:fieldName`, not on blank node identity.
-
----
-
-## Multiple shapes
-
-You can define multiple shapes for different entity types in the same index:
-
-```turtle
-<#index> a text:TextIndexLucene ;
-    text:directory "mem" ;
-    text:shapes ( <#BookShape> <#ArticleShape> ) ;
-    .
-
-<#BookShape>
-    sh:targetClass ex:Book ;
-    sh:property [ idx:fieldName "title" ; sh:path rdfs:label ; idx:defaultSearch true ] ;
-    sh:property [ idx:fieldName "genre" ; idx:fieldType idx:KeywordField ; idx:facetable true ; sh:path ex:genre ] .
-
-<#ArticleShape>
-    sh:targetClass ex:Article ;
-    sh:property [ idx:fieldName "title" ; sh:path dct:title ; idx:defaultSearch true ] ;
-    sh:property [ idx:fieldName "journal" ; idx:fieldType idx:KeywordField ; idx:facetable true ; sh:path ex:journal ] .
-```
-
-Each entity gets a `docType` discriminator field (the local name of its `sh:targetClass`), so Book and Article documents coexist in the same index.
-
----
-
-## Hierarchical Facets
-
-Hierarchical facets allow drill-down navigation through a tree of related fields. For example, state → commodity, where selecting a state reveals commodity counts within that state.
-
-Define hierarchies on a shape using `idx:facetHierarchy` with an RDF list of field resources. The list order defines the hierarchy levels (parent → child):
-
-```turtle
-@prefix field: <urn:jena:lucene:field#> .
-
-field:state
-    idx:fieldName "state" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:state .
-
-field:commodity
-    idx:fieldName "commodity" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:commodity .
-
-<#SiteShape>
-    sh:targetClass ex:Site ;
-    sh:property field:title ;
-    sh:property field:state ;
-    sh:property field:commodity ;
-    idx:facetHierarchy ( field:state field:commodity ) .
-```
-
-### Rules
-
-- `idx:facetHierarchy` takes an RDF list of field IRIs (named resources)
-- At least 2 levels are required
-- Each referenced field must exist as a `sh:property` on the same shape (or globally)
-- Multiple shapes can share the same hierarchy definition
-- The dimension name is auto-generated by joining field names with `_` (e.g., `state_commodity`)
-
-### How it works
-
-Hierarchical fields are indexed using Lucene's taxonomy (`DirectoryTaxonomyWriter`). Each document gets a `FacetField` with path components from parent to child levels. At query time, `FastTaxonomyFacetCounts` provides drill-down counts and `MultiFacets` combines hierarchy and flat facet results.
-
-Drill-down is triggered automatically when a CQL `=` filter targets a hierarchy level field. See [SPARQL API — Hierarchy Drill-Down](02-sparql-api.md#hierarchy-drill-down) for query examples.
-
----
-
-## Nested Child Collections
-
-Use `idx:nested` when hierarchy levels belong to a repeated correlated child record rather than to the entity itself.
-
-Typical examples:
-
-- identifiers: `schema:identifier / schema:propertyID / schema:value`
-- assessments: `pe:hasLocationAssessment / pe:method / pe:status / pe:resolvedFeature`
-
-### Identifier Example
-
-```turtle
-@prefix field:  <urn:jena:lucene:field#> .
-@prefix schema: <https://schema.org/> .
-
-field:identifierType
-    idx:fieldName "identifierType" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    idx:multiValued true ;
-    sh:path schema:propertyID .
-
-field:identifierValueExact
-    idx:fieldName "identifierValueExact" ;
-    idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    idx:multiValued true ;
-    sh:path schema:value .
-
-field:identifierValueText
-    idx:fieldName "identifierValueText" ;
-    idx:fieldType idx:TextField ;
-    idx:multiValued true ;
-    idx:analyzer [ a text:EdgeNGramAnalyzer ] ;
-    idx:queryAnalyzer [ a text:LowerCaseKeywordAnalyzer ] ;
-    sh:path schema:value .
-
-<#BoreholeShape>
-    sh:targetClass ex:Borehole ;
-    sh:property field:title ;
-    idx:nested [
-        idx:joinPath schema:identifier ;
-        idx:property field:identifierType ;
-        idx:property field:identifierValueExact ;
-        idx:property field:identifierValueText ;
-        idx:facetHierarchy ( field:identifierType field:identifierValueExact ) ;
-    ] .
-```
-
-### Rules
-
-- `idx:joinPath` is required inside `idx:nested`
-- `idx:joinPath` supports:
-  - a simple predicate path
-  - an inverse predicate path such as `[ sh:inversePath schema:about ]`
-  - a sequence composed from simple and inverse predicate steps
-- `idx:joinPath` does not support alternative paths
-- `idx:property` fields are evaluated relative to the child node reached by `idx:joinPath`
-- a field IRI may belong to only one scope: either root `sh:property` or one `idx:nested` block
-- direct hierarchies such as `state -> commodity` stay as ordinary shape-level `idx:facetHierarchy`
-
-For example, these are valid nested joins:
-
-```turtle
-# Parent --identifier--> child
-idx:joinPath schema:identifier ;
-
-# Child --about--> parent
-idx:joinPath [ sh:inversePath schema:about ] ;
-
-# Parent --assessmentLink--> x, child --aboutAssessment--> x
-idx:joinPath (
-    ex:assessmentLink
-    [ sh:inversePath ex:aboutAssessment ]
-) ;
-```
-
-### Phase 1 Query Semantics
-
-The current implementation fixes correlated hierarchy population, but does not yet implement block join.
-
-- hierarchy tuples inside `idx:nested` are emitted per child record, so drill-down counts are correlated
-- exact `=` filters across contiguous hierarchy levels are compiled into one hierarchy path query
-- a bare `=` filter on a level-0 hierarchy field also compiles to a hierarchy drill-down query
-- nested fields are still flattened onto the parent Lucene document for ordinary non-hierarchy queries
-- a lone child-field filter, child-field `OR`/`NOT`, or a range filter on a child field still uses the flattened parent field until block join exists
-
-So `identifierType = Company AND identifierValueExact = 8412` is correlated, but `identifierValueExact = 8412` alone is still a parent-level field filter.
-
----
-
-## Validation rules
-
-- `text:shapes` and `text:entityMap` are **mutually exclusive** — specifying both throws an error
-- Each shape must have at least one `sh:targetClass`
-- Each field must have at least one path (`sh:path` or `idx:path`)
-- Each field must have an `idx:fieldName`
-- The shapes list must not be empty

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -3,11 +3,11 @@
 ## Running Tests
 
 ```bash
-# Full jena-text suite (366 tests)
+# Full jena-text suite (546 tests)
 mvn test -pl jena-text
 
 # Only SHACL / faceting tests
-mvn test -pl jena-text -Dtest="TestShaclIndexMapping,TestShaclDocumentBuilding,TestShaclTextDocProducer,TestShaclAssembler,TestShaclEntityPerDocument,TestNativeFacetCounts,TestTextFacetPF,TestTextQueryPFFilters,TestSearchExecution,TestHierarchicalFacets,TestHierarchicalFacetsSparql"
+mvn test -pl jena-text -Dtest="TestShaclIndexMapping,TestShaclDocumentBuilding,TestShaclTextDocProducer,TestShaclAssembler,TestShaclEntityPerDocument,TestNativeFacetCounts,TestTextFacetPF,TestTextQueryPFFilters,TestSearchExecution,TestHierarchicalFacets,TestHierarchicalFacetsSparql,TestSortSpec"
 ```
 
 All tests run via JUnit 4 and are aggregated in `TS_Text.java` (Surefire only picks up `**/TS_*.java`).
@@ -21,30 +21,37 @@ All tests run via JUnit 4 and are aggregated in `TS_Text.java` (Surefire only pi
 | Class | Tests | What it covers |
 |-------|-------|---------------|
 | `TestNativeFacetCounts` | 10 | Java API: open facets, filtered facets, maxValues, minCount, getAllChildren, empty/nonexistent fields |
-| `TestTextFacetPF` | 7 | SPARQL `luc:facet` PF: basic counts, multiple fields, filters, maxValues, minCount, maxValues=0 |
-| `TestTextQueryPFFilters` | 6 | SPARQL `luc:query` with JSON filters: single filter, multi-field, no matches, JSON parsing |
-| `TestSearchExecution` | 6 | Shared execution: key generation, normalisation, reuse across PFs |
+| `TestTextFacetPF` | 16 | SPARQL `luc:facet` PF: flat/range facets, mixed requests, filters, maxValues, minCount, subject arity checks, empty-string placeholders |
+| `TestTextQueryPFFilters` | 13 | SPARQL `luc:query` with JSON filters, field-IRI scoping, empty-string placeholders, string limits, and end-to-end sort pushdown |
+| `TestSearchExecution` | 10 | Shared execution: key generation, normalisation, index-aware reuse, and sort-sensitive cache keys |
 
 ### SHACL Entity-Per-Document Tests
 
 | Class | Tests | What it covers |
 |-------|-------|---------------|
-| `TestShaclIndexMapping` | 8 | Data model: predicate lookup, class lookup, irrelevant predicates, facet field names, defaults |
+| `TestShaclIndexMapping` | 13 | Data model: predicate lookup, class lookup, field resolution, facet field names, defaults, hierarchy metadata |
 | `TestShaclDocumentBuilding` | 11 | Lucene doc building: TEXT/KEYWORD/INT/LONG/DOUBLE field types, multi-valued, discriminator, null fields, int-from-string |
 | `TestShaclTextDocProducer` | 5 | Change listener: add type creates doc, add property rebuilds, delete type removes, irrelevant predicate ignored, multiple entities |
-| `TestShaclAssembler` | 3 | Config parsing: valid shapes parsed, EntityDefinition derived, both shapes+entityMap errors |
+| `TestShaclAssembler` | 9 | Config parsing: valid shapes, SHACL/entity-map exclusivity, hierarchy config, and assembler validation paths |
 | `TestShaclEntityPerDocument` | 7 | End-to-end: text search, SPARQL `luc:query`, facet counts, filtered facets, add after load, entity-per-doc model verification |
 
 ### Hierarchical Facets Tests
 
 | Class | Tests | What it covers |
 |-------|-------|---------------|
-| `TestHierarchicalFacets` | 8 | Java API: taxonomy indexing, top-level facets, drill-down path building, flat+hierarchy coexistence, multi-valued hierarchies, empty dimensions |
+| `TestHierarchicalFacets` | 9 | Java API: taxonomy indexing, top-level facets, drill-down path building, flat+hierarchy coexistence, multi-valued hierarchies, empty dimensions |
 | `TestHierarchicalFacetsSparql` | 3 | SPARQL `luc:facet` with hierarchy: top-level via field IRI, drill-down via CQL filter, flat facets alongside hierarchy |
+
+### Sort Tests
+
+| Class | Tests | What it covers |
+|-------|-------|---------------|
+| `TestSortSpec` | 9 | Sort JSON parsing, field-IRI sort specs, Lucene sort construction, numeric selector semantics, invalid text-field sorting |
+| `TestTextQueryPFFilters` | 13 | End-to-end SPARQL `luc:query` sorting with field IRIs, including descending and filtered ascending order |
 
 ### Existing Tests (unchanged, verifying no regressions)
 
-303 pre-existing tests covering text search, multilingual support, graph indexing, deletion, analyzers, property lists, etc. All pass unchanged.
+The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 546 tests.
 
 ---
 
@@ -116,13 +123,13 @@ TextIndexLucene index = (TextIndexLucene) Assembler.general().open(indexSpec);
 - Shared execution between PFs
 - Facet count accuracy with filters
 - minCount and maxValues options
+- End-to-end SPARQL sort pushdown using field IRIs
 - Hierarchical facets: taxonomy indexing, top-level counts, drill-down via CQL filters, flat+hierarchy coexistence
-- Backward compatibility (all 303 existing tests pass unchanged)
+- Range facets on numeric fields: single-valued, multi-valued, open-ended buckets, mixed flat+range requests, and 5-slot `luc:facet` bindings
+- Multi-valued numeric sorting semantics (`MIN` for ascending, `MAX` for descending)
 
 ### Not yet covered (candidates for future tests)
 
-- Range facets on numeric fields: single-valued, multi-valued, open-ended buckets, mixed flat+range requests, and 5-slot `luc:facet` bindings
-- Multi-valued numeric sorting semantics (`MIN` for ascending, `MAX` for descending)
 - Named graph support in SHACL mode
 - Multiple shapes with overlapping predicates
 - Large-scale performance (10k+ entities)

--- a/docs/2026-04-08-graph-filtering-target-model.md
+++ b/docs/2026-04-08-graph-filtering-target-model.md
@@ -1,0 +1,75 @@
+# 2026-04-08 Graph Filtering Target Model
+
+Status: design only
+
+## Decision
+
+Do not add graph-specific slots to the SHACL property-function signatures.
+
+Graph scoping should be modeled as a normal doc-level field filter using a reserved synthetic field IRI:
+
+```text
+urn:jena:lucene:field#sourceGraph
+```
+
+## Rationale
+
+Trying to expose `?graph` as a dedicated binding causes awkward semantics:
+
+- on `luc:query`, it is ambiguous whether the graph is per-hit, per-entity, or per-matched-value
+- on `luc:match`, it implies per-field-value provenance, which is more expensive and not needed for the immediate use case
+- adding dedicated graph bindings complicates otherwise clean fixed-arity signatures
+
+The graph-filtering use case is really doc-level:
+
+- users want to constrain search to entities that have indexed content from graph X
+- that fits naturally as a normal CQL filter over a synthetic keyword field
+
+## Intended Semantics
+
+`sourceGraph` is a multi-valued KEYWORD field.
+
+At index time:
+
+1. build the entity document as normal
+2. collect every graph touched while resolving indexed values for that entity
+3. add each discovered graph IRI to `sourceGraph`
+
+At query time:
+
+- filtering to graph X means “this entity has at least one indexed value sourced from graph X”
+
+Example target filter:
+
+```json
+{"op":"=","args":[{"property":"urn:jena:lucene:field#sourceGraph"},"http://example.org/graph/A"]}
+```
+
+## Relationship To Index-Time Graph Restriction
+
+This model does not replace strict graph partitioning at index time.
+
+Recommended split:
+
+- index-time graph restriction:
+  - used when users want true graph-isolated indexing
+  - only selected graphs contribute to the index
+- query-time `sourceGraph` filtering:
+  - used for flexible post-filtering within a broader index
+
+If indexing is restricted to one graph, `sourceGraph` naturally reflects only that graph anyway.
+
+## Non-Goals For This Pass
+
+- no dedicated `?graph` result slot on `luc:query`
+- no dedicated `?graph` result slot on `luc:match`
+- no per-match graph provenance
+- no immediate implementation changes required in this design-only pass
+
+## Future Implementation Notes
+
+When implemented, this likely needs:
+
+- reserved-field handling in the SHACL index mapping/runtime
+- indexing support to collect source graphs while traversing fields
+- documentation examples showing `sourceGraph` filters in `luc:query` and `luc:facet`

--- a/docs/2026-04-08-issue-21-plan.md
+++ b/docs/2026-04-08-issue-21-plan.md
@@ -1,0 +1,307 @@
+# Issue 21 Plan On Main
+
+Status: draft
+
+This plan is based on the current `main` branch, not `cql-faceting`.
+
+## Current Main Baseline
+
+`main` already has the newer SHACL search model:
+
+- `luc:query` returns `?hit` and supports joining to `luc:match`
+- `luc:match` returns per-hit field/value rows
+- external field references are already field IRIs, not `idx:fieldName`
+- `luc:facet` already uses field IRIs in `facetFields`, CQL filters, and sort specs
+- `luc:query` still carries a scalar `?match` slot, which should now be removed
+
+Current `luc:query` on `main` is:
+
+```sparql
+(?hit ?entity ?score ?match ?totalHits ?graph)
+  luc:query (fieldSpec queryString cqlFilter? sortSpec? limit? highlight?)
+```
+
+Current `luc:facet` on `main` is documented as:
+
+```sparql
+(?field ?value ?count)
+  luc:facet (fieldSpec queryString facetFields cqlFilter? maxValues? minCount?)
+```
+
+and
+
+```sparql
+(?field ?value ?low ?high ?count)
+  luc:facet (fieldSpec queryString facetFields cqlFilter? maxValues? minCount?)
+```
+
+The problem raised in issue #21 still exists on `main`:
+
+- there is no separate query-time index selector
+- SHACL query/facet execution resolves the default registry index only
+- `fieldSpec` occupies the first object slot, so index selection and field selection cannot both be expressed
+- the scalar `?match` slot in `luc:query` no longer fits the `?hit` + `luc:match` model cleanly
+
+## Goal
+
+Add explicit index selection to the current `main` API without discarding:
+
+- `?hit`
+- `luc:match`
+- field-IRI-based field selection
+- existing SHACL `SearchExecution` sharing model
+
+Remove from the API:
+
+- `?match` on `luc:query`
+
+## Design Direction
+
+### 1. Add Index Selector Before Field Spec
+
+`luc:query` should move from:
+
+```sparql
+luc:query (fieldSpec queryString ...)
+```
+
+to:
+
+```sparql
+luc:query (indexSelector fieldSpec queryString ...)
+```
+
+`luc:facet` should move from:
+
+```sparql
+luc:facet (fieldSpec queryString facetFields ...)
+```
+
+to:
+
+```sparql
+luc:facet (indexSelector fieldSpec queryString facetFields ...)
+```
+
+This keeps the current main semantics for field selection while making index selection explicit and first.
+
+### 1a. Remove `?match` From `luc:query`
+
+The query result shape should move from:
+
+```sparql
+(?hit ?entity ?score ?match ?totalHits ?graph)
+```
+
+to:
+
+```sparql
+(?hit ?entity ?score ?totalHits ?graph)
+```
+
+Rationale:
+
+- once `?hit` exists, per-hit match details belong in `luc:match`
+- a single scalar `?match` in `luc:query` is ambiguous for multi-field hits
+- no backward compatibility is required for keeping `?match`
+
+`luc:match` becomes the only API for returning matched field/value rows.
+
+### 2. Preserve Field IRIs
+
+No change to current public field identity rules:
+
+- `fieldSpec` remains `"default"` or a JSON array of field IRIs
+- CQL `property` entries remain field IRIs
+- sort spec `field` entries remain field IRIs
+- `luc:facet` field arrays remain field IRIs
+- `luc:match` continues returning field IRIs
+
+`idx:fieldName` stays internal.
+
+### 3. Fixed Positional Signatures Only
+
+Parsing should be explicit and fixed-arity.
+
+Do not continue the current token-shape parsing approach where JSON shape, integer detection, or prefixes determine meaning.
+
+For the initial implementation, there should be no optional object arguments at all.
+
+Supported signatures should be a very small set of exact positional forms.
+
+For `luc:query`, the active signature should be:
+
+```sparql
+(?hit ?entity ?score ?totalHits ?graph)
+  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
+```
+
+Highlight is deferred. It should not participate in the active query signature for this first pass.
+
+For `luc:facet`, use exact positional signatures as well:
+
+```sparql
+(?field ?value ?count)
+  luc:facet (indexSelector fieldSpec queryString facetFields maxValues minCount)
+```
+
+```sparql
+(?field ?value ?count)
+  luc:facet (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)
+```
+
+and the corresponding 5-slot subject form for range facets.
+
+This means:
+
+- no short form
+- no omitted filter
+- no omitted sort
+- no omitted minCount
+- no omitted highlight
+
+If convenience forms are added later, they should come later as additional explicit signatures, not heuristic reinterpretations.
+
+### 4. Fail Fast On Arity
+
+For both property functions:
+
+- reject unsupported arities immediately
+- include expected arity/signature and actual arity in the error message
+- do not silently reinterpret argument lists
+
+## Required Code Changes
+
+### A. Index Resolution
+
+Update SHACL query/facet execution to resolve an explicit index selector instead of always using the default registry entry.
+
+Current main behavior to replace:
+
+- `ShaclTextQueryPF.chooseTextIndex()` calls `registry.getDefault()`
+- `TextFacetPF.chooseTextIndex()` calls `registry.getDefault()`
+
+Required changes:
+
+- support `indexSelector` as the first object argument
+- resolve by token id
+- resolve by canonical index IRI when available
+- raise a hard error for unknown selectors
+
+### B. Registry Model
+
+Extend `TextIndexRegistry` so it can resolve:
+
+- token selectors such as `"objects"`
+- canonical index IRIs
+
+The cache key in `SearchExecution` must include resolved index identity to avoid cross-index pollution.
+
+### C. Assembler Model
+
+Current main assembler still accepts:
+
+- legacy `text:index`
+- `text:indexes` as RDF list only
+
+Issue #21 direction should be reflected in the plan:
+
+- standardize on `text:indexes`
+- ideally allow `text:indexes :indexA`
+- also allow `text:indexes ( :indexA :indexB )`
+- require or derive `text:indexId`
+- reject duplicate index ids
+
+### D. Query Parser
+
+Update `ShaclTextQueryPF`:
+
+- prepend `indexSelector` before the current `fieldSpec`
+- keep `?hit` subject shape
+- remove `?match` from the subject shape
+- keep `luc:match` compatibility via `?hit`
+- remove heuristic argument interpretation in favor of exact signatures
+
+### E. Facet Parser
+
+Update `TextFacetPF`:
+
+- prepend `indexSelector` before the current `fieldSpec`
+- keep existing field-IRI-based `facetFields`
+- keep range-facet support
+- replace heuristic parsing with exact signatures
+
+### F. Shared Execution
+
+Update `SearchExecution` keying and creation so shared state includes:
+
+- resolved index identity
+- fieldSpec
+- query string
+- CQL filter
+- sort spec
+
+This preserves correct sharing between `luc:query`, `luc:facet`, and `luc:match`.
+
+## Tests To Update Or Add
+
+### Query
+
+- `luc:query` with explicit index selector and `"default"` fieldSpec
+- `luc:query` with explicit index selector and field-IRI array fieldSpec
+- unknown index selector error
+- wrong arity error
+- `luc:query` no longer binds `?match`
+- `luc:match` still joins correctly through `?hit`
+
+### Facets
+
+- `luc:facet` with explicit index selector
+- `luc:facet` with explicit index selector plus CQL filter
+- range facet requests with explicit index selector
+- wrong arity error
+
+### Multi-index
+
+- same query text against two different indexes does not share execution state
+- same fieldSpec/query/filter on different indexes produces different `SearchExecution` keys
+- duplicate `text:indexId` config error
+
+## Docs To Update
+
+At minimum:
+
+- `docs/01-user-guide.md`
+- `docs/02-sparql-api.md`
+- `docs/03-configuration.md`
+- `docs/README.md`
+
+The updated docs should reflect the current-main model plus the issue #21 delta:
+
+- `luc:query` uses `?hit` and no longer exposes `?match`
+- `luc:match` is the sole per-hit match-detail API
+- field references remain IRIs
+- index selector is now the first argument
+- `fieldSpec` moves to second position
+- object signatures are fixed-arity, with no optional args in the first implementation
+- highlight is deferred and should not be shown as part of the active supported syntax yet
+
+Also update:
+
+- `lucene_sparq_one_page.html`
+
+And move/roll that page into the demo app under `./demo` so it lives with the demo surface rather than at repository root.
+
+The one-page HTML doc should also explicitly document sort, which is currently easy to miss.
+
+## Summary
+
+On `main`, the right change is not "replace field names with IRIs" because that part is already done.
+
+The actual gap is:
+
+1. add explicit index selection ahead of the existing `fieldSpec`
+2. preserve the current `?hit` / `luc:match` model and remove `?match` from `luc:query`
+3. make parsing strict and positional
+4. make shared execution and cache keys index-aware
+5. document exact fixed signatures only, with sort included in the docs and one-page demo page

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,212 +1,80 @@
-# Jena Text Index: Faceting & Entity-Per-Document
+# Jena Text SHACL Docs
 
-This documentation covers the faceted search and entity-per-document indexing features added to Apache Jena's `jena-text` module.
+This doc set covers the SHACL/entity-per-document search model in `jena-text`.
 
-## Feature Overview
+## Status
 
-### Feature Status
+| Feature | Status | Notes |
+|---|---|---|
+| `luc:query` | Done | Fixed-position query API with explicit `indexSelector` and `fieldSpec` |
+| `luc:match` | Done | Sole per-hit match-detail API |
+| `luc:facet` | Done | Fixed-position facet API with field IRIs and range facets |
+| Multi-index selection | Done | Query-time `indexSelector` plus `text:indexes` config |
+| Field IRIs | Done | Public SPARQL uses field IRIs only |
+| Sort pushdown | Done | Sort specs use field IRIs in the public API |
+| Graph scoping model | Designed | Reserved synthetic field `urn:jena:lucene:field#sourceGraph`; implementation deferred |
+| Highlight API | Deferred | Reserved for later, not active in the current `luc:query` signature |
 
-| Feature | Status | SPARQL | Description |
-|---------|--------|--------|-------------|
-| Entity-per-document indexing | Done | — | SHACL shapes define entity types with typed fields (TEXT, KEYWORD, INT, LONG, DOUBLE, LATLON) |
-| Text search with filters | Done | `luc:query` | Full-text search with CQL2-JSON structured filters |
-| Facet counts | Done | `luc:facet` | Field value counts with maxValues, minCount controls |
-| Per-hit field match details | Done | `luc:match` | Join with `luc:query` via `?hit` to get which fields matched and their values |
-| Shared execution | Done | — | `luc:query` + `luc:facet` + `luc:match` share a single Lucene search when co-occurring |
-| Automatic index maintenance | Done | — | Change listener rebuilds entity docs on triple add/delete |
-| Inverse and sequence paths | Done | — | `sh:inversePath` and multi-hop sequence paths for cross-entity indexing |
-| Spatial filtering | Done | `luc:query`/`luc:facet` | Bounding-box and polygon filter via LatLonShape. See [Spatial Filtering](09-spatial.md) |
-| Field IRIs | Done | `luc:query`/`luc:facet` | Named field resources preserve their IRI; `?field` bindings return IRIs |
-| Hierarchical facets | Done | `luc:facet` | Taxonomy drill-down over ordered KEYWORD field hierarchies |
-| Range facets | Designed | `luc:facet` | Numeric bucket counts via range objects; range-capable queries use 5-slot facet rows |
-| DrillSideways | Proposed | `luc:facet` | Filtered dimension still shows all values (standard faceted UI pattern) |
-| Result grouping | Proposed | `luc:group` | Group search hits by field value |
-| Suggest / Autocomplete | Proposed | `luc:suggest` | Type-ahead completions via Lucene suggesters |
-| Bulk SHACL reindexer | Proposed | — | CLI tool for full reindex using SHACL shapes |
+## Core Rules
 
-Range facets extend `luc:facet` rather than introducing a separate PF. Existing 3-slot flat facet queries remain valid; range-capable facet requests use a 5-slot subject form.
+- `luc:query` object arguments are exactly `(indexSelector fieldSpec queryString cqlFilter sortSpec limit)`.
+- `luc:facet` object arguments are exactly `(indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)`.
+- `luc:query` does not expose `?match`.
+- `luc:match` is the only match-detail API.
+- Use `"null"` placeholders for unused `cqlFilter` and `sortSpec`.
+- Query-time field references are always field IRIs.
+- Graph filtering is intended to use a reserved synthetic field, not a dedicated result slot.
 
-Public API rule: external field references are always IRIs in `luc:query`, `luc:facet`, `luc:match`, CQL filter `property` entries, sort specs, and returned `?field` bindings. Internal Lucene field names from `idx:fieldName` remain implementation details, except for the special `"default"` fieldSpec shorthand and ordinary Lucene query strings supplied as search text.
+## Example
 
-### Component Architecture
+```sparql
+PREFIX luc: <urn:jena:lucene:index#>
 
-```mermaid
-graph TB
-    subgraph SPARQL["SPARQL Interface"]
-        LQ["luc:query<br/><i>search + CQL2-JSON filters</i>"]
-        LF["luc:facet<br/><i>field value counts and range buckets</i>"]
-    end
-
-    subgraph Execution["Query Execution"]
-        SE["SearchExecution<br/><i>shared state via ExecutionContext</i>"]
-        SQP["ShaclTextQueryPF"]
-        TFP["TextFacetPF"]
-    end
-
-    subgraph Index["Lucene Index"]
-        TIL["TextIndexLucene"]
-        FC["FacetsConfig + DocValues<br/><i>facets and numeric bucket sources</i>"]
-    end
-
-    subgraph Indexing["Index Maintenance"]
-        STDP["ShaclTextDocProducer<br/><i>change listener</i>"]
-        SIM["ShaclIndexMapping<br/><i>IndexProfile + FieldDef</i>"]
-    end
-
-    subgraph Config["Assembler Config (TTL)"]
-        TS["text:shapes<br/><i>SHACL entity-per-document</i>"]
-    end
-
-    subgraph Store["RDF Store"]
-        DS["TDB2 Dataset"]
-    end
-
-    LQ --> SQP
-    LF --> TFP
-    SQP --> SE
-    TFP --> SE
-    SE --> TIL
-    TIL --> FC
-
-    DS -- "triple change" --> STDP
-    STDP --> SIM
-    STDP -- "rebuild entity doc" --> TIL
-    SIM -- "field types, profiles" --> TIL
-
-    TS -- "parsed by ShaclIndexAssembler" --> SIM
-    style LQ fill:#1a6dd4,stroke:#0d4a94,color:#fff
-    style LF fill:#1a6dd4,stroke:#0d4a94,color:#fff
-    style SQP fill:#1a6dd4,stroke:#0d4a94,color:#fff
-    style TFP fill:#1a6dd4,stroke:#0d4a94,color:#fff
-    style SE fill:#1a6dd4,stroke:#0d4a94,color:#fff
-    style STDP fill:#1a6dd4,stroke:#0d4a94,color:#fff
-    style SIM fill:#1a6dd4,stroke:#0d4a94,color:#fff
-    style TS fill:#1a6dd4,stroke:#0d4a94,color:#fff
-    style FC fill:#1a6dd4,stroke:#0d4a94,color:#fff
-```
-
-See [Architecture](04-architecture.md) for detailed query flow and indexing flow diagrams. The upstream Jena `text:query` / `text:entityMap` (classic mode) is unchanged and still available but not shown here.
-
-### Roadmap
-
-```mermaid
-timeline
-    title Feature Roadmap
-    section Done
-        Entity-per-document indexing   : SHACL shapes, typed fields, change listener
-        luc꞉query with CQL2-JSON      : Full-text search with CQL2-JSON filters
-        luc꞉facet counts               : Field value counts with maxValues, minCount
-        Shared execution               : Single Lucene search shared across PFs
-        Inverse and sequence paths     : sh꞉inversePath and multi-hop sequence paths
-        Spatial filtering              : LatLonShape with bbox and polygon filters
-        Field IRIs                     : Named field resources, IRI bindings in query results
-        Hierarchical facets            : Taxonomy drill-down via luc꞉facet
-    section Proposed
-        DrillSideways                  : Standard faceted UI counting (opt-in on luc꞉facet)
-        Range facets                   : Numeric bucket counts via luc꞉facet range objects and 5-slot rows
-        Result grouping                : Group hits by field via luc꞉group
-        Suggest / Autocomplete         : Type-ahead via luc꞉suggest
-        Bulk SHACL reindexer           : CLI tool for full reindex
-```
-
-All proposed extensions are additive — no breaking changes to existing query or response models. See [Use Cases](08-use-cases.md) for how these features combine in a real application.
-
-## Documents
-
-| Document | Audience | Description |
-|----------|----------|-------------|
-| [User Guide](01-user-guide.md) | Users / Integrators | Configure, query, deploy with Fuseki, troubleshoot |
-| [SPARQL API Reference](02-sparql-api.md) | Users / Developers | `text:query`, `luc:query`, `luc:facet` syntax, Lucene query syntax, Java API |
-| [Configuration Reference](03-configuration.md) | Admins / Integrators | Assembler TTL config for both indexing modes |
-| [Architecture](04-architecture.md) | Developers | Internal design, document models, shared execution |
-| [Testing](05-testing.md) | Developers / QA | Test coverage, how to run tests |
-| [Design Decisions](06-design-decisions.md) | Developers / Reviewers | Why things are the way they are |
-| [Known Limitations & Future Work](07-future-work.md) | All | What's deferred, what needs attention |
-| [Use Cases](08-use-cases.md) | All / Business | Search portal example showing how features combine |
-| [Spatial Filtering](09-spatial.md) | Users / Developers | LatLonShape indexing, CQL2-JSON spatial queries |
-
-## Quick Start
-
-```turtle
-# Entity-per-document indexing with SHACL shapes
-text:shapes ( <#BookShape> ) ;
+SELECT ?entity ?score WHERE {
+  (?hit ?entity ?score)
+    luc:query ("default" "default" "learning" "null" "null" 20) .
+}
 ```
 
 ```sparql
 PREFIX luc: <urn:jena:lucene:index#>
 
-# Search
-(?s ?sc) luc:query ("machine learning") .
-
-# Facet counts (field IRIs in the JSON array)
-(?f ?v ?c) luc:facet ("default" "machine learning"
-    '["urn:jena:lucene:field#category"]' 10) .
-
-# Search with CQL2-JSON filter (field IRI as property)
-(?s ?sc) luc:query ("default" "learning"
-    '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}' 20) .
+SELECT ?entity ?field ?value WHERE {
+  (?hit ?entity ?score)
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+  (?hit ?field ?value) luc:match () .
+}
 ```
 
-## Build & Test
+```sparql
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?field ?value ?low ?high ?count WHERE {
+  (?field ?value ?low ?high ?count)
+    luc:facet (
+      "default"
+      "default"
+      "learning"
+      '["urn:jena:lucene:field#category"]'
+      "null"
+      10
+      0
+    ) .
+}
+```
+
+## Documents
+
+| Document | Purpose |
+|---|---|
+| [01-user-guide.md](01-user-guide.md) | Practical setup and query usage |
+| [02-sparql-api.md](02-sparql-api.md) | Full SHACL SPARQL signatures and examples |
+| [03-configuration.md](03-configuration.md) | Assembler and index configuration |
+| [04-architecture.md](04-architecture.md) | Internal design and execution flow |
+| [05-testing.md](05-testing.md) | Test coverage and commands |
+
+## Build And Test
 
 ```bash
-mvn test -pl jena-text                    # 366 tests
-mvn clean install -pl jena-fuseki2/jena-fuseki-server -am -DskipTests  # build Fuseki
+mvn -pl jena-text test
 ```
-
-## Archive
-
-Previous working documents, design reviews, and phase summaries are in [archive/](archive/).
-
-## What Changed
-
-Summary of additions to the upstream Apache Jena codebase as part of this work.
-
-### Java Source (`jena-text/src/main/java`) — 16 files, +2,594 lines
-
-**9 new classes:**
-
-| Class | Lines | Role |
-|-------|-------|------|
-| `TextIndexLucene` (extended) | +646 | SHACL faceting methods added to central index |
-| `ShaclTextQueryPF` | +340 | `luc:query` property function with JSON filter support |
-| `TextFacetPF` | +354 | `luc:facet` property function for facet counts |
-| `ShaclIndexAssembler` | +303 | Parses `text:shapes` RDF config into `ShaclIndexMapping` |
-| `ShaclTextDocProducer` | +191 | Change listener — rebuilds entity Lucene docs on triple changes |
-| `SearchExecution` | +188 | Shared execution state between `luc:query` and `luc:facet` |
-| `ShaclIndexMapping` | +186 | Data model: `IndexProfile`, `FieldDef`, `FieldType` enum |
-| `FacetedTextResults` | +106 | Result container for faceted search |
-| `FacetValue` | +73 | Immutable (value, count) pair |
-| `IndexVocab` | +67 | `urn:jena:lucene:index#` namespace constants |
-
-**7 modified classes** (additive only): `TextIndexConfig`, `Entity`, `TextQuery`, `TextVocab`, `TextDatasetAssembler`, `TextIndexLuceneAssembler`, `TextVocab`
-
-### Java Tests (`jena-text/src/test/java`) — 12 new files, +2,329 lines
-
-| Test Class | Tests | Coverage |
-|------------|-------|----------|
-| `TestTextFacetPF` | 7 | SPARQL `luc:facet` property function |
-| `TestNativeFacetCounts` | 10 | Java API facet operations |
-| `TestShaclEntityPerDocument` | 7 | End-to-end text search and facets |
-| `TestTextQueryPFFilters` | 6 | `luc:query` with JSON filters |
-| `TestShaclDocumentBuilding` | 11 | Lucene doc building, all field types |
-| `TestShaclTextDocProducer` | 5 | Change listener lifecycle |
-| `TestShaclIndexMapping` | 8 | Data model, predicate/class lookup |
-| `TestSearchExecution` | 6 | Shared execution key normalisation |
-| `TestShaclAssembler` | 3 | Config parsing |
-| `TestFacetedResults` | — | Faceted result container |
-| `TestUpdateDocumentFacets` | — | Document update with facets |
-| `TS_Text` (modified) | — | Suite registration for new tests |
-
-### Documentation (`docs/`) — 25 new files, +5,373 lines
-
-8 core docs (user guide, SPARQL API, configuration, architecture, testing, design decisions, future work) and 17 archive documents (design specs, review notes, phase summaries).
-
-### Totals
-
-| | Files | Lines |
-|---|---|---|
-| Java source | 16 (9 new, 7 modified) | +2,594 |
-| Java tests | 12 (all new) | +2,329 |
-| Documentation | 25 (all new) | +5,373 |
-| **Total** | **54** | **+10,299** |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,9 +21,10 @@ This doc set covers the SHACL/entity-per-document search model in `jena-text`.
 - `luc:facet` object arguments are exactly `(indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)`.
 - `luc:query` does not expose `?match`.
 - `luc:match` is the only match-detail API.
-- Use `"null"` placeholders for unused `cqlFilter` and `sortSpec`.
+- Use `""` placeholders for unused `cqlFilter` and `sortSpec`.
 - Query-time field references are always field IRIs.
 - Graph filtering is intended to use a reserved synthetic field, not a dedicated result slot.
+- `luc:facet` always uses the 5-slot subject form; flat facet rows leave `?low` and `?high` unbound.
 
 ## Example
 
@@ -32,7 +33,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" "default" "learning" "null" "null" 20) .
+    luc:query ("default" "default" "learning" "" "" 20) .
 }
 ```
 
@@ -41,7 +42,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?field ?value WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "null" "null" 10) .
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
   (?hit ?field ?value) luc:match () .
 }
 ```
@@ -56,7 +57,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
       "default"
       "learning"
       '["urn:jena:lucene:field#category"]'
-      "null"
+      ""
       10
       0
     ) .

--- a/jena-text/src/main/java/org/apache/jena/query/text/SearchExecution.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SearchExecution.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 public class SearchExecution {
     private static final Logger log = LoggerFactory.getLogger(SearchExecution.class);
 
+    private final String indexIdentity;
     private final List<String> searchFields;
     private final String queryString;
     private final CqlExpression filter;
@@ -58,9 +59,10 @@ public class SearchExecution {
     private boolean hitsComputed = false;
     private boolean searchHitsComputed = false;
 
-    public SearchExecution(List<String> searchFields, String queryString,
+    public SearchExecution(String indexIdentity, List<String> searchFields, String queryString,
                            CqlExpression filter, List<SortSpec> sortSpecs,
                            ShaclTextIndexLucene textIndex, String graphURI, String lang) {
+        this.indexIdentity = indexIdentity;
         this.searchFields = searchFields != null ? new ArrayList<>(searchFields) : new ArrayList<>();
         this.queryString = queryString;
         this.filter = filter;
@@ -75,12 +77,13 @@ public class SearchExecution {
      * If one already exists with the same key, it is reused.
      */
     public static SearchExecution getOrCreate(ExecutionContext execCxt,
+                                              String indexIdentity,
                                               List<String> searchFields,
                                               String queryString, CqlExpression filter,
                                               List<SortSpec> sortSpecs,
                                               ShaclTextIndexLucene textIndex,
                                               String graphURI, String lang) {
-        String key = buildKey(searchFields, queryString, filter, sortSpecs);
+        String key = buildKey(indexIdentity, searchFields, queryString, filter, sortSpecs);
         Symbol symbol = Symbol.create(TextQuery.NS + "searchExecution/" + key);
 
         Object existing = execCxt.getContext().get(symbol);
@@ -89,7 +92,7 @@ public class SearchExecution {
             return (SearchExecution) existing;
         }
 
-        SearchExecution se = new SearchExecution(searchFields, queryString, filter,
+        SearchExecution se = new SearchExecution(indexIdentity, searchFields, queryString, filter,
             sortSpecs, textIndex, graphURI, lang);
         execCxt.getContext().put(symbol, se);
         log.trace("Created new SearchExecution for key: {}", key);
@@ -99,15 +102,17 @@ public class SearchExecution {
     /**
      * Build a cache key from search fields, query string, CQL filter, and sort specs.
      */
-    static String buildKey(List<String> searchFields, String queryString,
+    static String buildKey(String indexIdentity, List<String> searchFields, String queryString,
                            CqlExpression filter, List<SortSpec> sortSpecs) {
         StringBuilder sb = new StringBuilder();
+
+        sb.append("index=").append(indexIdentity != null ? indexIdentity : TextIndexRegistry.DEFAULT_ID);
 
         if (searchFields != null && !searchFields.isEmpty()) {
             List<String> sorted = searchFields.stream()
                 .sorted()
                 .collect(Collectors.toList());
-            sb.append("fields=").append(String.join(",", sorted));
+            sb.append("|fields=").append(String.join(",", sorted));
         }
 
         sb.append("|qs=").append(queryString != null ? queryString : "");
@@ -206,6 +211,10 @@ public class SearchExecution {
 
     public CqlExpression getFilter() {
         return filter;
+    }
+
+    public String getIndexIdentity() {
+        return indexIdentity;
     }
 
     public String getQueryString() {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
@@ -58,18 +58,19 @@ import org.slf4j.LoggerFactory;
 /**
  * SPARQL property function for SHACL-mode text queries ({@code luc:query}).
  * <p>
- * Argument format:
+ * Supported argument format:
  * <pre>
- * (?hit ?entity ?score ?match ?totalHits ?graph) luc:query (fieldSpec queryString cqlFilter? sortSpec? limit?)
+ * (?hit ?entity ?score ?totalHits ?graph) luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
  * </pre>
  * <p>
  * {@code ?hit} is a query-scoped blank node identifier for joining with {@code luc:match}.
- * The first string literal is the field specification: {@code "default"} searches all
+ * The second string literal is the field specification: {@code "default"} searches all
  * defaultSearch fields, and a JSON array of field IRIs like
  * {@code '["urn:jena:lucene:field#title","urn:jena:lucene:field#description"]'} searches specific fields.
  */
 public class ShaclTextQueryPF extends PropertyFunctionBase {
     private static final Logger log = LoggerFactory.getLogger(ShaclTextQueryPF.class);
+    private static final int QUERY_ARG_ARITY = 6;
 
     private ShaclTextIndexLucene textIndex = null;
     private boolean warningIssued = false;
@@ -82,36 +83,46 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
 
         if (argSubject.isList()) {
             int size = argSubject.getArgListSize();
-            if (size == 0 || size > 6) {
-                throw new QueryBuildException("Subject has " + size + " elements, must be 1-6 " +
-                    "(?hit ?entity ?score ?match ?totalHits ?graph): " + argSubject);
+            if (size == 0 || size > 5) {
+                throw new QueryBuildException("Subject has " + size + " elements, must be 1-5 " +
+                    "(?hit ?entity ?score ?totalHits ?graph): " + argSubject);
             }
         }
 
-        if (argObject.isList()) {
-            List<Node> list = argObject.getArgList();
-            if (list.isEmpty()) {
-                throw new QueryBuildException("Zero-length argument list");
-            }
+        if (!argObject.isList()) {
+            throw new QueryBuildException("luc:query expects exactly " + QUERY_ARG_ARITY
+                + " object arguments: (indexSelector fieldSpec queryString cqlFilter sortSpec limit)");
+        }
+        int size = argObject.getArgListSize();
+        if (size != QUERY_ARG_ARITY) {
+            throw new QueryBuildException("luc:query expects exactly " + QUERY_ARG_ARITY
+                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit), got " + size);
         }
     }
 
-    private static ShaclTextIndexLucene chooseTextIndex(ExecutionContext execCxt, DatasetGraph dsg) {
+    private record ResolvedTextIndex(String identity, ShaclTextIndexLucene index) {}
+
+    private static ResolvedTextIndex chooseTextIndex(ExecutionContext execCxt, DatasetGraph dsg, String selector) {
         // Try registry first
         Object regObj = execCxt.getContext().get(TextQuery.textIndexRegistry);
         if (regObj instanceof TextIndexRegistry registry) {
-            TextIndexLucene idx = registry.getDefault();
+            TextIndexRegistry.ResolvedIndex resolved = registry.resolve(selector);
+            TextIndexLucene idx = resolved.index();
             if (idx instanceof ShaclTextIndexLucene shaclIdx) {
-                return shaclIdx;
+                return new ResolvedTextIndex(resolved.canonicalKey(), shaclIdx);
             }
             Log.warn(ShaclTextQueryPF.class, "Text index is not a ShaclTextIndexLucene");
             return null;
         }
 
         // Fall back to single index
+        if (!TextIndexRegistry.DEFAULT_ID.equals(selector)) {
+            throw new TextIndexException("Single-index datasets only support index selector \"" +
+                TextIndexRegistry.DEFAULT_ID + "\", got: " + selector);
+        }
         Object obj = execCxt.getContext().get(TextQuery.textIndex);
         if (obj instanceof ShaclTextIndexLucene shaclIdx) {
-            return shaclIdx;
+            return new ResolvedTextIndex(TextIndexRegistry.DEFAULT_ID, shaclIdx);
         }
         if (obj != null) {
             Log.warn(ShaclTextQueryPF.class, "Context setting '" + TextQuery.textIndex + "' is not a ShaclTextIndexLucene");
@@ -119,7 +130,7 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         if (dsg instanceof DatasetGraphText) {
             TextIndex ti = ((DatasetGraphText) dsg).getTextIndex();
             if (ti instanceof ShaclTextIndexLucene shaclIdx) {
-                return shaclIdx;
+                return new ResolvedTextIndex(TextIndexRegistry.DEFAULT_ID, shaclIdx);
             }
             Log.warn(ShaclTextQueryPF.class, "TextIndex is not a ShaclTextIndexLucene");
         }
@@ -142,8 +153,8 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         argSubject = Substitute.substitute(argSubject, binding);
         argObject = Substitute.substitute(argObject, binding);
 
-        // Subject shape: (?hit ?entity ?score ?match ?totalHits ?graph)
-        Node hit = null, entity = null, score = null, match = null, totalHitsNode = null, graph = null;
+        // Subject shape: (?hit ?entity ?score ?totalHits ?graph)
+        Node hit = null, entity = null, score = null, totalHitsNode = null, graph = null;
 
         if (argSubject.isList()) {
             hit = argSubject.getArg(0);
@@ -156,17 +167,12 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
                     throw new QueryExecException("Score is not a variable: " + argSubject);
             }
             if (argSubject.getArgListSize() > 3) {
-                match = argSubject.getArg(3);
-                if (!match.isVariable())
-                    throw new QueryExecException("Match is not a variable: " + argSubject);
-            }
-            if (argSubject.getArgListSize() > 4) {
-                totalHitsNode = argSubject.getArg(4);
+                totalHitsNode = argSubject.getArg(3);
                 if (!totalHitsNode.isVariable())
                     throw new QueryExecException("Total hits is not a variable: " + argSubject);
             }
-            if (argSubject.getArgListSize() > 5) {
-                graph = argSubject.getArg(5);
+            if (argSubject.getArgListSize() > 4) {
+                graph = argSubject.getArg(4);
                 if (!graph.isVariable())
                     throw new QueryExecException("Graph is not a variable: " + argSubject);
             }
@@ -181,19 +187,19 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         if (args == null)
             return IterLib.noResults(execCxt);
 
-        // Resolve text index (always uses default)
-        textIndex = chooseTextIndex(execCxt, execCxt.getDataset());
-        if (textIndex == null) {
+        ResolvedTextIndex resolvedTextIndex = chooseTextIndex(execCxt, execCxt.getDataset(), args.indexSelector);
+        if (resolvedTextIndex == null) {
             if (!warningIssued) {
                 Log.warn(getClass(), "No text index - no text search performed");
                 warningIssued = true;
             }
             return IterLib.result(binding, execCxt);
         }
+        textIndex = resolvedTextIndex.index();
 
         // Use SearchExecution for shared state with luc:facet and luc:match
         SearchExecution se = SearchExecution.getOrCreate(
-            execCxt, args.searchFields, args.queryString,
+            execCxt, resolvedTextIndex.identity(), args.searchFields, args.queryString,
             args.cqlFilter, args.sortSpecs, textIndex, null, null);
 
         int limit = args.limit > 0 ? args.limit : 10000;
@@ -213,7 +219,7 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         }
 
         long totalHits = totalHitsNode != null ? se.getTotalHits() : -1;
-        QueryIterator qIter = resultsToQueryIterator(binding, hit, entity, score, match,
+        QueryIterator qIter = resultsToQueryIterator(binding, hit, entity, score,
             totalHitsNode, totalHits, graph, hits, execCxt);
         if (args.limit >= 0)
             qIter = new QueryIterSlice(qIter, 0, args.limit, execCxt);
@@ -221,13 +227,12 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
     }
 
     private QueryIterator resultsToQueryIterator(Binding binding,
-                                                  Node hitNode, Node entityNode, Node scoreNode, Node matchNode,
+                                                  Node hitNode, Node entityNode, Node scoreNode,
                                                   Node totalHitsNode, long totalHits, Node graphNode,
                                                   Collection<SearchHit> results, ExecutionContext execCxt) {
         Var hitVar = Var.isVar(hitNode) ? Var.alloc(hitNode) : null;
         Var entityVar = (entityNode != null && Var.isVar(entityNode)) ? Var.alloc(entityNode) : null;
         Var scoreVar = (scoreNode == null) ? null : Var.alloc(scoreNode);
-        Var matchVar = (matchNode == null) ? null : Var.alloc(matchNode);
         Var totalHitsVar = (totalHitsNode == null) ? null : Var.alloc(totalHitsNode);
         Node totalHitsValue = totalHitsVar != null
             ? NodeFactory.createLiteralDT(String.valueOf(totalHits), XSDDatatype.XSDinteger) : null;
@@ -238,13 +243,6 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
             if (hitVar != null) bmap.add(hitVar, sh.getHitId());
             if (entityVar != null) bmap.add(entityVar, sh.getEntityNode());
             if (scoreVar != null) bmap.add(scoreVar, NodeFactoryExtra.floatToNode(sh.getScore()));
-            if (matchVar != null) {
-                // Bind ?match to the first field match value if available
-                List<FieldMatch> fieldMatches = sh.getFieldMatches();
-                if (!fieldMatches.isEmpty() && fieldMatches.get(0).getValue() != null) {
-                    bmap.add(matchVar, fieldMatches.get(0).getValue());
-                }
-            }
             if (totalHitsVar != null) bmap.add(totalHitsVar, totalHitsValue);
             if (graphVar != null && sh.getGraph() != null) bmap.add(graphVar, sh.getGraph());
             return bmap.build();
@@ -257,141 +255,91 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
     /**
      * Parse object arguments.
      * <p>
-     * Arg order: (fieldSpec queryString cqlFilter? sortSpec? limit? highlight?)
-     * <ul>
-     *   <li>First literal = field spec ("default", field name, or JSON array of field names)</li>
-     *   <li>Next plain literal = query string</li>
-     *   <li>JSON with "op" key = CQL filter</li>
-     *   <li>JSON with "field" key = sort spec</li>
-     *   <li>Integer = limit</li>
-     *   <li>"highlight:..." = highlight options</li>
-     * </ul>
+     * Arg order: (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
      */
     private QueryArgs parseArgs(PropFuncArg argObject) {
-        List<String> searchFields = new ArrayList<>();
-        String queryString = null;
-        CqlExpression cqlFilter = null;
-        List<SortSpec> sortSpecs = null;
-        int limit = -1;
-        String highlight = null;
-
-        if (argObject.isNode()) {
-            Node o = argObject.getArg();
-            if (!o.isLiteral()) {
-                log.warn("Object to luc:query is not a literal: " + argObject);
-                return null;
-            }
-            queryString = o.getLiteralLexicalForm();
-            searchFields.add("default");
-            return new QueryArgs(searchFields, queryString, cqlFilter, sortSpecs, limit, highlight);
+        if (!argObject.isList()) {
+            throw new QueryExecException("luc:query expects exactly " + QUERY_ARG_ARITY
+                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit)");
         }
-
         List<Node> list = argObject.getArgList();
-        if (list.isEmpty())
-            throw new TextIndexException("luc:query object list can not be empty");
-
-        int idx = 0;
-
-        // First literal = field spec: "default" or JSON array of field IRIs
-        if (idx < list.size() && list.get(idx).isLiteral()) {
-            String lex = list.get(idx).getLiteralLexicalForm();
-            if (lex.startsWith("[")) {
-                // JSON array of field IRIs
-                JsonArray arr = JSON.parseAny(lex).getAsArray();
-                for (int i = 0; i < arr.size(); i++) {
-                    searchFields.add(arr.get(i).getAsString().value());
-                }
-                idx++;
-            } else if ("default".equals(lex)) {
-                searchFields.add("default");
-                idx++;
-            }
+        if (list.size() != QUERY_ARG_ARITY) {
+            throw new QueryExecException("luc:query expects exactly " + QUERY_ARG_ARITY
+                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit), got " + list.size());
         }
 
-        // Query string (next non-JSON literal)
-        if (idx < list.size() && list.get(idx).isLiteral()) {
-            String lex = list.get(idx).getLiteralLexicalForm();
-            if (!lex.startsWith("{") && !lex.startsWith("[")) {
-                queryString = lex;
-                idx++;
-            }
-        }
+        String indexSelector = requireLiteralString(list.get(0), "indexSelector");
+        List<String> searchFields = new ArrayList<>();
+        parseFieldSpec(requireLiteralString(list.get(1), "fieldSpec"), searchFields);
+        String queryString = requireLiteralString(list.get(2), "queryString");
+        CqlExpression cqlFilter = parseCqlFilter(requireLiteralString(list.get(3), "cqlFilter"));
+        List<SortSpec> sortSpecs = parseSortSpec(requireLiteralString(list.get(4), "sortSpec"));
+        int limit = parseLimit(list.get(5));
 
-        if (queryString == null) {
-            log.warn("No query string in luc:query arguments: " + list);
+        return new QueryArgs(indexSelector, searchFields, queryString, cqlFilter, sortSpecs, limit);
+    }
+
+    private static String requireLiteralString(Node node, String label) {
+        if (!node.isLiteral()) {
+            throw new QueryExecException("luc:query " + label + " must be a literal, got: " + node);
+        }
+        return node.getLiteralLexicalForm();
+    }
+
+    private static void parseFieldSpec(String fieldSpec, List<String> searchFields) {
+        if ("default".equals(fieldSpec)) {
+            searchFields.add("default");
+            return;
+        }
+        if (!fieldSpec.startsWith("[")) {
+            throw new QueryExecException("luc:query fieldSpec must be \"default\" or a JSON array of field IRIs");
+        }
+        JsonArray arr = JSON.parseAny(fieldSpec).getAsArray();
+        for (int i = 0; i < arr.size(); i++) {
+            searchFields.add(arr.get(i).getAsString().value());
+        }
+    }
+
+    private static CqlExpression parseCqlFilter(String filterLex) {
+        if ("null".equals(filterLex)) {
             return null;
         }
-
-        if (searchFields.isEmpty()) {
-            searchFields.add("default");
-        }
-
-        // Remaining args: CQL filter, sort spec, limit, highlight
-        while (idx < list.size()) {
-            Node n = list.get(idx);
-            if (n.isLiteral()) {
-                String lex = n.getLiteralLexicalForm();
-                if (lex.startsWith("{")) {
-                    if (isCqlFilter(lex)) {
-                        cqlFilter = CqlParser.parse(lex);
-                    } else if (SortSpecParser.isSortSpec(lex)) {
-                        sortSpecs = SortSpecParser.parse(lex);
-                    }
-                } else if (lex.startsWith("[")) {
-                    // Array sort spec
-                    if (SortSpecParser.isSortSpec(lex)) {
-                        sortSpecs = SortSpecParser.parse(lex);
-                    }
-                } else if (lex.startsWith("highlight:")) {
-                    highlight = lex.substring("highlight:".length());
-                } else {
-                    try {
-                        int v = Integer.parseInt(lex);
-                        limit = (v < 0) ? -1 : v;
-                    } catch (NumberFormatException e) {
-                        try {
-                            int v = NodeFactoryExtra.nodeToInt(n);
-                            limit = (v < 0) ? -1 : v;
-                        } catch (Exception ex) {
-                            log.warn("Unexpected argument in luc:query: {}", lex);
-                        }
-                    }
-                }
-            }
-            idx++;
-        }
-
-        return new QueryArgs(searchFields, queryString, cqlFilter, sortSpecs, limit, highlight);
+        return CqlParser.parse(filterLex);
     }
 
-    /**
-     * Check if a JSON string is a CQL filter (has an "op" key).
-     */
-    private static boolean isCqlFilter(String json) {
-        return json.contains("\"op\"");
+    private static List<SortSpec> parseSortSpec(String sortLex) {
+        if ("null".equals(sortLex)) {
+            return null;
+        }
+        return SortSpecParser.parse(sortLex);
     }
 
-    private static boolean isJsonLike(String s) {
-        return s.startsWith("{") || s.startsWith("[");
+    private static int parseLimit(Node node) {
+        try {
+            int value = NodeFactoryExtra.nodeToInt(node);
+            return Math.max(value, -1);
+        } catch (Exception ex) {
+            throw new QueryExecException("luc:query limit must be an integer literal, got: " + node);
+        }
     }
 
     private static class QueryArgs {
+        final String indexSelector;
         final List<String> searchFields;
         final String queryString;
         final CqlExpression cqlFilter;
         final List<SortSpec> sortSpecs;
         final int limit;
-        final String highlight;
 
-        QueryArgs(List<String> searchFields, String queryString,
+        QueryArgs(String indexSelector, List<String> searchFields, String queryString,
                   CqlExpression cqlFilter, List<SortSpec> sortSpecs,
-                  int limit, String highlight) {
+                  int limit) {
+            this.indexSelector = indexSelector;
             this.searchFields = searchFields;
             this.queryString = queryString;
             this.cqlFilter = cqlFilter;
             this.sortSpecs = sortSpecs;
             this.limit = limit;
-            this.highlight = highlight;
         }
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
@@ -67,6 +67,7 @@ import org.slf4j.LoggerFactory;
  * The second string literal is the field specification: {@code "default"} searches all
  * defaultSearch fields, and a JSON array of field IRIs like
  * {@code '["urn:jena:lucene:field#title","urn:jena:lucene:field#description"]'} searches specific fields.
+ * Use the empty string literal ({@code ""}) when {@code cqlFilter} or {@code sortSpec} is intentionally absent.
  */
 public class ShaclTextQueryPF extends PropertyFunctionBase {
     private static final Logger log = LoggerFactory.getLogger(ShaclTextQueryPF.class);
@@ -111,8 +112,7 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
             if (idx instanceof ShaclTextIndexLucene shaclIdx) {
                 return new ResolvedTextIndex(resolved.canonicalKey(), shaclIdx);
             }
-            Log.warn(ShaclTextQueryPF.class, "Text index is not a ShaclTextIndexLucene");
-            return null;
+            throw new TextIndexException("Selected text index is not SHACL-enabled: " + selector);
         }
 
         // Fall back to single index
@@ -125,14 +125,14 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
             return new ResolvedTextIndex(TextIndexRegistry.DEFAULT_ID, shaclIdx);
         }
         if (obj != null) {
-            Log.warn(ShaclTextQueryPF.class, "Context setting '" + TextQuery.textIndex + "' is not a ShaclTextIndexLucene");
+            throw new TextIndexException("Configured text index is not SHACL-enabled");
         }
         if (dsg instanceof DatasetGraphText) {
             TextIndex ti = ((DatasetGraphText) dsg).getTextIndex();
             if (ti instanceof ShaclTextIndexLucene shaclIdx) {
                 return new ResolvedTextIndex(TextIndexRegistry.DEFAULT_ID, shaclIdx);
             }
-            Log.warn(ShaclTextQueryPF.class, "TextIndex is not a ShaclTextIndexLucene");
+            throw new TextIndexException("Dataset text index is not SHACL-enabled");
         }
         Log.warn(ShaclTextQueryPF.class, "Failed to find the text index");
         return null;
@@ -301,14 +301,14 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
     }
 
     private static CqlExpression parseCqlFilter(String filterLex) {
-        if ("null".equals(filterLex)) {
+        if (filterLex.isEmpty()) {
             return null;
         }
         return CqlParser.parse(filterLex);
     }
 
     private static List<SortSpec> parseSortSpec(String sortLex) {
-        if ("null".equals(sortLex)) {
+        if (sortLex.isEmpty()) {
             return null;
         }
         return SortSpecParser.parse(sortLex);
@@ -316,9 +316,9 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
 
     private static int parseLimit(Node node) {
         try {
-            int value = NodeFactoryExtra.nodeToInt(node);
+            int value = Integer.parseInt(requireLiteralString(node, "limit"));
             return Math.max(value, -1);
-        } catch (Exception ex) {
+        } catch (NumberFormatException ex) {
             throw new QueryExecException("luc:query limit must be an integer literal, got: " + node);
         }
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
@@ -106,8 +106,7 @@ public class TextFacetPF extends PropertyFunctionBase {
             if (idx instanceof ShaclTextIndexLucene shaclIdx) {
                 return new ResolvedTextIndex(resolved.canonicalKey(), shaclIdx);
             }
-            Log.warn(TextFacetPF.class, "Text index is not a ShaclTextIndexLucene - faceting not supported");
-            return null;
+            throw new TextIndexException("Selected text index is not SHACL-enabled: " + selector);
         }
 
         // Fall back to single index
@@ -120,14 +119,14 @@ public class TextFacetPF extends PropertyFunctionBase {
             return new ResolvedTextIndex(TextIndexRegistry.DEFAULT_ID, shaclIdx);
         }
         if (obj != null) {
-            Log.warn(TextFacetPF.class, "Context setting '" + TextQuery.textIndex + "' is not a ShaclTextIndexLucene");
+            throw new TextIndexException("Configured text index is not SHACL-enabled");
         }
         if (dsg instanceof DatasetGraphText) {
             TextIndex ti = ((DatasetGraphText) dsg).getTextIndex();
             if (ti instanceof ShaclTextIndexLucene shaclIdx) {
                 return new ResolvedTextIndex(TextIndexRegistry.DEFAULT_ID, shaclIdx);
             }
-            Log.warn(TextFacetPF.class, "TextIndex is not a ShaclTextIndexLucene - faceting not supported");
+            throw new TextIndexException("Dataset text index is not SHACL-enabled");
         }
         Log.warn(TextFacetPF.class, "Failed to find the text index");
         return null;
@@ -297,7 +296,7 @@ public class TextFacetPF extends PropertyFunctionBase {
     }
 
     private static CqlExpression parseCqlFilter(String filterLex) {
-        if ("null".equals(filterLex)) {
+        if (filterLex.isEmpty()) {
             return null;
         }
         return CqlParser.parse(filterLex);

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
@@ -56,14 +56,15 @@ import org.slf4j.LoggerFactory;
  * <p>
  * <b>Syntax:</b>
  * <pre>
- * (?field ?value ?low ?high ?count) luc:facet (...)
+ * (?field ?value ?low ?high ?count) luc:facet (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)
  * </pre>
  * <p>
- * The first string literal is the field specification for text query scoping
+ * The second string literal is the field specification for text query scoping
  * (same as luc:query). CQL filters are JSON objects with an {@code "op"} key.
  */
 public class TextFacetPF extends PropertyFunctionBase {
     private static final Logger log = LoggerFactory.getLogger(TextFacetPF.class);
+    private static final int FACET_ARG_ARITY = 7;
 
     private ShaclTextIndexLucene textIndex = null;
     private boolean warningIssued = false;
@@ -83,30 +84,40 @@ public class TextFacetPF extends PropertyFunctionBase {
             throw new QueryBuildException("Subject must be a 5-element variable list: (field value low high count)");
         }
 
-        if (argObject.isList()) {
-            List<Node> list = argObject.getArgList();
-            if (list.isEmpty()) {
-                throw new QueryBuildException("Object list must contain at least a query string and facet fields");
-            }
+        if (!argObject.isList()) {
+            throw new QueryBuildException("luc:facet expects exactly " + FACET_ARG_ARITY
+                + " object arguments: (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)");
+        }
+        int size = argObject.getArgListSize();
+        if (size != FACET_ARG_ARITY) {
+            throw new QueryBuildException("luc:facet expects exactly " + FACET_ARG_ARITY
+                + " object arguments (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount), got " + size);
         }
     }
 
-    private static ShaclTextIndexLucene chooseTextIndex(ExecutionContext execCxt, DatasetGraph dsg) {
+    private record ResolvedTextIndex(String identity, ShaclTextIndexLucene index) {}
+
+    private static ResolvedTextIndex chooseTextIndex(ExecutionContext execCxt, DatasetGraph dsg, String selector) {
         // Try registry first
         Object regObj = execCxt.getContext().get(TextQuery.textIndexRegistry);
         if (regObj instanceof TextIndexRegistry registry) {
-            TextIndexLucene idx = registry.getDefault();
+            TextIndexRegistry.ResolvedIndex resolved = registry.resolve(selector);
+            TextIndexLucene idx = resolved.index();
             if (idx instanceof ShaclTextIndexLucene shaclIdx) {
-                return shaclIdx;
+                return new ResolvedTextIndex(resolved.canonicalKey(), shaclIdx);
             }
             Log.warn(TextFacetPF.class, "Text index is not a ShaclTextIndexLucene - faceting not supported");
             return null;
         }
 
         // Fall back to single index
+        if (!TextIndexRegistry.DEFAULT_ID.equals(selector)) {
+            throw new TextIndexException("Single-index datasets only support index selector \"" +
+                TextIndexRegistry.DEFAULT_ID + "\", got: " + selector);
+        }
         Object obj = execCxt.getContext().get(TextQuery.textIndex);
         if (obj instanceof ShaclTextIndexLucene shaclIdx) {
-            return shaclIdx;
+            return new ResolvedTextIndex(TextIndexRegistry.DEFAULT_ID, shaclIdx);
         }
         if (obj != null) {
             Log.warn(TextFacetPF.class, "Context setting '" + TextQuery.textIndex + "' is not a ShaclTextIndexLucene");
@@ -114,7 +125,7 @@ public class TextFacetPF extends PropertyFunctionBase {
         if (dsg instanceof DatasetGraphText) {
             TextIndex ti = ((DatasetGraphText) dsg).getTextIndex();
             if (ti instanceof ShaclTextIndexLucene shaclIdx) {
-                return shaclIdx;
+                return new ResolvedTextIndex(TextIndexRegistry.DEFAULT_ID, shaclIdx);
             }
             Log.warn(TextFacetPF.class, "TextIndex is not a ShaclTextIndexLucene - faceting not supported");
         }
@@ -139,15 +150,15 @@ public class TextFacetPF extends PropertyFunctionBase {
             return IterLib.noResults(execCxt);
         }
 
-        // Resolve text index (always uses default)
-        textIndex = chooseTextIndex(execCxt, execCxt.getDataset());
-        if (textIndex == null) {
+        ResolvedTextIndex resolvedTextIndex = chooseTextIndex(execCxt, execCxt.getDataset(), args.indexSelector);
+        if (resolvedTextIndex == null) {
             if (!warningIssued) {
                 Log.warn(getClass(), "No text index - no facet counts available");
                 warningIssued = true;
             }
             return IterLib.noResults(execCxt);
         }
+        textIndex = resolvedTextIndex.index();
 
         if (!textIndex.isFacetingEnabled()) {
             Log.warn(getClass(), "Faceting is not enabled on this text index. Configure facet fields in the index definition.");
@@ -163,7 +174,7 @@ public class TextFacetPF extends PropertyFunctionBase {
                 validatedArgs.searchFields, validatedArgs.cqlFilter, validatedArgs.queryString, validatedArgs.facetRequest);
 
             SearchExecution se = SearchExecution.getOrCreate(
-                execCxt, validatedArgs.searchFields, validatedArgs.queryString,
+                execCxt, resolvedTextIndex.identity(), validatedArgs.searchFields, validatedArgs.queryString,
                 validatedArgs.cqlFilter, null, textIndex, null, null);
             facetCounts = se.getFacetCounts(validatedArgs.facetRequest, validatedArgs.maxValues, validatedArgs.minCount);
         } catch (Exception e) {
@@ -236,79 +247,68 @@ public class TextFacetPF extends PropertyFunctionBase {
     /**
      * Parse the object argument list.
      * <p>
-     * Arg order: (fieldSpec queryString facetFields cqlFilter? maxValues? minCount?)
+     * Arg order: (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)
      */
     private FacetArgs parseObjectArgs(PropFuncArg argObject) {
+        if (!argObject.isList()) {
+            throw new QueryExecException("luc:facet expects exactly " + FACET_ARG_ARITY
+                + " object arguments (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)");
+        }
+        List<Node> list = argObject.getArgList();
+        if (list.size() != FACET_ARG_ARITY) {
+            throw new QueryExecException("luc:facet expects exactly " + FACET_ARG_ARITY
+                + " object arguments (indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount), got " + list.size());
+        }
+
+        String indexSelector = requireLiteralString(list.get(0), "indexSelector");
         List<String> searchFields = new ArrayList<>();
-        String queryString = null;
         List<String> facetFields = new ArrayList<>();
         List<FacetRequest.RangeFacetSpec> rangeFields = new ArrayList<>();
-        CqlExpression cqlFilter = null;
-        int maxValues = 10;
-        int minCount = 0;
-        boolean maxValuesSet = false;
+        parseFieldSpec(requireLiteralString(list.get(1), "fieldSpec"), searchFields);
+        String queryString = requireLiteralString(list.get(2), "queryString");
+        parseFacetRequestArray(requireLiteralString(list.get(3), "facetFields"), facetFields, rangeFields);
+        CqlExpression cqlFilter = parseCqlFilter(requireLiteralString(list.get(4), "cqlFilter"));
+        int maxValues = parseInteger(list.get(5), "maxValues");
+        int minCount = parseInteger(list.get(6), "minCount");
 
-        if (argObject.isNode()) {
-            log.warn("luc:facet requires at least a query string and facet fields");
+        return new FacetArgs(indexSelector, searchFields, queryString,
+            new FacetRequest(facetFields, rangeFields), cqlFilter, maxValues, minCount);
+    }
+
+    private static String requireLiteralString(Node node, String label) {
+        if (!node.isLiteral()) {
+            throw new QueryExecException("luc:facet " + label + " must be a literal, got: " + node);
+        }
+        return node.getLiteralLexicalForm();
+    }
+
+    private static void parseFieldSpec(String fieldSpec, List<String> searchFields) {
+        if ("default".equals(fieldSpec)) {
+            searchFields.add("default");
+            return;
+        }
+        if (!fieldSpec.startsWith("[")) {
+            throw new QueryExecException("luc:facet fieldSpec must be \"default\" or a JSON array of field IRIs");
+        }
+        JsonArray arr = JSON.parseAny(fieldSpec).getAsArray();
+        for (int i = 0; i < arr.size(); i++) {
+            searchFields.add(arr.get(i).getAsString().value());
+        }
+    }
+
+    private static CqlExpression parseCqlFilter(String filterLex) {
+        if ("null".equals(filterLex)) {
             return null;
         }
+        return CqlParser.parse(filterLex);
+    }
 
-        List<Node> list = argObject.getArgList();
-        int idx = 0;
-
-        // 1. First literal = field spec: "default" or JSON array of field IRIs
-        if (idx < list.size() && list.get(idx).isLiteral()) {
-            String lex = list.get(idx).getLiteralLexicalForm();
-            if ("default".equals(lex)) {
-                searchFields.add("default");
-                idx++;
-            }
+    private static int parseInteger(Node node, String label) {
+        try {
+            return Integer.parseInt(requireLiteralString(node, label));
+        } catch (NumberFormatException ex) {
+            throw new QueryExecException("luc:facet " + label + " must be an integer literal, got: " + node);
         }
-
-        // 2. Query string (first non-JSON, non-integer literal)
-        if (idx < list.size() && list.get(idx).isLiteral()) {
-            String lex = list.get(idx).getLiteralLexicalForm();
-            if (!lex.startsWith("[") && !lex.startsWith("{") && !isInteger(lex)) {
-                queryString = lex;
-                idx++;
-            }
-        }
-
-        if (searchFields.isEmpty()) {
-            searchFields.add("default");
-        }
-
-        // 3. Parse remaining: JSON arrays (facet fields), JSON objects (CQL), and integers
-        while (idx < list.size()) {
-            Node n = list.get(idx);
-            if (n.isLiteral()) {
-                String lex = n.getLiteralLexicalForm();
-                if (lex.startsWith("[")) {
-                    parseFacetRequestArray(lex, facetFields, rangeFields);
-                } else if (lex.startsWith("{")) {
-                    // JSON object: CQL filter (has "op" key)
-                    if (lex.contains("\"op\"")) {
-                        cqlFilter = CqlParser.parse(lex);
-                    }
-                } else if (isInteger(lex)) {
-                    if (!maxValuesSet) {
-                        maxValues = Integer.parseInt(lex);
-                        maxValuesSet = true;
-                    } else {
-                        minCount = Integer.parseInt(lex);
-                    }
-                } else {
-                    if (queryString == null) {
-                        queryString = lex;
-                    } else {
-                        log.warn("Unexpected argument in luc:facet: {}", lex);
-                    }
-                }
-            }
-            idx++;
-        }
-
-        return new FacetArgs(searchFields, queryString, new FacetRequest(facetFields, rangeFields), cqlFilter, maxValues, minCount);
     }
 
     private void parseFacetRequestArray(String json, List<String> facetFields, List<FacetRequest.RangeFacetSpec> rangeFields) {
@@ -374,7 +374,7 @@ public class TextFacetPF extends PropertyFunctionBase {
             validatedRanges.add(spec);
         }
 
-        return new FacetArgs(args.searchFields, args.queryString, new FacetRequest(validatedFlatFields, validatedRanges),
+        return new FacetArgs(args.indexSelector, args.searchFields, args.queryString, new FacetRequest(validatedFlatFields, validatedRanges),
             args.cqlFilter, args.maxValues, args.minCount);
     }
 
@@ -447,16 +447,8 @@ public class TextFacetPF extends PropertyFunctionBase {
         return node;
     }
 
-    private static boolean isInteger(String s) {
-        try {
-            Integer.parseInt(s);
-            return true;
-        } catch (NumberFormatException e) {
-            return false;
-        }
-    }
-
     private static class FacetArgs {
+        final String indexSelector;
         final List<String> searchFields;
         final String queryString;
         final FacetRequest facetRequest;
@@ -464,8 +456,9 @@ public class TextFacetPF extends PropertyFunctionBase {
         final int maxValues;
         final int minCount;
 
-        FacetArgs(List<String> searchFields, String queryString, FacetRequest facetRequest,
+        FacetArgs(String indexSelector, List<String> searchFields, String queryString, FacetRequest facetRequest,
                   CqlExpression cqlFilter, int maxValues, int minCount) {
+            this.indexSelector = indexSelector;
             this.searchFields = searchFields;
             this.queryString = queryString;
             this.facetRequest = facetRequest;

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexRegistry.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexRegistry.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Named registry of {@link TextIndexLucene} instances for multi-index support.
@@ -34,9 +35,40 @@ import java.util.Map;
  */
 public class TextIndexRegistry {
 
+    public static final class ResolvedIndex {
+        private final String canonicalKey;
+        private final TextIndexLucene index;
+
+        private ResolvedIndex(String canonicalKey, TextIndexLucene index) {
+            this.canonicalKey = canonicalKey;
+            this.index = index;
+        }
+
+        public String canonicalKey() {
+            return canonicalKey;
+        }
+
+        public TextIndexLucene index() {
+            return index;
+        }
+    }
+
+    private static final class Entry {
+        private final String id;
+        private final String canonicalKey;
+        private final TextIndexLucene index;
+
+        private Entry(String id, String canonicalKey, TextIndexLucene index) {
+            this.id = id;
+            this.canonicalKey = canonicalKey;
+            this.index = index;
+        }
+    }
+
     public static final String DEFAULT_ID = "default";
 
     private final Map<String, TextIndexLucene> indexes = new LinkedHashMap<>();
+    private final Map<String, Entry> selectors = new LinkedHashMap<>();
     private String defaultId;
 
     public TextIndexRegistry() {}
@@ -51,7 +83,31 @@ public class TextIndexRegistry {
     }
 
     public void register(String id, TextIndexLucene index) {
+        register(id, null, index);
+    }
+
+    public void register(String id, String canonicalIri, TextIndexLucene index) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(index, "index");
+        String canonicalKey = canonicalIri != null ? canonicalIri : id;
+
+        Entry existingById = selectors.get(id);
+        if (existingById != null && existingById.index != index) {
+            throw new TextIndexException("Duplicate text index selector: " + id);
+        }
+        if (canonicalIri != null) {
+            Entry existingByIri = selectors.get(canonicalIri);
+            if (existingByIri != null && existingByIri.index != index) {
+                throw new TextIndexException("Duplicate text index selector: " + canonicalIri);
+            }
+        }
+
         indexes.put(id, index);
+        Entry entry = new Entry(id, canonicalKey, index);
+        selectors.put(id, entry);
+        if (canonicalIri != null) {
+            selectors.put(canonicalIri, entry);
+        }
         if (defaultId == null) {
             defaultId = id;
         }
@@ -65,11 +121,26 @@ public class TextIndexRegistry {
         return idx;
     }
 
+    public ResolvedIndex resolve(String selector) {
+        Entry entry = selectors.get(selector);
+        if (entry == null) {
+            throw new TextIndexException("No text index registered with selector: " + selector);
+        }
+        return new ResolvedIndex(entry.canonicalKey, entry.index);
+    }
+
     public TextIndexLucene getDefault() {
         if (defaultId == null) {
             throw new TextIndexException("No text indexes registered");
         }
         return indexes.get(defaultId);
+    }
+
+    public ResolvedIndex getDefaultResolved() {
+        if (defaultId == null) {
+            throw new TextIndexException("No text indexes registered");
+        }
+        return resolve(defaultId);
     }
 
     public String getDefaultId() {

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexRegistry.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexRegistry.java
@@ -92,12 +92,12 @@ public class TextIndexRegistry {
         String canonicalKey = canonicalIri != null ? canonicalIri : id;
 
         Entry existingById = selectors.get(id);
-        if (existingById != null && existingById.index != index) {
+        if (existingById != null && !Objects.equals(existingById.canonicalKey, canonicalKey)) {
             throw new TextIndexException("Duplicate text index selector: " + id);
         }
         if (canonicalIri != null) {
             Entry existingByIri = selectors.get(canonicalIri);
-            if (existingByIri != null && existingByIri.index != index) {
+            if (existingByIri != null && !Objects.equals(existingByIri.id, id)) {
                 throw new TextIndexException("Duplicate text index selector: " + canonicalIri);
             }
         }

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextDatasetAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextDatasetAssembler.java
@@ -30,7 +30,9 @@ import static org.apache.jena.query.text.assembler.TextVocab.textDataset;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.assembler.Mode;
@@ -100,19 +102,25 @@ public class TextDatasetAssembler extends DatasetAssembler implements Assembler 
     private Dataset openMultiIndex(Assembler a, Resource root, Mode mode,
                                     Dataset ds, Statement indexesStmt, Resource textDocProducerNode) {
         RDFNode indexesNode = indexesStmt.getObject();
-        if (!indexesNode.canAs(RDFList.class)) {
-            throw new TextIndexException("text:indexes must be an RDF list: " + indexesNode);
+        List<Resource> indexResources = new ArrayList<>();
+        if (indexesNode.isResource() && !indexesNode.canAs(RDFList.class)) {
+            indexResources.add(indexesNode.asResource());
+        } else if (indexesNode.canAs(RDFList.class)) {
+            RDFList indexesList = indexesNode.as(RDFList.class);
+            for (RDFNode node : indexesList.asJavaList()) {
+                if (!node.isResource()) {
+                    throw new TextIndexException("Each element of text:indexes must be a resource: " + node);
+                }
+                indexResources.add(node.asResource());
+            }
+        } else {
+            throw new TextIndexException("text:indexes must be a resource or an RDF list: " + indexesNode);
         }
-
-        RDFList indexesList = indexesNode.as(RDFList.class);
         TextIndexRegistry registry = new TextIndexRegistry();
         List<TextDocProducer> producers = new ArrayList<>();
+        Set<String> seenIds = new HashSet<>();
 
-        for (RDFNode node : indexesList.asJavaList()) {
-            if (!node.isResource()) {
-                throw new TextIndexException("Each element of text:indexes must be a resource: " + node);
-            }
-            Resource indexRes = node.asResource();
+        for (Resource indexRes : indexResources) {
             TextIndex textIndex = (TextIndex) a.open(indexRes);
 
             if (!(textIndex instanceof TextIndexLucene luceneIndex)) {
@@ -128,7 +136,11 @@ public class TextDatasetAssembler extends DatasetAssembler implements Assembler 
                 indexId = indexRes.isURIResource() ? indexRes.getLocalName() : "index_" + registry.size();
             }
 
-            registry.register(indexId, luceneIndex);
+            if (!seenIds.add(indexId)) {
+                throw new TextIndexException("Duplicate text:indexId: " + indexId);
+            }
+
+            registry.register(indexId, indexRes.isURIResource() ? indexRes.getURI() : null, luceneIndex);
 
             // Create doc producer for this index
             if (luceneIndex instanceof ShaclTextIndexLucene shaclIndex) {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
@@ -437,7 +437,7 @@ public class TestDemoMiningScenarios {
     public void testFacetCountsCommodity() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "commodity\"]' \"null\" 20 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "commodity\"]' \"\" 20 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -451,7 +451,7 @@ public class TestDemoMiningScenarios {
     public void testFacetCountsState() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "state\"]' \"null\" 20 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "state\"]' \"\" 20 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -472,7 +472,7 @@ public class TestDemoMiningScenarios {
     public void testFacetCountsMultipleFields() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "state\", \"" + FP + "commodity\"]' \"null\" 20 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "state\", \"" + FP + "commodity\"]' \"\" 20 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -518,7 +518,7 @@ public class TestDemoMiningScenarios {
     public void testFacetWildcardExpandsAllFields() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"*\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"*\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -548,7 +548,7 @@ public class TestDemoMiningScenarios {
         // Verify wildcard returns same results as listing all facetable fields explicitly
         String wildcardSparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"*\"]' \"null\" 0 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"*\"]' \"\" 0 0)\n" +
             "}";
         String explicitSparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
@@ -558,7 +558,7 @@ public class TestDemoMiningScenarios {
             FP + "state\", \"" +
             FP + "operator\", \"" +
             FP + "status\", \"" +
-            FP + "authorName\"]' \"null\" 0 0)\n" +
+            FP + "authorName\"]' \"\" 0 0)\n" +
             "}";
 
         Map<String, Map<String, Long>> wildcardResults = facetResultMap(wildcardSparql);
@@ -578,7 +578,7 @@ public class TestDemoMiningScenarios {
         // Wildcard facets with text search for "copper"
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"copper\" '[\"*\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"copper\" '[\"*\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -634,7 +634,7 @@ public class TestDemoMiningScenarios {
     public void testAuthorNameFacetCounts() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "authorName\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "authorName\"]' \"\" 10 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -669,9 +669,9 @@ public class TestDemoMiningScenarios {
     public void testCombinedQueryAndFacet() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?entity ?score ?f ?v ?low ?high ?c WHERE {\n" +
-            "  { (?hit ?entity ?score) luc:query (\"default\" \"default\" \"iron ore\" \"null\" \"null\" 20) }\n" +
+            "  { (?hit ?entity ?score) luc:query (\"default\" \"default\" \"iron ore\" \"\" \"\" 20) }\n" +
             "  UNION\n" +
-            "  { (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"iron ore\" '[\"" + FP + "state\"]' \"null\" 10 0) }\n" +
+            "  { (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"iron ore\" '[\"" + FP + "state\"]' \"\" 10 0) }\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -717,7 +717,7 @@ public class TestDemoMiningScenarios {
     public void testEntityTypeDistribution() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "entityType\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "entityType\"]' \"\" 10 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -735,8 +735,8 @@ public class TestDemoMiningScenarios {
         sb.append("PREFIX luc: <urn:jena:lucene:index#>\n");
         sb.append("SELECT ?s WHERE {\n");
         sb.append("  (?hit ?s ?score) luc:query (\"default\" \"default\" \"").append(queryText).append("\" ");
-        sb.append(filter != null ? "'" + filter + "'" : "\"null\"");
-        sb.append(" \"null\" ").append(limit).append(")\n}");
+        sb.append(filter != null ? "'" + filter + "'" : "\"\"");
+        sb.append(" \"\" ").append(limit).append(")\n}");
 
         Set<String> results = new HashSet<>();
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
@@ -437,7 +437,7 @@ public class TestDemoMiningScenarios {
     public void testFacetCountsCommodity() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"" + FP + "commodity\"]' 20)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "commodity\"]' \"null\" 20 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -451,7 +451,7 @@ public class TestDemoMiningScenarios {
     public void testFacetCountsState() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"" + FP + "state\"]' 20)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "state\"]' \"null\" 20 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -472,7 +472,7 @@ public class TestDemoMiningScenarios {
     public void testFacetCountsMultipleFields() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"" + FP + "state\", \"" + FP + "commodity\"]' 20)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "state\", \"" + FP + "commodity\"]' \"null\" 20 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -500,8 +500,8 @@ public class TestDemoMiningScenarios {
         // Facets for Gold entities only
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"" + FP + "state\"]' " +
-            "'{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "commodity\"},\"" + EX + "commodity/Gold\"]}' 20)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "state\"]' " +
+            "'{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "commodity\"},\"" + EX + "commodity/Gold\"]}' 20 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -518,7 +518,7 @@ public class TestDemoMiningScenarios {
     public void testFacetWildcardExpandsAllFields() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"*\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"*\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -548,17 +548,17 @@ public class TestDemoMiningScenarios {
         // Verify wildcard returns same results as listing all facetable fields explicitly
         String wildcardSparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"*\"]' 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"*\"]' \"null\" 0 0)\n" +
             "}";
         String explicitSparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" +
             FP + "entityType\", \"" +
             FP + "commodity\", \"" +
             FP + "state\", \"" +
             FP + "operator\", \"" +
             FP + "status\", \"" +
-            FP + "authorName\"]' 0)\n" +
+            FP + "authorName\"]' \"null\" 0 0)\n" +
             "}";
 
         Map<String, Map<String, Long>> wildcardResults = facetResultMap(wildcardSparql);
@@ -578,7 +578,7 @@ public class TestDemoMiningScenarios {
         // Wildcard facets with text search for "copper"
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"copper\" '[\"*\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"copper\" '[\"*\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -605,8 +605,8 @@ public class TestDemoMiningScenarios {
         // Wildcard facets with CQL filter
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"*\"]' " +
-            "'{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "state\"},\"" + EX + "state/WA\"]}' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"*\"]' " +
+            "'{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "state\"},\"" + EX + "state/WA\"]}' 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -634,7 +634,7 @@ public class TestDemoMiningScenarios {
     public void testAuthorNameFacetCounts() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"" + FP + "authorName\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "authorName\"]' \"null\" 10 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -669,9 +669,9 @@ public class TestDemoMiningScenarios {
     public void testCombinedQueryAndFacet() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?entity ?score ?f ?v ?low ?high ?c WHERE {\n" +
-            "  { (?hit ?entity ?score) luc:query (\"default\" \"iron ore\" 20) }\n" +
+            "  { (?hit ?entity ?score) luc:query (\"default\" \"default\" \"iron ore\" \"null\" \"null\" 20) }\n" +
             "  UNION\n" +
-            "  { (?f ?v ?low ?high ?c) luc:facet (\"default\" \"iron ore\" '[\"" + FP + "state\"]' 10) }\n" +
+            "  { (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"iron ore\" '[\"" + FP + "state\"]' \"null\" 10 0) }\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -717,7 +717,7 @@ public class TestDemoMiningScenarios {
     public void testEntityTypeDistribution() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"*\" '[\"" + FP + "entityType\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"*\" '[\"" + FP + "entityType\"]' \"null\" 10 0)\n" +
             "}";
 
         Map<String, Long> counts = facetCountMap(sparql);
@@ -734,11 +734,9 @@ public class TestDemoMiningScenarios {
         StringBuilder sb = new StringBuilder();
         sb.append("PREFIX luc: <urn:jena:lucene:index#>\n");
         sb.append("SELECT ?s WHERE {\n");
-        sb.append("  (?hit ?s ?score) luc:query (\"default\" \"").append(queryText).append("\"");
-        if (filter != null) {
-            sb.append(" '").append(filter).append("'");
-        }
-        sb.append(" ").append(limit).append(")\n}");
+        sb.append("  (?hit ?s ?score) luc:query (\"default\" \"default\" \"").append(queryText).append("\" ");
+        sb.append(filter != null ? "'" + filter + "'" : "\"null\"");
+        sb.append(" \"null\" ").append(limit).append(")\n}");
 
         Set<String> results = new HashSet<>();
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java
@@ -147,7 +147,7 @@ public class TestHierarchicalFacetsSparql {
         // Requesting the type field (level 0) returns top-level hierarchy values.
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n"
             + "SELECT ?field ?value ?low ?high ?count WHERE {\n"
-            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"*\" '[\"urn:jena:lucene:field#type\"]' 10)\n"
+            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"default\" \"*\" '[\"urn:jena:lucene:field#type\"]' \"null\" 10 0)\n"
             + "}";
 
         dataset.begin(ReadWrite.READ);
@@ -174,10 +174,10 @@ public class TestHierarchicalFacetsSparql {
         // auto-detects hierarchy membership and returns subtype children under Water.
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n"
             + "SELECT ?field ?value ?low ?high ?count WHERE {\n"
-            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"*\""
+            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"default\" \"*\""
             + " '[\"urn:jena:lucene:field#subtype\"]'"
             + " '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#type\"},\"Water\"]}'"
-            + " 10)\n"
+            + " 10 0)\n"
             + "}";
 
         dataset.begin(ReadWrite.READ);
@@ -203,7 +203,7 @@ public class TestHierarchicalFacetsSparql {
         // Flat facets (type, subtype) should still work alongside hierarchy
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n"
             + "SELECT ?field ?value ?low ?high ?count WHERE {\n"
-            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"*\" '[\"type\"]' 10)\n"
+            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"default\" \"*\" '[\"urn:jena:lucene:field#type\"]' \"null\" 10 0)\n"
             + "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java
@@ -147,7 +147,7 @@ public class TestHierarchicalFacetsSparql {
         // Requesting the type field (level 0) returns top-level hierarchy values.
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n"
             + "SELECT ?field ?value ?low ?high ?count WHERE {\n"
-            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"default\" \"*\" '[\"urn:jena:lucene:field#type\"]' \"null\" 10 0)\n"
+            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"default\" \"*\" '[\"urn:jena:lucene:field#type\"]' \"\" 10 0)\n"
             + "}";
 
         dataset.begin(ReadWrite.READ);
@@ -203,7 +203,7 @@ public class TestHierarchicalFacetsSparql {
         // Flat facets (type, subtype) should still work alongside hierarchy
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n"
             + "SELECT ?field ?value ?low ?high ?count WHERE {\n"
-            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"default\" \"*\" '[\"urn:jena:lucene:field#type\"]' \"null\" 10 0)\n"
+            + "  (?field ?value ?low ?high ?count) luc:facet (\"default\" \"default\" \"*\" '[\"urn:jena:lucene:field#type\"]' \"\" 10 0)\n"
             + "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
@@ -210,7 +210,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'Pilbara' \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'Pilbara' \"\" \"\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -236,7 +236,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'GSWA' \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'GSWA' \"\" \"\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -288,7 +288,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "' \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "' \"\" \"\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
@@ -210,7 +210,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"urn:jena:lucene:field#label\"]' 'Pilbara') .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'Pilbara' \"null\" \"null\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -236,7 +236,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"urn:jena:lucene:field#label\"]' 'GSWA') .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'GSWA' \"null\" \"null\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -288,7 +288,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "') .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "' \"null\" \"null\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSearchExecution.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSearchExecution.java
@@ -38,8 +38,8 @@ public class TestSearchExecution {
         List<String> fields1 = Arrays.asList("description", "title");
         List<String> fields2 = Arrays.asList("title", "description");
 
-        String key1 = SearchExecution.buildKey(fields1, "test query", null, null);
-        String key2 = SearchExecution.buildKey(fields2, "test query", null, null);
+        String key1 = SearchExecution.buildKey("default", fields1, "test query", null, null);
+        String key2 = SearchExecution.buildKey("default", fields2, "test query", null, null);
 
         assertEquals("Key should be the same regardless of field order", key1, key2);
     }
@@ -49,24 +49,24 @@ public class TestSearchExecution {
         CqlExpression filter1 = new CqlExpression.CqlComparison("=", "state", "WA");
         CqlExpression filter2 = new CqlExpression.CqlComparison("=", "state", "WA");
 
-        String key1 = SearchExecution.buildKey(null, "test", filter1, null);
-        String key2 = SearchExecution.buildKey(null, "test", filter2, null);
+        String key1 = SearchExecution.buildKey("default", null, "test", filter1, null);
+        String key2 = SearchExecution.buildKey("default", null, "test", filter2, null);
 
         assertEquals("Same CQL filter should produce same key", key1, key2);
     }
 
     @Test
     public void testBuildKeyDifferentQueries() {
-        String key1 = SearchExecution.buildKey(null, "query1", null, null);
-        String key2 = SearchExecution.buildKey(null, "query2", null, null);
+        String key1 = SearchExecution.buildKey("default", null, "query1", null, null);
+        String key2 = SearchExecution.buildKey("default", null, "query2", null, null);
 
         assertNotEquals("Different queries should produce different keys", key1, key2);
     }
 
     @Test
     public void testBuildKeyDifferentFields() {
-        String key1 = SearchExecution.buildKey(List.of("title"), "test", null, null);
-        String key2 = SearchExecution.buildKey(List.of("description"), "test", null, null);
+        String key1 = SearchExecution.buildKey("default", List.of("title"), "test", null, null);
+        String key2 = SearchExecution.buildKey("default", List.of("description"), "test", null, null);
 
         assertNotEquals("Different fields should produce different keys", key1, key2);
     }
@@ -76,24 +76,25 @@ public class TestSearchExecution {
         List<SortSpec> sort1 = List.of(new SortSpec("year", true));
         List<SortSpec> sort2 = List.of(new SortSpec("year", false));
 
-        String key1 = SearchExecution.buildKey(null, "test", null, sort1);
-        String key2 = SearchExecution.buildKey(null, "test", null, sort2);
+        String key1 = SearchExecution.buildKey("default", null, "test", null, sort1);
+        String key2 = SearchExecution.buildKey("default", null, "test", null, sort2);
 
         assertNotEquals("Different sort specs should produce different keys", key1, key2);
     }
 
     @Test
     public void testBuildKeyNullFields() {
-        String key1 = SearchExecution.buildKey(null, "test", null, null);
-        String key2 = SearchExecution.buildKey(new ArrayList<>(), "test", null, null);
+        String key1 = SearchExecution.buildKey("default", null, "test", null, null);
+        String key2 = SearchExecution.buildKey("default", new ArrayList<>(), "test", null, null);
 
         assertEquals("Null and empty fields should produce the same key", key1, key2);
     }
 
     @Test
     public void testBuildKeyNullQuery() {
-        String key = SearchExecution.buildKey(null, null, null, null);
+        String key = SearchExecution.buildKey("default", null, null, null, null);
         assertNotNull(key);
+        assertTrue(key.contains("index=default"));
         assertTrue(key.contains("|qs="));
     }
 
@@ -106,10 +107,18 @@ public class TestSearchExecution {
         CqlExpression and1 = new CqlExpression.CqlAnd(List.of(a, b));
         CqlExpression and2 = new CqlExpression.CqlAnd(List.of(b, a));
 
-        String key1 = SearchExecution.buildKey(null, "test", and1, null);
-        String key2 = SearchExecution.buildKey(null, "test", and2, null);
+        String key1 = SearchExecution.buildKey("default", null, "test", and1, null);
+        String key2 = SearchExecution.buildKey("default", null, "test", and2, null);
 
         assertEquals("AND with different arg order should produce same key", key1, key2);
+    }
+
+    @Test
+    public void testBuildKeyDifferentIndexes() {
+        String key1 = SearchExecution.buildKey("reports", null, "test", null, null);
+        String key2 = SearchExecution.buildKey("ocr", null, "test", null, null);
+
+        assertNotEquals("Different index identities should produce different keys", key1, key2);
     }
 
     @Test

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
@@ -148,7 +148,7 @@ public class TestShaclEntityPerDocument {
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <" + NS + ">\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine learning\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine learning\" \"\" \"\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
@@ -148,7 +148,7 @@ public class TestShaclEntityPerDocument {
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <" + NS + ">\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('default' 'machine learning') .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine learning\" \"null\" \"null\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
@@ -111,10 +111,11 @@ public class TestShaclLucQueryRawValueOnMultiValuedField {
     }
 
     @Test
-    public void testLucQueryReturnsMatchedRawValueForMultiValuedField() {
+    public void testLucMatchReturnsMatchedValueForMultiValuedField() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?matchRaw WHERE {\n" +
-            "  (?hit ?s ?score ?matchRaw) luc:query ('[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?field ?matchRaw) luc:match ()\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
@@ -114,7 +114,7 @@ public class TestShaclLucQueryRawValueOnMultiValuedField {
     public void testLucMatchReturnsMatchedValueForMultiValuedField() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?matchRaw WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" \"\" \"\" 10) .\n" +
             "  (?hit ?field ?matchRaw) luc:match ()\n" +
             "}";
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
@@ -191,7 +191,7 @@ public class TestShaclPathSupport {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('default' 'machine') .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"null\" \"null\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -241,7 +241,7 @@ public class TestShaclPathSupport {
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <" + NS + ">\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('default' 'machine') .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"null\" \"null\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -301,7 +301,7 @@ public class TestShaclPathSupport {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('default' 'learning OR physics OR deep' '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#authorName\"},\"Jane Smith\"]}') .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning OR physics OR deep\" '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#authorName\"},\"Jane Smith\"]}' \"null\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
@@ -191,7 +191,7 @@ public class TestShaclPathSupport {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -241,7 +241,7 @@ public class TestShaclPathSupport {
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <" + NS + ">\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -301,7 +301,7 @@ public class TestShaclPathSupport {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning OR physics OR deep\" '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#authorName\"},\"Jane Smith\"]}' \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning OR physics OR deep\" '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#authorName\"},\"Jane Smith\"]}' \"\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
@@ -140,7 +140,7 @@ public class TestTextFacetPF {
     public void testBasicFacetCounts() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "category\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -166,7 +166,7 @@ public class TestTextFacetPF {
     public void testFacetFieldIsURI() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "category\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -189,7 +189,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMultipleFields() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "category\", \"" + FP + "author\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\", \"" + FP + "author\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -216,7 +216,7 @@ public class TestTextFacetPF {
     public void testFacetWildcard() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"*\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"*\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -243,7 +243,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithFilters() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "author\"]' '{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "category\"},\"" + NS + "category/technology\"]}' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' '{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "category\"},\"" + NS + "category/technology\"]}' 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -267,7 +267,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMaxValues() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "author\"]' 1)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 1 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -290,7 +290,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMinCount() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "author\"]' 10 2)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 10 2)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -315,7 +315,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMaxValuesZero() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "author\"]' 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 0 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -338,7 +338,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMinCountAndMaxValues() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "author\"]' 0 2)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 0 2)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -364,7 +364,7 @@ public class TestTextFacetPF {
     public void testRangeFacetFiveSlotBindings() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[{\"field\":\"" + FP + "year\",\"ranges\":[null,2020,2023,null]}]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[{\"field\":\"" + FP + "year\",\"ranges\":[null,2020,2023,null]}]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -390,7 +390,7 @@ public class TestTextFacetPF {
     public void testMixedFlatAndRangeFacets() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "category\", {\"field\":\"" + FP + "year\",\"ranges\":[null,2020,2023,null]}]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\", {\"field\":\"" + FP + "year\",\"ranges\":[null,2020,2023,null]}]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -425,7 +425,7 @@ public class TestTextFacetPF {
     public void testNumericFacetFieldBareStringRejected() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "year\"]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "year\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -445,7 +445,7 @@ public class TestTextFacetPF {
     public void testThreeSlotSubjectRejected() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?c WHERE {\n" +
-            "  (?f ?v ?c) luc:facet (\"default\" \"learning\" '[\"" + FP + "author\"]' 10)\n" +
+            "  (?f ?v ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -467,7 +467,7 @@ public class TestTextFacetPF {
     public void testRangeObjectOnNonNumericFieldRejected() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"learning\" '[{\"field\":\"" + FP + "category\",\"ranges\":[1,2]}]' 10)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[{\"field\":\"" + FP + "category\",\"ranges\":[1,2]}]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -487,8 +487,8 @@ public class TestTextFacetPF {
     public void testDifferentFacetRequestsDoNotReuseStaleCache() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT DISTINCT ?f1 ?f2 WHERE {\n" +
-            "  (?f1 ?v1 ?low1 ?high1 ?c1) luc:facet (\"default\" \"learning\" '[\"" + FP + "category\"]' 10) .\n" +
-            "  (?f2 ?v2 ?low2 ?high2 ?c2) luc:facet (\"default\" \"learning\" '[\"" + FP + "author\"]' 10)\n" +
+            "  (?f1 ?v1 ?low1 ?high1 ?c1) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"null\" 10 0) .\n" +
+            "  (?f2 ?v2 ?low2 ?high2 ?c2) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
@@ -140,7 +140,7 @@ public class TestTextFacetPF {
     public void testBasicFacetCounts() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -163,10 +163,36 @@ public class TestTextFacetPF {
     }
 
     @Test
+    public void testFlatFacetRowsLeaveLowAndHighUnbound() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"\" \"10\" \"0\")\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                int count = 0;
+                while (rs.hasNext()) {
+                    QuerySolution sol = rs.next();
+                    assertTrue("Flat facet rows should bind ?value", sol.contains("v"));
+                    assertFalse("Flat facet rows should leave ?low unbound", sol.contains("low"));
+                    assertFalse("Flat facet rows should leave ?high unbound", sol.contains("high"));
+                    count++;
+                }
+                assertTrue("Should have flat facet rows", count > 0);
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
     public void testFacetFieldIsURI() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -189,7 +215,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMultipleFields() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\", \"" + FP + "author\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\", \"" + FP + "author\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -216,7 +242,7 @@ public class TestTextFacetPF {
     public void testFacetWildcard() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"*\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"*\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -267,7 +293,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMaxValues() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 1 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"\" 1 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -290,7 +316,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMinCount() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 10 2)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"\" 10 2)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -315,7 +341,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMaxValuesZero() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 0 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"\" 0 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -338,7 +364,7 @@ public class TestTextFacetPF {
     public void testFacetCountsWithMinCountAndMaxValues() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 0 2)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"\" 0 2)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -364,7 +390,7 @@ public class TestTextFacetPF {
     public void testRangeFacetFiveSlotBindings() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[{\"field\":\"" + FP + "year\",\"ranges\":[null,2020,2023,null]}]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[{\"field\":\"" + FP + "year\",\"ranges\":[null,2020,2023,null]}]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -390,7 +416,7 @@ public class TestTextFacetPF {
     public void testMixedFlatAndRangeFacets() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\", {\"field\":\"" + FP + "year\",\"ranges\":[null,2020,2023,null]}]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\", {\"field\":\"" + FP + "year\",\"ranges\":[null,2020,2023,null]}]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -425,7 +451,7 @@ public class TestTextFacetPF {
     public void testNumericFacetFieldBareStringRejected() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "year\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "year\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -445,7 +471,7 @@ public class TestTextFacetPF {
     public void testThreeSlotSubjectRejected() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?c WHERE {\n" +
-            "  (?f ?v ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 10 0)\n" +
+            "  (?f ?v ?c) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -467,7 +493,7 @@ public class TestTextFacetPF {
     public void testRangeObjectOnNonNumericFieldRejected() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
-            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[{\"field\":\"" + FP + "category\",\"ranges\":[1,2]}]' \"null\" 10 0)\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[{\"field\":\"" + FP + "category\",\"ranges\":[1,2]}]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -487,8 +513,8 @@ public class TestTextFacetPF {
     public void testDifferentFacetRequestsDoNotReuseStaleCache() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT DISTINCT ?f1 ?f2 WHERE {\n" +
-            "  (?f1 ?v1 ?low1 ?high1 ?c1) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"null\" 10 0) .\n" +
-            "  (?f2 ?v2 ?low2 ?high2 ?c2) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"null\" 10 0)\n" +
+            "  (?f1 ?v1 ?low1 ?high1 ?c1) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "category\"]' \"\" 10 0) .\n" +
+            "  (?f2 ?v2 ?low2 ?high2 ?c2) luc:facet (\"default\" \"default\" \"learning\" '[\"" + FP + "author\"]' \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextIndexRegistry.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextIndexRegistry.java
@@ -85,6 +85,17 @@ public class TestTextIndexRegistry {
         assertEquals("urn:example:index:reports", resolved.canonicalKey());
     }
 
+    @Test
+    public void testReregisterSameLogicalIndexSelector() {
+        TextIndexRegistry reg = new TextIndexRegistry();
+        reg.register("reports", "urn:example:index:reports", index1);
+        reg.register("reports", "urn:example:index:reports", index2);
+
+        TextIndexRegistry.ResolvedIndex resolved = reg.resolve("reports");
+        assertSame(index2, resolved.index());
+        assertEquals("urn:example:index:reports", resolved.canonicalKey());
+    }
+
     @Test(expected = TextIndexException.class)
     public void testGetNonexistent() {
         TextIndexRegistry reg = TextIndexRegistry.single(index1);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextIndexRegistry.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextIndexRegistry.java
@@ -75,6 +75,16 @@ public class TestTextIndexRegistry {
         assertEquals("reports", reg.getDefaultId());
     }
 
+    @Test
+    public void testResolveByCanonicalIri() {
+        TextIndexRegistry reg = new TextIndexRegistry();
+        reg.register("reports", "urn:example:index:reports", index1);
+
+        TextIndexRegistry.ResolvedIndex resolved = reg.resolve("urn:example:index:reports");
+        assertSame(index1, resolved.index());
+        assertEquals("urn:example:index:reports", resolved.canonicalKey());
+    }
+
     @Test(expected = TextIndexException.class)
     public void testGetNonexistent() {
         TextIndexRegistry reg = TextIndexRegistry.single(index1);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
@@ -123,7 +123,7 @@ public class TestTextMatchPF {
     public void testMatchReturnsSingleFieldForSingleFieldQuery() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -151,7 +151,7 @@ public class TestTextMatchPF {
         // Verify that ?hit from luc:query joins correctly with luc:match
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?field WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -175,7 +175,7 @@ public class TestTextMatchPF {
         // Use OPTIONAL so hits without field matches still appear
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10) .\n" +
             "  OPTIONAL { (?hit ?field ?value) luc:match () . }\n" +
             "}";
 
@@ -200,7 +200,7 @@ public class TestTextMatchPF {
         // For TEXT fields, ?value should be a literal
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"\" \"\" 10) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -238,7 +238,7 @@ public class TestTextMatchPF {
     public void testHitIdIsBlankNode() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
@@ -123,7 +123,7 @@ public class TestTextMatchPF {
     public void testMatchReturnsSingleFieldForSingleFieldQuery() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"null\" \"null\" 10) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -151,7 +151,7 @@ public class TestTextMatchPF {
         // Verify that ?hit from luc:query joins correctly with luc:match
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?field WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('default' \"machine\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"null\" \"null\" 10) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -175,7 +175,7 @@ public class TestTextMatchPF {
         // Use OPTIONAL so hits without field matches still appear
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('default' \"learning\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"null\" \"null\" 10) .\n" +
             "  OPTIONAL { (?hit ?field ?value) luc:match () . }\n" +
             "}";
 
@@ -200,7 +200,7 @@ public class TestTextMatchPF {
         // For TEXT fields, ?value should be a literal
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"null\" \"null\" 10) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -238,7 +238,7 @@ public class TestTextMatchPF {
     public void testHitIdIsBlankNode() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('default' \"learning\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"null\" \"null\" 10) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -52,6 +52,7 @@ public class TestTextQueryPFFilters {
     private static final Node TITLE_PRED = NodeFactory.createURI(NS + "title");
     private static final Node CATEGORY_PRED = NodeFactory.createURI(NS + "category");
     private static final Node AUTHOR_PRED = NodeFactory.createURI(NS + "author");
+    private static final Node YEAR_PRED = NodeFactory.createURI(NS + "year");
 
     private Dataset dataset;
 
@@ -71,11 +72,15 @@ public class TestTextQueryPFFilters {
             true, true, true, false, false, false,
             Collections.singleton(AUTHOR_PRED));
 
+        FieldDef yearField = new FieldDef("year", FieldType.INT, null,
+            true, true, false, true, false, false,
+            Collections.singleton(YEAR_PRED));
+
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, authorField));
+            Arrays.asList(titleField, categoryField, authorField, yearField));
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -101,23 +106,24 @@ public class TestTextQueryPFFilters {
         dataset.begin(ReadWrite.WRITE);
         try {
             Model model = dataset.getDefaultModel();
-            addBook(model, "doc1", "Introduction to Machine Learning", NS + "category/technology", NS + "author/Smith");
-            addBook(model, "doc2", "Deep Learning Neural Networks", NS + "category/technology", NS + "author/Jones");
-            addBook(model, "doc3", "Machine Learning for Beginners", NS + "category/technology", NS + "author/Smith");
-            addBook(model, "doc4", "Learning About Quantum Physics", NS + "category/science", NS + "author/Wilson");
-            addBook(model, "doc5", "Machine Learning in Biology", NS + "category/science", NS + "author/Smith");
+            addBook(model, "doc1", "Introduction to Machine Learning", NS + "category/technology", NS + "author/Smith", 2018);
+            addBook(model, "doc2", "Deep Learning Neural Networks", NS + "category/technology", NS + "author/Jones", 2021);
+            addBook(model, "doc3", "Machine Learning for Beginners", NS + "category/technology", NS + "author/Smith", 2022);
+            addBook(model, "doc4", "Learning About Quantum Physics", NS + "category/science", NS + "author/Wilson", 2019);
+            addBook(model, "doc5", "Machine Learning in Biology", NS + "category/science", NS + "author/Smith", 2024);
             dataset.commit();
         } finally {
             dataset.end();
         }
     }
 
-    private void addBook(Model model, String id, String title, String categoryUri, String authorUri) {
+    private void addBook(Model model, String id, String title, String categoryUri, String authorUri, int year) {
         Resource book = ResourceFactory.createResource(NS + id);
         model.add(book, RDF.type, ResourceFactory.createResource(NS + "Book"));
         model.add(book, ResourceFactory.createProperty(NS + "title"), title);
         model.add(book, ResourceFactory.createProperty(NS + "category"), ResourceFactory.createResource(categoryUri));
         model.add(book, ResourceFactory.createProperty(NS + "author"), ResourceFactory.createResource(authorUri));
+        model.add(book, ResourceFactory.createProperty(NS + "year"), ResourceFactory.createTypedLiteral(year));
     }
 
     @After
@@ -401,6 +407,56 @@ public class TestTextQueryPFFilters {
                 for (String s : subjects) {
                     assertFalse("Should not find doc4 (science)", s.equals(NS + "doc4"));
                 }
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testLucQuerySortDescendingByFieldIri() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "PREFIX ex: <http://example.org/>\n" +
+            "SELECT ?s ?year WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" '{\"field\":\"urn:jena:lucene:field#year\",\"order\":\"desc\"}' 10) .\n" +
+            "  ?s ex:year ?year .\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                List<Integer> years = new ArrayList<>();
+                while (rs.hasNext()) {
+                    years.add(rs.next().getLiteral("year").getInt());
+                }
+                assertEquals(Arrays.asList(2024, 2022, 2021, 2019, 2018), years);
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testLucQuerySortAscendingWithFilter() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "PREFIX ex: <http://example.org/>\n" +
+            "SELECT ?s ?year WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' " +
+            "    '{\"field\":\"urn:jena:lucene:field#year\",\"order\":\"asc\"}' 10) .\n" +
+            "  ?s ex:year ?year .\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                List<Integer> years = new ArrayList<>();
+                while (rs.hasNext()) {
+                    years.add(rs.next().getLiteral("year").getInt());
+                }
+                assertEquals(Arrays.asList(2018, 2021, 2022), years);
             }
         } finally {
             dataset.end();

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -131,7 +131,7 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithoutFilters() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"null\" \"null\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -156,8 +156,8 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithCqlEqualFilter() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' 20)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"null\" 20)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -183,11 +183,11 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithCqlAndFilter() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" " +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
             "    '{\"op\":\"and\",\"args\":[" +
             "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}," +
             "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#author\"},\"http://example.org/author/Smith\"]}" +
-            "    ]}' 20)\n" +
+            "    ]}' \"null\" 20)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -213,8 +213,8 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithCqlNoMatches() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/nonexistent\"]}' 20)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/nonexistent\"]}' \"null\" 20)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -233,7 +233,7 @@ public class TestTextQueryPFFilters {
         // Search only the "title" field via its IRI (JSON array)
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"null\" \"null\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -258,7 +258,7 @@ public class TestTextQueryPFFilters {
         // Search multiple fields via JSON array of IRIs
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"null\" \"null\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -282,7 +282,7 @@ public class TestTextQueryPFFilters {
         // Search a single field and check that luc:match returns ?field bound to the field IRI
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?score ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"null\" \"null\" 10) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -307,11 +307,11 @@ public class TestTextQueryPFFilters {
     }
 
     @Test
-    public void testLucQueryLiteralBinding() {
-        // ?lit should be populated with the stored value from the matched field
+    public void testLucQueryTotalHitsBinding() {
+        // The fourth luc:query slot now binds ?totalHits rather than a raw match literal
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
-            "SELECT ?s ?score ?lit WHERE {\n" +
-            "  (?hit ?s ?score ?lit) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" 10)\n" +
+            "SELECT ?s ?score ?totalHits WHERE {\n" +
+            "  (?hit ?s ?score ?totalHits) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"null\" \"null\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -321,11 +321,10 @@ public class TestTextQueryPFFilters {
                 int count = 0;
                 while (rs.hasNext()) {
                     QuerySolution sol = rs.next();
-                    assertNotNull("?lit should be bound", sol.get("lit"));
-                    assertTrue("?lit should be a literal for TEXT field",
-                        sol.get("lit").isLiteral());
-                    assertTrue("?lit should contain 'Machine'",
-                        sol.getLiteral("lit").getString().contains("Machine"));
+                    assertNotNull("?totalHits should be bound", sol.get("totalHits"));
+                    assertTrue("?totalHits should be a literal", sol.get("totalHits").isLiteral());
+                    assertTrue("?totalHits should be positive",
+                        sol.getLiteral("totalHits").getInt() > 0);
                     count++;
                 }
                 assertTrue("Should find results", count > 0);
@@ -340,7 +339,7 @@ public class TestTextQueryPFFilters {
         // With "default", luc:match should still return field matches
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"learning\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"null\" \"null\" 10) .\n" +
             "  OPTIONAL { (?hit ?field ?value) luc:match () . }\n" +
             "}";
 
@@ -367,8 +366,8 @@ public class TestTextQueryPFFilters {
         // Search specific field (by IRI) with CQL filter
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query ('[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' 20)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" " +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"null\" 20)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -131,7 +131,7 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithoutFilters() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"null\" \"null\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -153,11 +153,29 @@ public class TestTextQueryPFFilters {
     }
 
     @Test
+    public void testLucQueryAcceptsEmptyPlaceholdersAndStringLimit() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s ?score WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" \"10\")\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                assertTrue("Empty placeholders and a string limit should still yield results", rs.hasNext());
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
     public void testLucQueryWithCqlEqualFilter() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
             "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"null\" 20)\n" +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"\" 20)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -187,7 +205,7 @@ public class TestTextQueryPFFilters {
             "    '{\"op\":\"and\",\"args\":[" +
             "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}," +
             "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#author\"},\"http://example.org/author/Smith\"]}" +
-            "    ]}' \"null\" 20)\n" +
+            "    ]}' \"\" 20)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -214,7 +232,7 @@ public class TestTextQueryPFFilters {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
             "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/nonexistent\"]}' \"null\" 20)\n" +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/nonexistent\"]}' \"\" 20)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -233,7 +251,7 @@ public class TestTextQueryPFFilters {
         // Search only the "title" field via its IRI (JSON array)
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"null\" \"null\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -258,7 +276,7 @@ public class TestTextQueryPFFilters {
         // Search multiple fields via JSON array of IRIs
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"null\" \"null\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -282,7 +300,7 @@ public class TestTextQueryPFFilters {
         // Search a single field and check that luc:match returns ?field bound to the field IRI
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?score ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -311,7 +329,7 @@ public class TestTextQueryPFFilters {
         // The fourth luc:query slot now binds ?totalHits rather than a raw match literal
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score ?totalHits WHERE {\n" +
-            "  (?hit ?s ?score ?totalHits) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"null\" \"null\" 10)\n" +
+            "  (?hit ?s ?score ?totalHits) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"\" \"\" 10)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -339,7 +357,7 @@ public class TestTextQueryPFFilters {
         // With "default", luc:match should still return field matches
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"null\" \"null\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10) .\n" +
             "  OPTIONAL { (?hit ?field ?value) luc:match () . }\n" +
             "}";
 
@@ -367,7 +385,7 @@ public class TestTextQueryPFFilters {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
             "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"null\" 20)\n" +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"\" 20)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);


### PR DESCRIPTION
## Summary

This updates the SHACL Lucene SPARQL API to use fixed-position, fixed-arity argument lists with explicit index selection, and refreshes the demo/docs to match.

It also improves the mining demo so the nested identifier hierarchy is visible as a real drill-down facet, sorted fields are visible on result cards, and identifier search can hit nested identifier values as well as top-level identifiers.

## What changed

- Make `luc:query` and `luc:facet` fixed-arity in SHACL mode
- Require explicit `indexSelector` in the first argument position
- Remove `?match` from `luc:query`
- Keep `luc:match` as the place to retrieve per-hit match detail
- Make parsing fail fast on arity/position errors instead of using shape detection
- Use `""` as the empty placeholder for absent `cqlFilter` / `sortSpec`
- Keep sort in the API and route it through field IRIs in the SPARQL layer
- Make shared search execution/index resolution index-aware
- Allow `text:indexes` to be a single resource or an RDF list
- Update docs, examples, and demo queries to the current API
- Move/update the one-page explainer under `demo/`
- Add demo sort coverage and end-to-end sort tests
- Restore visible `year` / `depth` rows on result cards so sorting is obvious
- Expose the nested identifier hierarchy in the demo as a single `identifiers` drill-down group
- Update the demo borehole data to use blank-node identifier records for `company`, `anumber`, and `mnumber`
- Make the demo identifier search box query both top-level `identifier` and nested `identifierValueText`

## Demo/UI notes

- The nested identifier hierarchy now behaves as a hierarchy group instead of two sibling facet filters
- `Clear all filters` now clears hierarchy selections as well
- Expanded hierarchy state is restored after search
- Identifier drill-down remains based on extra facet queries per opened parent
- The current nested text + sibling filter limitation still exists for exact same-child correlation; block join is still the longer-term solution for that case

## Testing

- `mvn -pl jena-text test`
- `mvn -q -pl . validate`
- `node --check demo/app-static/app.js`

## Notes

This PR intentionally aligns the public SPARQL API around field IRIs and fixed positional arguments, while keeping Lucene field names as internal storage/config concerns.