### PR TITLE
Warn and keep first value for non-multi-valued SHACL fields

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -31,6 +31,7 @@ import org.apache.jena.geosparql.implementation.vocabulary.SRS_URI;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.text.assembler.IndexVocab;
 import org.apache.jena.query.text.cql.CqlExpression;
 import org.apache.jena.query.text.cql.CqlToLuceneCompiler;
 import org.apache.lucene.document.*;
@@ -90,6 +91,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
 
     /** Index field name for taxonomy facet ordinals (kept separate from SSDV's $facets). */
     private static final String TAXO_INDEX_FIELD = "$taxo_facets";
+    private static final String MULTI_VALUED_CONFIG_IRI = IndexVocab.NS + "multiValued";
 
     private final ShaclIndexMapping shaclMapping;
     private final List<String> facetFields;
@@ -512,7 +514,13 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
             if (value instanceof List) {
                 @SuppressWarnings("unchecked")
                 List<Object> values = (List<Object>) value;
-                for (Object v : values) {
+                List<Object> valuesToIndex = values;
+                if (!fieldDef.isMultiValued() && values.size() > 1) {
+                    log.warn("Multiple values found for non-multi-valued field '{}' on entity '{}'; only the first value will be indexed. To index all values, set <{}> true in the index configuration.",
+                        fieldDef.getFieldName(), entity.getId(), MULTI_VALUED_CONFIG_IRI);
+                    valuesToIndex = Collections.singletonList(values.get(0));
+                }
+                for (Object v : valuesToIndex) {
                     addFieldToDoc(doc, fieldDef, v);
                 }
             } else {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclDocumentBuilding.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclDocumentBuilding.java
@@ -205,14 +205,37 @@ public class TestShaclDocumentBuilding {
 
     @Test
     public void testMultiValuedField() {
+        FieldDef multiTitleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, true, true,
+            Collections.singleton(TITLE_PRED));
+        IndexProfile multiValueProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "BookShapeMulti"),
+            Collections.singleton(BOOK_CLASS),
+            "uri", "docType",
+            Collections.singletonList(multiTitleField));
+
         Entity entity = new Entity("http://example.org/book1", null);
         entity.addValue("title", "First Title");
         entity.addValue("title", "Second Title");
 
-        Document doc = textIndex.docFromMapping(entity, testProfile);
+        Document doc = textIndex.docFromMapping(entity, multiValueProfile);
 
         IndexableField[] titleFields = doc.getFields("title");
-        assertTrue("Should have 2 title fields for multi-valued", titleFields.length >= 2);
+        assertEquals("Should have 2 title fields for multi-valued", 2, titleFields.length);
+    }
+
+    @Test
+    public void testNonMultiValuedSortableFieldOnlyIndexesFirstValue() {
+        Entity entity = new Entity("http://example.org/book1", null);
+        entity.addValue("category", "Science");
+        entity.addValue("category", "Technology");
+
+        Document doc = textIndex.docFromMapping(entity, testProfile);
+
+        assertEquals("Science", doc.get("category"));
+        assertEquals("Should only index one category value for non-multi-valued field", 2,
+            doc.getFields("category").length);
+        textIndex.updateEntityForProfile(entity, testProfile);
     }
 
     @Test


### PR DESCRIPTION
## Summary

When SHACL indexing extracted multiple values for a field that was not configured as multi-valued, Lucene could fail with a duplicate DocValues exception for sortable/facetable fields. This change makes that behavior explicit and non-fatal for the
document build path.

## Changes

- Warn when multiple values are found for a field whose `idx:multiValued` setting is not `true`
- Index only the first value for that field instead of passing all values through to Lucene
- Include the full config IRI in the warning message:
  - `urn:jena:lucene:index#multiValued`
- Add regression coverage for:
  - explicitly multi-valued fields retaining multiple values
  - non-multi-valued sortable fields indexing only the first value without error

## Behavior

Previous behavior:
- Multiple extracted values for a non-multi-valued sortable/facetable field could trigger a Lucene `IllegalArgumentException` such as:
  - `DocValuesField "endDate" appears more than once in this document`

New behavior:
- A warning is logged
- Only the first value is indexed
- Users who want all values indexed can set `idx:multiValued true` using:
  - `urn:jena:lucene:index#multiValued`

## Verification

- Ran:
  - `mvn -pl jena-text -Dtest=TestShaclDocumentBuilding test`