### PR TITLE
Add date literal round-trip support and temporal range controls to the demo UI

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -11,8 +11,9 @@ using an Australian mining domain with reports, boreholes, sites, and authors.
 
 For Docker workflows:
 - Docker Desktop
-- **GitHub CR**: `gh` CLI authenticated with `write:packages` scope (only for `task ghcr-push`)
-- **Azure CR**: `az` CLI authenticated (only for `task image-push`)
+- Root image tasks live in `../Taskfile.yml`
+- **GitHub CR**: `gh` CLI authenticated with `write:packages` scope (only if using the root GHCR push tasks)
+- **Azure CR**: `az` CLI authenticated (only if using the root ACR push tasks)
 
 ## Quick start
 
@@ -36,7 +37,8 @@ task stop
 ## Quick start (Docker)
 
 ```bash
-# Build the image with a multi-stage Docker build and start Fuseki locally
+# Build the runtime image from the repo root, then start Fuseki locally from demo/
+task -d .. runtime-build
 task docker-start
 
 # Load data and run queries (in a separate terminal)
@@ -179,55 +181,22 @@ year   2024       null  null  1
 
 ## Server image
 
-### Building
+Image build and publish tasks were moved to the repo root so the `demo/` task file stays focused on demo/test workflows.
 
-Build the server Docker image locally:
-
-```bash
-task image-build
-```
-
-This produces `fuseki-ai:6.1.0-SNAPSHOT` by default. The image is built with a standard multi-stage `docker build`, compiling the Fuseki server jar inside Docker rather than requiring a host-built jar. The runtime image is based on `eclipse-temurin:21-jre-alpine` and includes the server config and demo mining dataset.
-
-Override the image name or tag:
+Build the runtime image from the repo root:
 
 ```bash
-task image-build IMAGE_NAME=myapp IMAGE_TAG=latest
+task -d .. runtime-build
 ```
 
-### Pushing to GitHub Container Registry
+Push from the repo root if needed:
 
 ```bash
-task ghcr-push
+task -d .. runtime-ghcr-push
+task -d .. runtime-acr-push ACR_NAME=myregistry
 ```
 
-Pushes to `ghcr.io/aiworkerjohns/fuseki-ai:6.1.0-SNAPSHOT`. Override the owner:
-
-```bash
-task ghcr-push GHCR_OWNER=other-org
-```
-
-New packages default to private. Set visibility to public via GitHub > Package Settings > Change visibility.
-
-The `gh` CLI must have the `write:packages` scope. Add it with:
-
-```bash
-gh auth refresh -s write:packages
-```
-
-To run the published GHCR image with the demo `docker-compose.yml`:
-
-```bash
-task docker-start-ghcr
-```
-
-### Pushing to Azure Container Registry
-
-```bash
-task image-push ACR_NAME=myregistry
-```
-
-Pushes to `myregistry.azurecr.io/fuseki-ai:6.1.0-SNAPSHOT`. The task checks for an active Azure session and runs `az login` if needed, then authenticates with the ACR before pushing.
+The demo Docker tasks here (`docker-start`, `docker-serve`, `docker-start-ghcr`) still work; they now assume the relevant image already exists locally or in GHCR.
 
 ## Loader / reindexer image
 
@@ -239,11 +208,13 @@ The image runs two steps sequentially:
 
 ### Building
 
+Build the loader image from the repo root:
+
 ```bash
-task loader-build
+task -d .. loader-build
 ```
 
-Produces `fuseki-loader:6.1.0-SNAPSHOT`. Requires the Fuseki JAR to be built first (`task build`).
+This produces `fuseki-loader:6.1.0-SNAPSHOT`.
 
 ### Running
 
@@ -281,15 +252,6 @@ task loader-index
 
 This runs the loader container with `MODE=index`, so it skips `tdb2.tdbloader` and only runs `shacltextindexer`.
 
-If you want a published image whose default startup mode is already safe for reindex-only use:
-
-```bash
-task loader-index-build
-task loader-index-acr-push ACR_NAME=gswadevacr
-```
-
-This produces and pushes `fuseki-loader-index:6.1.0-SNAPSHOT`, which bakes in `MODE=index` as the default while still allowing overrides at runtime.
-
 ### Using with the server image
 
 The loader and server images share volumes, so you can bulk-load data offline then start the server:
@@ -316,17 +278,16 @@ A `docker-compose.yml` example is provided in `loader/`.
 
 ### Pushing
 
+Use the root task file for loader publishing:
+
 ```bash
-# GitHub Container Registry
-task loader-ghcr-push
+task -d .. loader-ghcr-push
+task -d .. loader-acr-push ACR_NAME=gswadevacr
+```
 
-# Azure Container Registry
-task loader-acr-push ACR_NAME=gswadevacr
+For safe text-only reindex from GHCR:
 
-# Safe index-only loader image to ACR
-task loader-index-acr-push ACR_NAME=gswadevacr
-
-# Safe text-only reindex from GHCR
+```bash
 task loader-index-ghcr
 ```
 

--- a/demo/Taskfile.yml
+++ b/demo/Taskfile.yml
@@ -21,6 +21,12 @@ tasks:
     cmds:
       - mvn clean install -pl jena-fuseki2/jena-fuseki-server -am -DskipTests
 
+  build-fast:
+    desc: Incremental Fuseki server build without clean
+    dir: ..
+    cmds:
+      - mvn install -pl jena-fuseki2/jena-fuseki-server -am -DskipTests
+
   stop:
     desc: Stop the running Fuseki server (sends SIGTERM for clean shutdown)
     cmds:
@@ -86,6 +92,9 @@ tasks:
           - queries/17-sort-boreholes-by-depth-asc.rq
           - queries/18-nested-identifier-company-drilldown.rq
           - queries/19-nested-identifier-exact-pair.rq
+          - queries/20-date-range-filter.rq
+          - queries/21-match-review-note-languages.rq
+          - queries/22-match-qa-passed-boolean.rq
         cmd: |
           echo "=== {{.ITEM}} ==="
           curl -s -X POST "{{.SERVER_URL}}/mining/query" \
@@ -128,39 +137,44 @@ tasks:
       - task load FUSEKI_PORT={{.FUSEKI_PORT}}
       - task app FUSEKI_PORT={{.FUSEKI_PORT}} APP_PORT={{.APP_PORT}}
 
+  refresh-fast:
+    desc: Restart Fuseki and app without deleting DB/Lucene or reloading data
+    cmds:
+      - pkill -f "serve_app.py --port {{.APP_PORT}}" || true
+      - pkill -f "jena-fuseki-server.*--port {{.FUSEKI_PORT}}" || true
+      - |
+        cd test
+        rm -f fuseki.log
+        nohup java -jar ../{{.FUSEKI_JAR}} --port {{.FUSEKI_PORT}} --config config.ttl > fuseki.log 2>&1 &
+      - |
+        for i in $(seq 1 30); do
+          if curl -sf "{{.SERVER_URL}}/$/ping" >/dev/null 2>&1; then
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "Fuseki failed to start; see demo/test/fuseki.log"
+        exit 1
+      - task app FUSEKI_PORT={{.FUSEKI_PORT}} APP_PORT={{.APP_PORT}}
+
+  rebuild-start:
+    desc: Rebuild Fuseki, restart the demo server, reload data, then launch the app
+    cmds:
+      - task build
+      - task refresh FUSEKI_PORT={{.FUSEKI_PORT}} APP_PORT={{.APP_PORT}}
+
+  rebuild-start-fast:
+    desc: Incremental rebuild and restart without clean reindex
+    cmds:
+      - task build-fast
+      - task refresh-fast FUSEKI_PORT={{.FUSEKI_PORT}} APP_PORT={{.APP_PORT}}
+
   clean:
     desc: Remove mining TDB2 and Lucene data directories
     dir: test
     cmds:
       - rm -rf DB Lucene
       - echo "Cleaned mining DB and Lucene directories"
-
-  # ── Docker (Fuseki server image) ─────────────────────────
-
-  image-build:
-    desc: "Build Docker image locally (optionally: task image-build IMAGE_NAME=myapp IMAGE_TAG=latest)"
-    dir: ..
-    cmds:
-      - docker build -f demo/test/Dockerfile -t {{.IMAGE_NAME}}:{{.IMAGE_TAG}} .
-
-  image-push:
-    desc: "Build and push image to ACR (usage: task image-push ACR_NAME=gswadevacr)"
-    requires:
-      vars: [ACR_NAME]
-    deps: [image-build]
-    cmds:
-      - az account show > /dev/null 2>&1 || az login
-      - az acr login --name {{.ACR_NAME}}
-      - docker tag {{.IMAGE_NAME}}:{{.IMAGE_TAG}} {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:{{.IMAGE_TAG}}
-      - docker push {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:{{.IMAGE_TAG}}
-
-  ghcr-push:
-    desc: "Build and push image to GitHub CR (usage: task ghcr-push)"
-    deps: [image-build]
-    cmds:
-      - gh auth token | docker login ghcr.io -u {{.GHCR_OWNER}} --password-stdin
-      - docker tag {{.IMAGE_NAME}}:{{.IMAGE_TAG}} ghcr.io/{{.GHCR_OWNER}}/{{.IMAGE_NAME}}:{{.IMAGE_TAG}}
-      - docker push ghcr.io/{{.GHCR_OWNER}}/{{.IMAGE_NAME}}:{{.IMAGE_TAG}}
 
   docker-start:
     desc: Start Fuseki in Docker (detached)
@@ -218,61 +232,8 @@ tasks:
 
   # ── Loader / Reindexer ──────────────────────────────────
 
-  loader-build:
-    desc: Build the loader/reindexer Docker image (extends fuseki-ai)
-    deps: [image-build]
-    dir: ..
-    cmds:
-      - docker build -f demo/loader/Dockerfile --build-arg BASE_IMAGE={{.IMAGE_NAME}} --build-arg BASE_TAG={{.IMAGE_TAG}} -t fuseki-loader:{{.IMAGE_TAG}} .
-
-  loader-ghcr-push:
-    desc: Build and push loader image to GitHub CR
-    deps: [loader-build]
-    cmds:
-      - gh auth token | docker login ghcr.io -u {{.GHCR_OWNER}} --password-stdin
-      - docker tag fuseki-loader:{{.IMAGE_TAG}} ghcr.io/{{.GHCR_OWNER}}/fuseki-loader:{{.IMAGE_TAG}}
-      - docker push ghcr.io/{{.GHCR_OWNER}}/fuseki-loader:{{.IMAGE_TAG}}
-
-  loader-acr-push:
-    desc: "Build and push loader image to ACR (usage: task loader-acr-push ACR_NAME=gswadevacr)"
-    requires:
-      vars: [ACR_NAME]
-    deps: [loader-build]
-    cmds:
-      - az account show > /dev/null 2>&1 || az login
-      - az acr login --name {{.ACR_NAME}}
-      - docker tag fuseki-loader:{{.IMAGE_TAG}} {{.ACR_NAME}}.azurecr.io/fuseki-loader:{{.IMAGE_TAG}}
-      - docker push {{.ACR_NAME}}.azurecr.io/fuseki-loader:{{.IMAGE_TAG}}
-
-  loader-index-build:
-    desc: Build the loader image with MODE=index as the default
-    deps: [image-build]
-    dir: ..
-    cmds:
-      - docker build -f demo/loader/Dockerfile --build-arg BASE_IMAGE={{.IMAGE_NAME}} --build-arg BASE_TAG={{.IMAGE_TAG}} --build-arg DEFAULT_MODE=index -t fuseki-loader-index:{{.IMAGE_TAG}} .
-
-  loader-index-ghcr-push:
-    desc: Build and push the index-only loader image to GitHub CR
-    deps: [loader-index-build]
-    cmds:
-      - gh auth token | docker login ghcr.io -u {{.GHCR_OWNER}} --password-stdin
-      - docker tag fuseki-loader-index:{{.IMAGE_TAG}} ghcr.io/{{.GHCR_OWNER}}/fuseki-loader-index:{{.IMAGE_TAG}}
-      - docker push ghcr.io/{{.GHCR_OWNER}}/fuseki-loader-index:{{.IMAGE_TAG}}
-
-  loader-index-acr-push:
-    desc: "Build and push the index-only loader image to ACR (usage: task loader-index-acr-push ACR_NAME=gswadevacr)"
-    requires:
-      vars: [ACR_NAME]
-    deps: [loader-index-build]
-    cmds:
-      - az account show > /dev/null 2>&1 || az login
-      - az acr login --name {{.ACR_NAME}}
-      - docker tag fuseki-loader-index:{{.IMAGE_TAG}} {{.ACR_NAME}}.azurecr.io/fuseki-loader-index:{{.IMAGE_TAG}}
-      - docker push {{.ACR_NAME}}.azurecr.io/fuseki-loader-index:{{.IMAGE_TAG}}
-
   loader-index:
     desc: Run the loader image in text-only reindex mode against an existing TDB2 store
-    deps: [loader-build]
     dir: loader
     env:
       IMAGE_NAME: 'fuseki-loader'

--- a/demo/app-static/app.css
+++ b/demo/app-static/app.css
@@ -718,6 +718,164 @@ code {
   color: var(--amber);
 }
 
+.temporal-panel {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 0.35rem;
+}
+
+.temporal-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  padding: 0.8rem;
+}
+
+.temporal-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.55rem;
+}
+
+.temporal-title {
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.temporal-clear-btn {
+  border: 1px solid var(--border);
+  background: var(--bg-raised);
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  padding: 0.2rem 0.45rem;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.temporal-clear-btn:hover {
+  color: var(--amber);
+  border-color: var(--amber);
+}
+
+.temporal-input-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 0.7rem;
+}
+
+.temporal-input-group {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.temporal-input {
+  font-size: 0.76rem;
+  font-family: var(--font-mono);
+}
+
+.temporal-slider-dual {
+  position: relative;
+  height: 2.1rem;
+  margin-bottom: 0.45rem;
+}
+
+.temporal-slider-track,
+.temporal-slider-range {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 0.32rem;
+  border-radius: 999px;
+}
+
+.temporal-slider-track {
+  left: 0;
+  right: 0;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.temporal-slider-range {
+  background: linear-gradient(90deg, rgba(212, 148, 76, 0.75), rgba(77, 184, 164, 0.78));
+  box-shadow: 0 0 0 1px rgba(212, 148, 76, 0.12);
+}
+
+.temporal-slider {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 2.1rem;
+  margin: 0;
+  background: transparent;
+  appearance: none;
+  -webkit-appearance: none;
+  pointer-events: none;
+}
+
+.temporal-slider::-webkit-slider-runnable-track {
+  height: 0.32rem;
+  background: transparent;
+}
+
+.temporal-slider::-moz-range-track {
+  height: 0.32rem;
+  background: transparent;
+}
+
+.temporal-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 0.95rem;
+  height: 0.95rem;
+  margin-top: -0.31rem;
+  border-radius: 50%;
+  border: 2px solid var(--amber);
+  background: #f2e4d1;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.35);
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.temporal-slider::-moz-range-thumb {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  border: 2px solid var(--amber);
+  background: #f2e4d1;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.35);
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.temporal-slider-low {
+  z-index: 3;
+}
+
+.temporal-slider-high {
+  z-index: 4;
+}
+
+.temporal-bound-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.68rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
 /* ── Hierarchy facets ── */
 .hierarchy-row {
   user-select: none;
@@ -825,10 +983,38 @@ code {
   margin-bottom: 0.5rem;
 }
 
+.result-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
 .result-card-label {
   font-weight: 700;
   font-size: 0.95rem;
   color: var(--text-primary);
+}
+
+.result-card-ttl-toggle {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border-radius: 999px;
+  padding: 0.22rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.result-card-ttl-toggle:hover,
+.result-card-ttl-toggle.is-active {
+  color: var(--amber);
+  border-color: rgba(212, 148, 76, 0.4);
+  background: var(--amber-dim);
 }
 
 .result-card-score {
@@ -939,6 +1125,41 @@ code {
 .prop-chip-neutral {
   background: var(--bg-elevated);
   color: var(--text-secondary);
+}
+
+.result-turtle-panel {
+  margin-top: 0.9rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.result-turtle-status,
+.result-turtle-error {
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.result-turtle-status {
+  color: var(--text-muted);
+}
+
+.result-turtle-error {
+  color: #f1a8a8;
+}
+
+.result-turtle-pre {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: #181b21;
+  color: #d9dde6;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.6;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 /* ── Log entries ── */

--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -12,6 +12,8 @@ const DEFAULT_LIMIT = 10;
 const FACET_LIMITS = [10, 25, 50, 100, 500];
 const DEFAULT_FACET_LIMIT = 10;
 const DEFAULT_SORT_DIRECTION = 'asc';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // RDF namespace constants
@@ -31,6 +33,19 @@ PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX ex:   <http://example.org/mining/>
 `;
 
+const TURTLE_PREFIXES = {
+    rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+    xsd: 'http://www.w3.org/2001/XMLSchema#',
+    dct: 'http://purl.org/dc/terms/',
+    ex: 'http://example.org/mining/',
+    luc: 'urn:jena:lucene:index#',
+    idx: 'urn:jena:lucene:index#',
+    sh: 'http://www.w3.org/ns/shacl#',
+    schema: 'https://schema.org/',
+    geo: 'http://www.opengis.net/ont/geosparql#',
+};
+
 // ---------------------------------------------------------------------------
 // Utility functions
 // ---------------------------------------------------------------------------
@@ -44,7 +59,55 @@ function shortName(uri) {
 }
 
 function escapeSparql(text) {
-    return text.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+    return String(text)
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+        .replace(/\r/g, '\\r')
+        .replace(/\n/g, '\\n');
+}
+
+function sparqlQuote(text) {
+    return `'${escapeSparql(text)}'`;
+}
+
+async function parseSparqlJsonResponse(resp) {
+    const body = await resp.text();
+    if (!resp.ok) {
+        if (resp.status === 405 && resp.url && resp.url.includes('/fuseki/')) {
+            throw new Error("SPARQL proxy rejected POST at /fuseki. The demo app is probably being served by a plain static server instead of demo/serve_app.py. Start it with `task app`.");
+        }
+        const detail = body.trim().slice(0, 400);
+        throw new Error(`SPARQL error: ${resp.status} ${resp.statusText}${detail ? ` - ${detail}` : ''}`);
+    }
+    try {
+        return JSON.parse(body);
+    } catch (err) {
+        const msg = String(err && err.message ? err.message : err);
+        const match = msg.match(/position (\d+)/);
+        if (match) {
+            const pos = Number(match[1]);
+            const start = Math.max(0, pos - 160);
+            const end = Math.min(body.length, pos + 160);
+            const context = body.slice(start, end)
+                .replace(/\r/g, '\\r')
+                .replace(/\n/g, '\\n');
+            throw new Error(`Invalid JSON from Fuseki at position ${pos}: ${context}`);
+        }
+        const preview = body.trim().slice(0, 400) || '(empty response)';
+        throw new Error(`Non-JSON response from Fuseki: ${preview}`);
+    }
+}
+
+async function parseSparqlTextResponse(resp) {
+    const body = await resp.text();
+    if (!resp.ok) {
+        if (resp.status === 405 && resp.url && resp.url.includes('/fuseki/')) {
+            throw new Error("SPARQL proxy rejected POST at /fuseki. The demo app is probably being served by a plain static server instead of demo/serve_app.py. Start it with `task app`.");
+        }
+        const detail = body.trim().slice(0, 400);
+        throw new Error(`SPARQL error: ${resp.status} ${resp.statusText}${detail ? ` - ${detail}` : ''}`);
+    }
+    return body;
 }
 
 function escapeHtml(text) {
@@ -87,6 +150,90 @@ function parseSortParam(sortParam, fieldIRIs) {
     };
 }
 
+function isTemporalFieldType(fieldType) {
+    const t = String(fieldType || '').toLowerCase();
+    return t.includes('datefield') || t.includes('datetimefield');
+}
+
+function isNumericFieldType(fieldType) {
+    const t = String(fieldType || '').toLowerCase();
+    return t.includes('int') || t.includes('long') || t.includes('double');
+}
+
+function facetRangeSpec(fieldName, fieldInfo) {
+    if (fieldName === 'year') return [null, 2000, 2010, 2020, null];
+    if (fieldName === 'depth') return [0, 100, 250, 500, 1000];
+    if (fieldName === 'confidenceScore') return [0.5, 0.7, 0.85, 0.95, null];
+    if (fieldName === 'publishedOn') return [null, '2020-01-01', '2022-01-01', '2024-01-01', null];
+    if (fieldName === 'indexedAt') return [null, '2024-01-01T00:00:00Z', '2024-02-01T00:00:00Z', '2024-03-01T00:00:00Z', null];
+    if (fieldInfo?.isTemporal) return [null, '2020-01-01', '2022-01-01', '2024-01-01', null];
+    return null;
+}
+
+function formatSelectedValue(field, value) {
+    if (typeof value === 'string' && value.startsWith('__RANGE__')) {
+        const [low, high] = value.substring(9).split('|');
+        return `${escapeHtml(field)} in “${escapeHtml(low || '*')} to ${escapeHtml(high || '*')}”`;
+    }
+    return `${escapeHtml(field)} = “${escapeHtml(shortName(value))}”`;
+}
+
+function temporalFieldPresetBounds(fieldName, fieldInfo) {
+    if (fieldName === 'publishedOn') return { min: '1985-01-01', max: '2025-12-31' };
+    if (fieldName === 'indexedAt') return { min: '2024-01-01T00:00', max: '2024-03-31T23:00' };
+    const ranges = facetRangeSpec(fieldName, fieldInfo) || [];
+    const concrete = ranges.filter(v => v != null);
+    if (concrete.length >= 2) {
+        return { min: String(concrete[0]), max: String(concrete[concrete.length - 1]) };
+    }
+    return fieldInfo?.isTemporal && String(fieldInfo.fieldType || '').toLowerCase().includes('datetime')
+        ? { min: '2024-01-01T00:00', max: '2024-12-31T23:00' }
+        : { min: '2000-01-01', max: '2025-12-31' };
+}
+
+function normalizeDateInput(value) {
+    return value ? value.slice(0, 10) : '';
+}
+
+function normalizeDateTimeInput(value) {
+    if (!value) return '';
+    if (/[+-]\d\d:\d\d$/.test(value) || value.endsWith('Z')) return value;
+    if (value.length === 16) return `${value}:00Z`;
+    if (value.length === 19) return `${value}Z`;
+    return value;
+}
+
+function formatTemporalInputValue(fieldInfo, value) {
+    if (!value) return '';
+    if (fieldInfo?.isTemporal && String(fieldInfo.fieldType || '').toLowerCase().includes('datetime')) {
+        return value.replace(/Z$/, '').slice(0, 16);
+    }
+    return value.slice(0, 10);
+}
+
+function temporalToMillis(fieldInfo, value) {
+    if (!value) return NaN;
+    if (fieldInfo?.isTemporal && String(fieldInfo.fieldType || '').toLowerCase().includes('datetime')) {
+        return Date.parse(normalizeDateTimeInput(value));
+    }
+    return Date.parse(`${normalizeDateInput(value)}T00:00:00Z`);
+}
+
+function millisToTemporal(fieldInfo, value) {
+    if (!Number.isFinite(value)) return '';
+    const iso = new Date(value).toISOString();
+    if (fieldInfo?.isTemporal && String(fieldInfo.fieldType || '').toLowerCase().includes('datetime')) {
+        return iso.slice(0, 19) + 'Z';
+    }
+    return iso.slice(0, 10);
+}
+
+function decorateLiteralDisplay(raw, lang, datatype) {
+    if (lang) return `${raw} @${lang}`;
+    if (datatype) return `${raw} ^^${shortName(datatype)}`;
+    return raw;
+}
+
 function renderJsonTree(obj, indent) {
     indent = indent || 0;
     if (obj === null) return '<span class="jt-null">null</span>';
@@ -111,6 +258,20 @@ function renderJsonTree(obj, indent) {
         return `<details open><summary class="jt-brace">{<span class="jt-count">${keys.length}</span>}</summary><div class="jt-indent">${items}</div><span class="jt-brace">}</span></details>`;
     }
     return escapeHtml(String(obj));
+}
+
+function formatTurtle(quads, prefixes = TURTLE_PREFIXES) {
+    return new Promise((resolve, reject) => {
+        const writer = new N3.Writer({ prefixes });
+        writer.addQuads(quads);
+        writer.end((error, result) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(result);
+        });
+    });
 }
 
 /**
@@ -146,17 +307,14 @@ function buildCqlFilter(selected, bbox, polygon, fieldIRIs, extraClauses) {
 
         for (const rv of rangeVals) {
             const parts = rv.substring(9).split('|');
-            const low = parts[0] !== '' ? Number(parts[0]) : null;
-            const high = parts[1] !== '' ? Number(parts[1]) : null;
+            const rawLow = parts[0] !== '' ? parts[0] : null;
+            const rawHigh = parts[1] !== '' ? parts[1] : null;
+            const temporal = (rawLow && isNaN(Number(rawLow))) || (rawHigh && isNaN(Number(rawHigh)));
+            const low = rawLow === null ? null : (temporal ? rawLow : Number(rawLow));
+            const high = rawHigh === null ? null : (temporal ? rawHigh : Number(rawHigh));
 
             if (low !== null && high !== null) {
-                fieldClauses.push({
-                    op: 'and',
-                    args: [
-                        {op: '>=', args: [{property: prop}, low]},
-                        {op: '<', args: [{property: prop}, high]}
-                    ]
-                });
+                fieldClauses.push({ op: 'between', args: [{property: prop}, low, high] });
             } else if (low !== null) {
                 fieldClauses.push({op: '>=', args: [{property: prop}, low]});
             } else if (high !== null) {
@@ -216,16 +374,47 @@ function parseCqlFilter(cqlString, fieldIRIs) {
     let cql;
     try { cql = JSON.parse(cqlString); } catch { return { selected, bbox, polygon }; }
 
-    const clauses = (cql.op === 'and') ? cql.args : [cql];
-    for (const clause of clauses) {
-        if (!clause.op || !clause.args) continue;
+    function addSelected(field, value) {
+        if (!selected[field]) selected[field] = [];
+        if (!selected[field].includes(value)) selected[field].push(value);
+    }
+
+    function visit(clause) {
+        if (!clause || !clause.op || !clause.args) return;
+        if (clause.op === 'and' || clause.op === 'or') {
+            for (const child of clause.args) visit(child);
+            return;
+        }
         if (clause.op === '=' && clause.args[0]?.property) {
+            addSelected(resolve(clause.args[0].property), clause.args[1]);
+            return;
+        }
+        if (clause.op === 'in' && clause.args[0]?.property) {
             const field = resolve(clause.args[0].property);
-            selected[field] = [clause.args[1]];
-        } else if (clause.op === 'in' && clause.args[0]?.property) {
+            for (const value of clause.args[1] || []) addSelected(field, value);
+            return;
+        }
+        if (clause.op === 'between' && clause.args[0]?.property) {
             const field = resolve(clause.args[0].property);
-            selected[field] = clause.args[1];
-        } else if (clause.op === 's_intersects') {
+            const bounds = Array.isArray(clause.args[1]) ? clause.args[1] : [clause.args[1], clause.args[2]];
+            addSelected(field, `__RANGE__${bounds[0] ?? ''}|${bounds[1] ?? ''}`);
+            return;
+        }
+        if ((clause.op === '>=' || clause.op === '>' || clause.op === '<=' || clause.op === '<') && clause.args[0]?.property) {
+            const field = resolve(clause.args[0].property);
+            const current = (selected[field] || []).find(v => typeof v === 'string' && v.startsWith('__RANGE__'));
+            let low = '';
+            let high = '';
+            if (current) {
+                [low, high] = current.substring(9).split('|');
+                selected[field] = selected[field].filter(v => v !== current);
+            }
+            if (clause.op === '>=' || clause.op === '>') low = String(clause.args[1]);
+            if (clause.op === '<=' || clause.op === '<') high = String(clause.args[1]);
+            addSelected(field, `__RANGE__${low}|${high}`);
+            return;
+        }
+        if (clause.op === 's_intersects') {
             const geom = clause.args[1];
             if (geom?.bbox) {
                 bbox = geom.bbox;
@@ -234,6 +423,8 @@ function parseCqlFilter(cqlString, fieldIRIs) {
             }
         }
     }
+
+    visit(cql);
     return { selected, bbox, polygon };
 }
 
@@ -327,6 +518,7 @@ function extractConfig(store) {
     const facetFields = [];
     const sortableFields = [];
     const fieldIRIs = {};
+    const fieldInfo = {};
     const predicateToFacet = {};
     const seenFacets = new Set();
     const seenSortable = new Set();
@@ -347,8 +539,8 @@ function extractConfig(store) {
         const fieldIRI = propNode.termType === 'NamedNode' ? propNode.value : null;
 
         const fieldTypeShort = shortName(fieldType.value);
-        const typeStr = fieldType.value.toLowerCase();
-        const isNumeric = typeStr.includes('int') || typeStr.includes('long') || typeStr.includes('double');
+        const isNumeric = isNumericFieldType(fieldType.value);
+        const isTemporal = isTemporalFieldType(fieldType.value);
 
         shape.fields.push({
             name: fieldName,
@@ -360,9 +552,18 @@ function extractConfig(store) {
             defaultSearch,
             sortable,
             isNumeric,
+            isTemporal,
         });
 
         if (fieldIRI) fieldIRIs[fieldName] = fieldIRI;
+        fieldInfo[fieldName] = {
+            iri: fieldIRI || fieldName,
+            fieldType: fieldTypeShort,
+            isNumeric,
+            isTemporal,
+            facetable,
+            sortable,
+        };
 
         if (sortable && !seenSortable.has(fieldName)) {
             seenSortable.add(fieldName);
@@ -371,6 +572,7 @@ function extractConfig(store) {
                 iri: fieldIRI || fieldName,
                 fieldType: fieldTypeShort,
                 isNumeric,
+                isTemporal,
             });
         }
 
@@ -461,6 +663,7 @@ function extractConfig(store) {
         facetFields,
         sortableFields,
         fieldIRIs,
+        fieldInfo,
         predicateToFacet,
         hierarchyDimensions,
     };
@@ -542,11 +745,13 @@ function searchApp() {
         maxFacetValues: DEFAULT_FACET_LIMIT,
         facetLimits: FACET_LIMITS,
         sortableFields: [],
+        temporalFields: [],
         sortField: '',
         sortDirection: DEFAULT_SORT_DIRECTION,
         selected: {},
         facetFields: [],
         fieldIRIs: {},
+        fieldInfo: {},
         predicateToFacet: {},
         hierarchyDimensions: new Map(),
         hierarchyChildren: {},  // dim → { parentValue: [{value, label, count}] }
@@ -613,6 +818,8 @@ function searchApp() {
             this.facetFields = config.facetFields;
             this.sortableFields = config.sortableFields || [];
             this.fieldIRIs = config.fieldIRIs;
+            this.fieldInfo = config.fieldInfo || {};
+            this.temporalFields = Object.keys(this.fieldInfo).filter(name => this.fieldInfo[name]?.isTemporal);
             this.predicateToFacet = config.predicateToFacet;
             this.hierarchyDimensions = config.hierarchyDimensions || new Map();
 
@@ -867,6 +1074,114 @@ function searchApp() {
                     Object.values(parents || {}).some(values => (values || []).length > 0));
         },
 
+        temporalFieldLabel(fieldName) {
+            return this.facetLabel(fieldName);
+        },
+
+        temporalInputType(fieldName) {
+            const info = this.fieldInfo[fieldName];
+            return info && String(info.fieldType || '').toLowerCase().includes('datetime') ? 'datetime-local' : 'date';
+        },
+
+        temporalSliderStep(fieldName) {
+            const info = this.fieldInfo[fieldName];
+            return info && String(info.fieldType || '').toLowerCase().includes('datetime') ? HOUR_MS : DAY_MS;
+        },
+
+        temporalBounds(fieldName) {
+            return temporalFieldPresetBounds(fieldName, this.fieldInfo[fieldName]);
+        },
+
+        temporalRangeSelection(fieldName) {
+            const values = this.selected[fieldName] || [];
+            const current = values.find(v => typeof v === 'string' && v.startsWith('__RANGE__'));
+            if (!current) return { low: '', high: '' };
+            const [low, high] = current.substring(9).split('|');
+            return { low: low || '', high: high || '' };
+        },
+
+        temporalInputValue(fieldName, side) {
+            const value = this.temporalRangeSelection(fieldName)[side];
+            return formatTemporalInputValue(this.fieldInfo[fieldName], value);
+        },
+
+        temporalSliderMin(fieldName) {
+            return temporalToMillis(this.fieldInfo[fieldName], this.temporalBounds(fieldName).min);
+        },
+
+        temporalSliderMax(fieldName) {
+            return temporalToMillis(this.fieldInfo[fieldName], this.temporalBounds(fieldName).max);
+        },
+
+        temporalSliderValue(fieldName, side) {
+            const bounds = this.temporalBounds(fieldName);
+            const range = this.temporalRangeSelection(fieldName);
+            const raw = range[side] || bounds[side === 'low' ? 'min' : 'max'];
+            return temporalToMillis(this.fieldInfo[fieldName], raw);
+        },
+
+        temporalSliderPercent(fieldName, side) {
+            const min = this.temporalSliderMin(fieldName);
+            const max = this.temporalSliderMax(fieldName);
+            const value = this.temporalSliderValue(fieldName, side);
+            if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) {
+                return side === 'low' ? 0 : 100;
+            }
+            return ((value - min) / (max - min)) * 100;
+        },
+
+        temporalSliderRangeStyle(fieldName) {
+            const low = this.temporalSliderPercent(fieldName, 'low');
+            const high = this.temporalSliderPercent(fieldName, 'high');
+            return `left:${Math.min(low, high)}%; width:${Math.max(0, Math.abs(high - low))}%;`;
+        },
+
+        setTemporalRange(fieldName, low, high) {
+            if (!this.selected[fieldName]) this.selected[fieldName] = [];
+            this.selected[fieldName] = this.selected[fieldName]
+                .filter(v => !(typeof v === 'string' && v.startsWith('__RANGE__')));
+            if (low || high) {
+                this.selected[fieldName].push(`__RANGE__${low || ''}|${high || ''}`);
+            }
+        },
+
+        async updateTemporalInput(fieldName, side, rawValue) {
+            const info = this.fieldInfo[fieldName];
+            const current = this.temporalRangeSelection(fieldName);
+            const next = side === 'low'
+                ? { low: info?.isTemporal && String(info.fieldType || '').toLowerCase().includes('datetime') ? normalizeDateTimeInput(rawValue) : normalizeDateInput(rawValue), high: current.high }
+                : { low: current.low, high: info?.isTemporal && String(info.fieldType || '').toLowerCase().includes('datetime') ? normalizeDateTimeInput(rawValue) : normalizeDateInput(rawValue) };
+            if (next.low && next.high && temporalToMillis(info, next.low) > temporalToMillis(info, next.high)) {
+                if (side === 'low') next.high = next.low;
+                else next.low = next.high;
+            }
+            this.setTemporalRange(fieldName, next.low, next.high);
+            this.pushUrl();
+            await this.executeSearch();
+        },
+
+        async updateTemporalSlider(fieldName, side, sliderValue) {
+            const info = this.fieldInfo[fieldName];
+            const current = this.temporalRangeSelection(fieldName);
+            const nextValue = millisToTemporal(info, Number(sliderValue));
+            const next = side === 'low'
+                ? { low: nextValue, high: current.high }
+                : { low: current.low, high: nextValue };
+            if (next.low && next.high && temporalToMillis(info, next.low) > temporalToMillis(info, next.high)) {
+                if (side === 'low') next.high = next.low;
+                else next.low = next.high;
+            }
+            this.setTemporalRange(fieldName, next.low, next.high);
+            this.pushUrl();
+            await this.executeSearch();
+        },
+
+        async clearTemporalRange(fieldName) {
+            this.setTemporalRange(fieldName, '', '');
+            this.pushUrl();
+            await this.executeSearch();
+        },
+
         sortLabel() {
             if (!this.sortField) return 'relevance';
             return `${this.sortField} ${this.sortDirection === 'desc' ? 'desc' : 'asc'}`;
@@ -972,8 +1287,7 @@ function searchApp() {
                 const childLevelIRI = childLevel.iri;
 
                 const term = this.identifier.trim() || this.q.trim() || '*';
-                    const searchField = this.identifier.trim() ? this.identifierFieldSelector() : 'default';
-                const escaped = escapeSparql(term);
+                const searchField = this.identifier.trim() ? this.identifierFieldSelector() : 'default';
 
                 const hierFilter = JSON.stringify({
                     op: '=',
@@ -1003,7 +1317,7 @@ function searchApp() {
 
                 const query = `${SPARQL_PREFIXES}
 SELECT ?field ?value ?low ?high ?count WHERE {
-    (?field ?value ?low ?high ?count) luc:facet ('default' '${searchField}' '${escaped}' '${JSON.stringify([childLevelIRI])}' '${combinedFilter}' ${this.maxFacetValues} 0)
+    (?field ?value ?low ?high ?count) luc:facet ('default' ${sparqlQuote(searchField)} ${sparqlQuote(term)} ${sparqlQuote(JSON.stringify([childLevelIRI]))} ${sparqlQuote(combinedFilter)} ${this.maxFacetValues} 0)
 }`;
                 const data = await this.runSparql(query);
                 const children = [];
@@ -1108,8 +1422,20 @@ SELECT ?field ?value ?low ?high ?count WHERE {
                 body: query,
                 signal,
             });
-            if (!resp.ok) throw new Error(`SPARQL error: ${resp.status} ${resp.statusText}`);
-            return resp.json();
+            return parseSparqlJsonResponse(resp);
+        },
+
+        async runSparqlText(query, accept = 'text/turtle', signal) {
+            const resp = await fetch(this.endpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/sparql-query',
+                    'Accept': accept,
+                },
+                body: query,
+                signal,
+            });
+            return parseSparqlTextResponse(resp);
         },
 
         // --- Query builders ---
@@ -1126,15 +1452,15 @@ SELECT ?field ?value ?low ?high ?count WHERE {
                 this.fieldIRIs,
                 this.buildHierarchyParentClauses()
             );
-            const filterArg = cqlFilter ? `'${cqlFilter}'` : "''";
+            const filterArg = cqlFilter ? sparqlQuote(cqlFilter) : "''";
             const sortSpec = buildSortSpec(this.sortField, this.sortDirection, this.fieldIRIs);
-            const sortArg = sortSpec ? `'${escapeSparql(sortSpec)}'` : "''";
+            const sortArg = sortSpec ? sparqlQuote(sortSpec) : "''";
             const facetRequests = this.facetFields.map(f => {
                 // For hierarchy dimensions, use the first level's field IRI
                 const hier = this.hierarchyDimensions.get(f);
                 const iri = hier ? hier[0].iri : (this.fieldIRIs[f] || f);
-                if (f === 'year') return { field: iri, ranges: [null, 2000, 2010, 2020, null] };
-                if (f === 'depth') return { field: iri, ranges: [0, 100, 250, 500, 1000] };
+                const ranges = facetRangeSpec(f, this.fieldInfo[f]);
+                if (ranges) return { field: iri, ranges };
                 return iri;
             });
             const facetFieldsJson = JSON.stringify(facetRequests);
@@ -1142,19 +1468,18 @@ SELECT ?field ?value ?low ?high ?count WHERE {
             return `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?totalHits) luc:query ('default' '${searchField}' '${escaped}' ${filterArg} ${sortArg} ${this.limit}) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' ${sparqlQuote(searchField)} ${sparqlQuote(term)} ${filterArg} ${sortArg} ${this.limit}) }
     UNION
-    { (?field ?value ?low ?high ?count) luc:facet ('default' '${searchField}' '${escaped}' '${facetFieldsJson}' ${filterArg} ${this.maxFacetValues} 0) }
+    { (?field ?value ?low ?high ?count) luc:facet ('default' ${sparqlQuote(searchField)} ${sparqlQuote(term)} ${sparqlQuote(facetFieldsJson)} ${filterArg} ${this.maxFacetValues} 0) }
 }`;
         },
 
         buildIdentifierSuggestionQuery(identifier) {
-            const escaped = escapeSparql(identifier);
             const fieldSpec = this.identifierFieldSelector();
             return `${SPARQL_PREFIXES}
 SELECT DISTINCT ?identifier
 WHERE {
-    (?hit ?entity ?score) luc:query ('default' '${fieldSpec}' '${escaped}' '' '' 8) .
+    (?hit ?entity ?score) luc:query ('default' ${sparqlQuote(fieldSpec)} ${sparqlQuote(identifier)} '' '' 8) .
     ?entity ex:identifier ?identifier .
 }
 ORDER BY LCASE(STR(?identifier))
@@ -1174,6 +1499,11 @@ WHERE {
       OPTIONAL { ?o rdfs:label ?oLabel }
     }
 }`;
+        },
+
+        buildDescribeQuery(uri) {
+            return `${SPARQL_PREFIXES}
+DESCRIBE <${uri}>`;
         },
 
         // --- Result parsing ---
@@ -1240,7 +1570,13 @@ WHERE {
                 }
                 for (const sv of (this.selected[f] || [])) {
                     if (!values[sv]) {
-                        values[sv] = { value: sv, label: shortName(sv), count: 0 };
+                        values[sv] = {
+                            value: sv,
+                            label: typeof sv === 'string' && sv.startsWith('__RANGE__')
+                                ? formatSelectedValue(f, sv).replace(`${escapeHtml(f)} in `, '').replace(/<\/?[^>]+(>|$)/g, '')
+                                : shortName(sv),
+                            count: 0
+                        };
                     }
                 }
                 merged[f] = Object.values(values).sort((a, b) =>
@@ -1263,6 +1599,11 @@ WHERE {
                         description: null,
                         properties: {},
                         rows: [],
+                        turtleOpen: false,
+                        turtleLoading: false,
+                        turtleLoaded: false,
+                        turtleText: '',
+                        turtleError: null,
                     };
                 }
                 const card = entities[uri];
@@ -1270,11 +1611,13 @@ WHERE {
                     const pred = shortName(row.p.value);
                     const raw = row.o.value;
                     const isUri = row.o.type === 'uri';
+                    const lang = row.o['xml:lang'] || null;
+                    const datatype = row.o.datatype || null;
                     const label = row.oLabel?.value;
-                    const display = label || (isUri ? shortName(raw) : raw);
+                    const display = label || (isUri ? shortName(raw) : decorateLiteralDisplay(raw, lang, datatype));
                     if (!card.properties[pred]) card.properties[pred] = [];
                     if (!card.properties[pred].some(e => e.raw === raw)) {
-                        card.properties[pred].push({ display, raw, isUri });
+                        card.properties[pred].push({ display, raw, isUri, lang, datatype });
                     }
                 }
             }
@@ -1344,7 +1687,7 @@ WHERE {
                     }
                     const facetField = this.predicateToFacet[pred] || null;
                     // Skip non-facetable literal values that do not add much to the card.
-                    if (!facetField && !values.some(v => v.isUri)) continue;
+                    if (!facetField && !values.some(v => v.isUri || v.lang || v.datatype)) continue;
                     const rowValues = [];
                     for (const pv of values) {
                         // Find the matching facet value — match by label or raw IRI
@@ -1364,7 +1707,9 @@ WHERE {
                             isActive: active,
                             clickable: !!facetField,
                             mapUri: null,
-                            tooltip: '',
+                            tooltip: pv.datatype || pv.lang
+                                ? [pv.lang ? `lang: ${pv.lang}` : null, pv.datatype ? `datatype: ${shortName(pv.datatype)}` : null].filter(Boolean).join(' | ')
+                                : '',
                             cssClass: !facetField ? 'prop-chip-neutral'
                                 : active ? 'prop-chip-active'
                                 : 'prop-chip-clickable',
@@ -1386,6 +1731,34 @@ WHERE {
             return cards.sort((a, b) => b.score - a.score);
         },
 
+        cardTurtleButtonLabel(card) {
+            if (card.turtleLoading) return 'loading';
+            return card.turtleOpen ? 'hide ttl' : 'ttl';
+        },
+
+        async toggleCardTurtle(card) {
+            card.turtleOpen = !card.turtleOpen;
+            if (!card.turtleOpen || card.turtleLoaded || card.turtleLoading) return;
+            await this.loadCardTurtle(card);
+        },
+
+        async loadCardTurtle(card) {
+            card.turtleLoading = true;
+            card.turtleError = null;
+            try {
+                const describeQuery = this.buildDescribeQuery(card.uri);
+                const rawTurtle = await this.runSparqlText(describeQuery, 'text/turtle');
+                const store = await parseTurtle(rawTurtle);
+                const quads = store.getQuads(null, null, null, null);
+                card.turtleText = await formatTurtle(quads);
+                card.turtleLoaded = true;
+            } catch (e) {
+                card.turtleError = e.message || String(e);
+            } finally {
+                card.turtleLoading = false;
+            }
+        },
+
         // --- Description ---
 
         buildDescription(hitCount, totalHits, totalSec) {
@@ -1403,12 +1776,9 @@ WHERE {
             const filters = [];
             for (const [field, values] of Object.entries(this.selected)) {
                 if (!values || values.length === 0) continue;
-                const quoted = values.map(v => `\u201c${escapeHtml(shortName(v))}\u201d`);
-                if (quoted.length === 1) {
-                    filters.push(`${escapeHtml(field)} = ${quoted[0]}`);
-                } else {
-                    filters.push(`(${escapeHtml(field)} = ${quoted.join(' OR ')})`);
-                }
+                const rendered = values.map(v => formatSelectedValue(field, v));
+                if (rendered.length === 1) filters.push(rendered[0]);
+                else filters.push(`(${rendered.join(' OR ')})`);
             }
             if (this.spatialBbox) {
                 filters.push('bbox [' + this.spatialBbox.map(n => n.toFixed(1)).join(', ') + ']');
@@ -1469,7 +1839,7 @@ WHERE {
                     this.buildHierarchyParentClauses()
                 );
                 if (cqlFilter) {
-                    this.logQuery('CQL Filter', JSON.stringify(JSON.parse(cqlFilter), null, 2));
+                    this.logQuery('CQL Filter', cqlFilter, null, false);
                 }
 
                 let t0 = performance.now();
@@ -1920,8 +2290,8 @@ function statsApp() {
                 // 1. Total entities + facet counts in one query
                 const facetRequests = facetFields.map(f => {
                     const iri = fieldIRIs[f] || f;
-                    if (f === 'year') return { field: iri, ranges: [null, 2000, 2010, 2020, null] };
-                    if (f === 'depth') return { field: iri, ranges: [0, 100, 250, 500, 1000] };
+                    const ranges = facetRangeSpec(f, config.fieldInfo?.[f]);
+                    if (ranges) return { field: iri, ranges };
                     return iri;
                 });
                 const facetFieldsJson = JSON.stringify(facetRequests);
@@ -1930,7 +2300,7 @@ SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
     { (?hit ?entity ?score ?totalHits) luc:query ('default' 'default' '*' '' '' 0) }
     UNION
-    { (?field ?value ?low ?high ?count) luc:facet ('default' 'default' '*' '${facetFieldsJson}' '' 0 0) }
+    { (?field ?value ?low ?high ?count) luc:facet ('default' 'default' '*' ${sparqlQuote(facetFieldsJson)} '' 0 0) }
 }`;
                 const statsData = await this.runSparql(endpoint, statsQuery);
                 const statsMs = performance.now() - t0;
@@ -2013,8 +2383,7 @@ WHERE {
                 },
                 body: query,
             });
-            if (!resp.ok) throw new Error(`SPARQL error: ${resp.status} ${resp.statusText}`);
-            return resp.json();
+            return parseSparqlJsonResponse(resp);
         },
     };
 }

--- a/demo/app-static/index.html
+++ b/demo/app-static/index.html
@@ -170,6 +170,67 @@
                 </details>
               </template>
 
+              <template x-if="temporalFields.length > 0">
+                <details class="facet-group" open>
+                  <summary class="facet-group-label">temporal range</summary>
+                  <div class="temporal-panel">
+                    <template x-for="fieldName in temporalFields" :key="fieldName">
+                      <div class="temporal-card">
+                        <div class="temporal-card-header">
+                          <span class="temporal-title" x-text="temporalFieldLabel(fieldName)"></span>
+                          <button class="temporal-clear-btn"
+                                  type="button"
+                                  x-show="temporalRangeSelection(fieldName).low || temporalRangeSelection(fieldName).high"
+                                  @click="clearTemporalRange(fieldName)">clear</button>
+                        </div>
+
+                        <div class="temporal-input-row">
+                          <label class="temporal-input-group">
+                            <span>from</span>
+                            <input class="input temporal-input"
+                                   :type="temporalInputType(fieldName)"
+                                   :value="temporalInputValue(fieldName, 'low')"
+                                   @change="updateTemporalInput(fieldName, 'low', $event.target.value)">
+                          </label>
+                          <label class="temporal-input-group">
+                            <span>to</span>
+                            <input class="input temporal-input"
+                                   :type="temporalInputType(fieldName)"
+                                   :value="temporalInputValue(fieldName, 'high')"
+                                   @change="updateTemporalInput(fieldName, 'high', $event.target.value)">
+                          </label>
+                        </div>
+
+                        <div class="temporal-slider-dual">
+                          <div class="temporal-slider-track"></div>
+                          <div class="temporal-slider-range"
+                               :style="temporalSliderRangeStyle(fieldName)"></div>
+                          <input class="temporal-slider temporal-slider-low"
+                                 type="range"
+                                 :min="temporalSliderMin(fieldName)"
+                                 :max="temporalSliderMax(fieldName)"
+                                 :step="temporalSliderStep(fieldName)"
+                                 :value="temporalSliderValue(fieldName, 'low')"
+                                 @input="updateTemporalSlider(fieldName, 'low', $event.target.value)">
+                          <input class="temporal-slider temporal-slider-high"
+                                 type="range"
+                                 :min="temporalSliderMin(fieldName)"
+                                 :max="temporalSliderMax(fieldName)"
+                                 :step="temporalSliderStep(fieldName)"
+                                 :value="temporalSliderValue(fieldName, 'high')"
+                                 @input="updateTemporalSlider(fieldName, 'high', $event.target.value)">
+                        </div>
+
+                        <div class="temporal-bound-row">
+                          <span x-text="temporalBounds(fieldName).min"></span>
+                          <span x-text="temporalBounds(fieldName).max"></span>
+                        </div>
+                      </div>
+                    </template>
+                  </div>
+                </details>
+              </template>
+
               <template x-for="fieldName in facetFields" :key="fieldName">
                 <div>
                   <template x-if="(facets[fieldName] || []).length > 0">
@@ -265,10 +326,18 @@
                  :class="{ 'is-highlighted': $store.app.highlightUri === card.uri }">
               <div class="result-card-header">
                 <span class="result-card-label" x-text="card.label"></span>
-                <span class="result-card-score">
-                  <span class="score-label">score</span>
-                  <span class="score-value" x-text="card.score.toFixed(2)"></span>
-                </span>
+                <div class="result-card-actions">
+                  <button class="result-card-ttl-toggle"
+                          type="button"
+                          :class="{ 'is-active': card.turtleOpen }"
+                          @click="toggleCardTurtle(card)"
+                          x-text="cardTurtleButtonLabel(card)">
+                  </button>
+                  <span class="result-card-score">
+                    <span class="score-label">score</span>
+                    <span class="score-value" x-text="card.score.toFixed(2)"></span>
+                  </span>
+                </div>
               </div>
 
               <template x-if="card.description">
@@ -303,6 +372,18 @@
                   </tbody>
                 </table>
               </template>
+
+              <div class="result-turtle-panel" x-show="card.turtleOpen">
+                <template x-if="card.turtleLoading">
+                  <div class="result-turtle-status">Loading Turtle...</div>
+                </template>
+                <template x-if="card.turtleError">
+                  <div class="result-turtle-error" x-text="card.turtleError"></div>
+                </template>
+                <template x-if="card.turtleText && !card.turtleLoading">
+                  <pre class="result-turtle-pre"><code x-text="card.turtleText"></code></pre>
+                </template>
+              </div>
             </div>
           </template>
 

--- a/demo/test/config.ttl
+++ b/demo/test/config.ttl
@@ -93,6 +93,43 @@ field:year
     idx:facetable true ;
     sh:path ex:year .
 
+field:publishedOn
+    idx:fieldName "publishedOn" ;
+    idx:fieldType idx:DateField ;
+    idx:sortable true ;
+    idx:facetable true ;
+    idx:storeLiteralMetadata true ;
+    sh:path ex:publishedOn .
+
+field:indexedAt
+    idx:fieldName "indexedAt" ;
+    idx:fieldType idx:DateTimeField ;
+    idx:sortable true ;
+    idx:storeLiteralMetadata true ;
+    sh:path ex:indexedAt .
+
+field:reviewNote
+    idx:fieldName "reviewNote" ;
+    idx:fieldType idx:TextField ;
+    idx:multiValued true ;
+    idx:storeLiteralMetadata true ;
+    sh:path ex:reviewNote .
+
+field:qaPassed
+    idx:fieldName "qaPassed" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true ;
+    idx:storeLiteralMetadata true ;
+    sh:path ex:qaPassed .
+
+field:confidenceScore
+    idx:fieldName "confidenceScore" ;
+    idx:fieldType idx:DoubleField ;
+    idx:facetable true ;
+    idx:sortable true ;
+    idx:storeLiteralMetadata true ;
+    sh:path ex:confidenceScore .
+
 field:authorName
     idx:fieldName "authorName" ;
     idx:fieldType idx:KeywordField ;
@@ -161,6 +198,11 @@ field:location
     sh:property field:operator ;
     sh:property field:status ;
     sh:property field:year ;
+    sh:property field:publishedOn ;
+    sh:property field:indexedAt ;
+    sh:property field:reviewNote ;
+    sh:property field:qaPassed ;
+    sh:property field:confidenceScore ;
     sh:property field:authorName ;
     sh:property field:authoredByUri ;
     idx:facetHierarchy ( field:state field:commodity ) .

--- a/demo/test/data/mining.ttl
+++ b/demo/test/data/mining.ttl
@@ -247,6 +247,11 @@ ex:report-mia-2023 a ex:MiningReport ;
     ex:operator operator:Glencore ;
     ex:status status:Current ;
     ex:year 2023 ;
+    ex:publishedOn "2023-11-18"^^xsd:date ;
+    ex:indexedAt "2024-01-09T09:15:00+10:00"^^xsd:dateTime ;
+    ex:reviewNote "QA validated by Brisbane modelling team."@en, "Validado por el equipo de modelado de Brisbane."@es ;
+    ex:qaPassed true ;
+    ex:confidenceScore "0.94"^^xsd:double ;
     ex:authoredBy ex:author-jones .
 
 ex:report-mia-2021 a ex:MiningReport ;
@@ -258,6 +263,11 @@ ex:report-mia-2021 a ex:MiningReport ;
     ex:operator operator:Glencore ;
     ex:status status:Current ;
     ex:year 2021 ;
+    ex:publishedOn "2021-08-04"^^xsd:date ;
+    ex:indexedAt "2024-01-10T08:00:00Z"^^xsd:dateTime ;
+    ex:reviewNote "Legacy exploration summary retained for reference."@en, "Conservé pour référence."@fr ;
+    ex:qaPassed true ;
+    ex:confidenceScore "0.81"^^xsd:double ;
     ex:authoredBy ex:author-chen .
 
 ex:report-od-2024 a ex:MiningReport ;
@@ -269,6 +279,11 @@ ex:report-od-2024 a ex:MiningReport ;
     ex:operator operator:BHP ;
     ex:status status:Current ;
     ex:year 2024 ;
+    ex:publishedOn "2024-02-15"^^xsd:date ;
+    ex:indexedAt "2024-02-20T14:45:00+09:30"^^xsd:dateTime ;
+    ex:reviewNote "Board review draft approved."@en, "Aprobado para revisión del directorio."@es ;
+    ex:qaPassed true ;
+    ex:confidenceScore "0.97"^^xsd:double ;
     ex:authoredBy ex:author-jones .
 
 ex:report-bod-2022 a ex:MiningReport ;
@@ -280,6 +295,11 @@ ex:report-bod-2022 a ex:MiningReport ;
     ex:operator operator:Newmont ;
     ex:status status:Current ;
     ex:year 2022 ;
+    ex:publishedOn "2022-12-01"^^xsd:date ;
+    ex:indexedAt "2024-01-07T06:30:00Z"^^xsd:dateTime ;
+    ex:reviewNote "Production commentary reconciled against plant records."@en ;
+    ex:qaPassed true ;
+    ex:confidenceScore "0.89"^^xsd:double ;
     ex:authoredBy ex:author-patel .
 
 ex:report-bh-1985 a ex:MiningReport ;
@@ -291,6 +311,11 @@ ex:report-bh-1985 a ex:MiningReport ;
     ex:operator operator:BHP ;
     ex:status status:Historical ;
     ex:year 1985 ;
+    ex:publishedOn "1985-06-30"^^xsd:date ;
+    ex:indexedAt "2024-01-03T11:10:00+10:00"^^xsd:dateTime ;
+    ex:reviewNote "Historical scan; OCR confidence lower than modern reports."@en ;
+    ex:qaPassed false ;
+    ex:confidenceScore "0.58"^^xsd:double ;
     ex:authoredBy ex:author-chen .
 
 ex:report-cad-2023 a ex:MiningReport ;
@@ -302,6 +327,11 @@ ex:report-cad-2023 a ex:MiningReport ;
     ex:operator operator:Newcrest ;
     ex:status status:Current ;
     ex:year 2023 ;
+    ex:publishedOn "2023-09-21"^^xsd:date ;
+    ex:indexedAt "2024-01-11T17:20:00+11:00"^^xsd:dateTime ;
+    ex:reviewNote "Peer reviewed for reserve committee."@en, "Examiné pour le comité des réserves."@fr ;
+    ex:qaPassed true ;
+    ex:confidenceScore "0.93"^^xsd:double ;
     ex:authoredBy ex:author-patel .
 
 ex:report-pil-2024 a ex:MiningReport ;
@@ -313,6 +343,11 @@ ex:report-pil-2024 a ex:MiningReport ;
     ex:operator operator:Rio-Tinto ;
     ex:status status:Current ;
     ex:year 2024 ;
+    ex:publishedOn "2024-03-04"^^xsd:date ;
+    ex:indexedAt "2024-03-05T07:05:00+08:00"^^xsd:dateTime ;
+    ex:reviewNote "Reserves statement translated for regional investor brief."@en, "Resumo revisado para investidores regionais."@pt ;
+    ex:qaPassed true ;
+    ex:confidenceScore "0.96"^^xsd:double ;
     ex:authoredBy ex:author-williams .
 
 ex:report-pil-exploration a ex:MiningReport ;
@@ -324,6 +359,11 @@ ex:report-pil-exploration a ex:MiningReport ;
     ex:operator operator:Rio-Tinto ;
     ex:status status:Current ;
     ex:year 2023 ;
+    ex:publishedOn "2023-07-19"^^xsd:date ;
+    ex:indexedAt "2024-01-13T05:50:00Z"^^xsd:dateTime ;
+    ex:reviewNote "Early-stage targets only; not for reserve reporting."@en ;
+    ex:qaPassed false ;
+    ex:confidenceScore "0.66"^^xsd:double ;
     ex:authoredBy ex:author-williams .
 
 # Demo case for multi-valued identifier search.
@@ -337,4 +377,9 @@ ex:report-identifier-demo a ex:MiningReport ;
     ex:operator operator:Newmont ;
     ex:status status:Current ;
     ex:year 2011 ;
+    ex:publishedOn "2011-05-12"^^xsd:date ;
+    ex:indexedAt "2024-01-06T12:00:00+10:00"^^xsd:dateTime ;
+    ex:reviewNote "Metadata regression fixture for luc:match."@en ;
+    ex:qaPassed true ;
+    ex:confidenceScore "0.72"^^xsd:double ;
     ex:authoredBy ex:author-patel .

--- a/demo/test/queries/20-date-range-filter.rq
+++ b/demo/test/queries/20-date-range-filter.rq
@@ -1,0 +1,17 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Date range filter on idx:DateField using CQL2-JSON between.
+
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?entity ?score
+WHERE {
+    (?hit ?entity ?score) luc:query (
+        "default"
+        "default"
+        "*"
+        '{"op":"and","args":[{"op":"=","args":[{"property":"urn:jena:lucene:field#entityType"},"http://example.org/mining/MiningReport"]},{"op":"between","args":[{"property":"urn:jena:lucene:field#publishedOn"},"2024-01-01","2024-12-31"]}]}'
+        '{"field":"urn:jena:lucene:field#publishedOn","order":"desc"}'
+        10
+    )
+}
+ORDER BY DESC(?score)

--- a/demo/test/queries/21-match-review-note-languages.rq
+++ b/demo/test/queries/21-match-review-note-languages.rq
@@ -1,0 +1,17 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Demonstrates luc:match round-tripping language-tagged literals from stored metadata.
+
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?entity ?field ?value
+WHERE {
+    (?hit ?entity ?score) luc:query (
+        "default"
+        '["urn:jena:lucene:field#reviewNote"]'
+        "réserves"
+        ""
+        ""
+        10
+    ) .
+    (?hit ?field ?value) luc:match () .
+}

--- a/demo/test/queries/22-match-qa-passed-boolean.rq
+++ b/demo/test/queries/22-match-qa-passed-boolean.rq
@@ -1,0 +1,17 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Demonstrates luc:match round-tripping typed boolean literals from stored metadata.
+
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?entity ?field ?value
+WHERE {
+    (?hit ?entity ?score) luc:query (
+        "default"
+        '["urn:jena:lucene:field#qaPassed"]'
+        "true"
+        ""
+        ""
+        10
+    ) .
+    (?hit ?field ?value) luc:match () .
+}

--- a/demo/test/tests.json
+++ b/demo/test/tests.json
@@ -30,6 +30,7 @@
   { "label": "Reports sorted by year desc", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/MiningReport\"]}&sort=year:desc", "minResults": 5 },
   { "label": "Boreholes sorted by depth asc", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Borehole\"]}&sort=depth:asc", "minResults": 5 },
   { "label": "\"copper\" sorted by year asc", "params": "?q=copper&sort=year:asc", "minResults": 3 },
+  { "label": "Reports sorted by publishedOn desc", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/MiningReport\"]}&sort=publishedOn:desc", "minResults": 5 },
 
   { "group": "Entity Types" },
   { "label": "Sites only", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/Site\"]}", "minResults": 5 },
@@ -39,6 +40,15 @@
   { "group": "Sequence Path (Author)" },
   { "label": "Author: Dr Sarah Jones", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"authorName\"},\"Dr Sarah Jones\"]}", "minResults": 1 },
   { "label": "Author: James Williams", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"authorName\"},\"James Williams\"]}", "minResults": 1 },
+
+  { "group": "Temporal Filters" },
+  { "label": "Reports published in 2024", "params": "?filter={\"op\":\"and\",\"args\":[{\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/MiningReport\"]},{\"op\":\"between\",\"args\":[{\"property\":\"publishedOn\"},\"2024-01-01\",\"2024-12-31\"]}]}", "minResults": 2 },
+  { "label": "Reports published before 2022", "params": "?filter={\"op\":\"and\",\"args\":[{\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/MiningReport\"]},{\"op\":\"<\",\"args\":[{\"property\":\"publishedOn\"},\"2022-01-01\"]}]}", "minResults": 2 },
+  { "label": "Recent indexed reports", "params": "?filter={\"op\":\"and\",\"args\":[{\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/MiningReport\"]},{\"op\":\">=\",\"args\":[{\"property\":\"indexedAt\"},\"2024-02-01T00:00:00Z\"]}]}", "minResults": 2 },
+
+  { "group": "Literal Metadata" },
+  { "label": "QA passed = true", "params": "?filter={\"op\":\"=\",\"args\":[{\"property\":\"qaPassed\"},\"true\"]}", "minResults": 5 },
+  { "label": "French review note", "params": "?q=r%C3%A9serves&filter={\"op\":\"=\",\"args\":[{\"property\":\"entityType\"},\"http://example.org/mining/MiningReport\"]}", "minResults": 1 },
 
   { "group": "Identifier Search" },
   { "label": "Identifier: 94130 (multi-valued demo record)", "params": "?id=94130", "minResults": 1 },

--- a/docs/2026-04-09_date_literal_round_trip_design.md
+++ b/docs/2026-04-09_date_literal_round_trip_design.md
@@ -1,0 +1,278 @@
+# Date Literal Round-Trip and Literal Metadata Storage
+
+Date: 2026-04-09
+
+## Context
+
+The current SHACL Lucene indexing path does not preserve general RDF literal metadata for indexed values.
+
+Current behavior:
+
+- `KEYWORD` values are stored as strings and, on read, may be re-emitted as IRIs if the stored string "looks like" a URI
+- `TEXT` values are re-emitted as plain string literals
+- `INT`, `LONG`, and `DOUBLE` values are re-emitted using the configured Lucene field type, not the original RDF datatype
+- there is no dedicated `DATE` or `DATETIME` field type
+- CQL range filtering and `between` only compile to Lucene queries for numeric field types
+- residual CQL expressions are currently logged and ignored, not post-filtered in Java
+
+This means ISO date literals stored as strings do not currently support real Lucene-backed range filtering, and typed literal fidelity is not preserved for round-trip output.
+
+## Problem
+
+We want:
+
+- correct range filtering for RDF date-like literals
+- exact round-trip output fidelity for `luc:match` and related value-returning paths
+- a design that avoids heuristic reconstruction from stored strings
+- a solution that does not require reading values back from the source graph for every hit
+
+The graph-lookup approach has some appeal, but it has important downsides:
+
+- ambiguous reconstruction for multi-valued fields
+- poor fit for `luc:match`, where we want the value that matched the Lucene document snapshot
+- possible drift between index state and graph state
+- extra query-time cost
+- nested field reconstruction becomes difficult or ambiguous
+
+So the preferred direction is to keep round-trip data in Lucene, but only for indexed fields and only for the term metadata actually needed.
+
+## Recommended Direction
+
+### 1. Add explicit literal metadata storage
+
+Introduce a field-level option to preserve RDF literal metadata for indexed values.
+
+Preferred public shape:
+
+- `idx:storeLiteralMetadata true`
+
+Semantics:
+
+- if the indexed value is a typed literal, store its datatype URI
+- if the indexed value is a language-tagged literal, store its language tag
+- if the indexed value is a plain literal, store no extra literal metadata
+- if the indexed value is an IRI, store no literal metadata
+
+This is preferable to separate public flags such as `storeDatatype` and `storeLangTag` unless we have a real use case for independent control. One flag is easier to explain and reason about.
+
+### 2. Add dedicated date-like field handling
+
+For proper range behavior, metadata storage alone is not enough. Date-like fields also need a normalized numeric companion representation for Lucene query execution.
+
+Preferred model:
+
+- keep the original lexical form for round-trip output
+- keep datatype metadata for reconstruction
+- store a numeric companion field for range, sort, and facet operations
+
+For example, for RDF field `eventDate`, Lucene storage could include:
+
+- `eventDate` — stored lexical string
+- `eventDate__datatype` — stored datatype URI
+- `eventDate__epoch` — numeric companion for query/range/sort/facet
+
+This is intentionally a dual-representation design:
+
+- lexical representation for exact round-trip fidelity
+- numeric representation for efficient typed query behavior
+
+## Why Not Pack Everything Into One Stored String
+
+A packed single-field representation such as `lexical|datatype|lang` is possible, but is not preferred.
+
+Downsides:
+
+- escaping and separator handling
+- harder debugging
+- harder evolution if more metadata is needed later
+- awkward query semantics if the same field is also used for matching
+
+If we want a compact format, a better alternative is:
+
+- one opaque stored serialized RDF term payload for round-trip
+- separate indexed Lucene companion fields for query behavior
+
+However, separate Lucene fields are the clearest first implementation.
+
+## Equality and Range Semantics
+
+We should avoid split semantics where equality uses lexical matching but range uses numeric matching.
+
+Recommended date-like semantics:
+
+- `=`, `<`, `<=`, `>`, `>=`, and `between` operate on the normalized numeric companion field
+- returned values still come from the stored lexical form plus stored datatype metadata
+- optional lexical equality can be added later if there is a concrete requirement for strict lexical matching rather than value equality
+
+This keeps query behavior coherent.
+
+## Temporal CQL Operators
+
+If we later add temporal CQL operators such as:
+
+- `t_before`
+- `t_after`
+- `t_during`
+- `t_meets`
+- `t_overlaps`
+
+they should be treated as higher-level temporal predicates over normalized temporal values, not as something Lucene understands directly.
+
+Lucene itself only gives us lower-level query primitives such as:
+
+- numeric exact queries
+- numeric range queries
+- boolean composition (`MUST`, `SHOULD`, `MUST_NOT`)
+
+So the implementation model should be:
+
+1. normalize date-like values into comparable numeric values
+2. lower each temporal operator into the corresponding Lucene boolean/range query combination
+
+For example, conceptually:
+
+- `t_before(a, b)` lowers to a comparison equivalent to `a_end < b_start`
+- `t_after(a, b)` lowers to a comparison equivalent to `a_start > b_end`
+- `t_during(a, b)` lowers to a conjunction equivalent to `a_start >= b_start && a_end <= b_end`
+
+### Do Not Rewrite Temporal Ops Back Into Lower-Level CQL
+
+There is little benefit in rewriting temporal operators into simpler CQL first.
+
+Reasons:
+
+- the current execution model targets Lucene directly
+- residual CQL is currently ignored rather than evaluated post-Lucene
+- temporal operators are effectively frontend sugar over Lucene boolean/range queries
+
+So the preferred approach is:
+
+- parse temporal operators as dedicated operations
+- compile them directly into Lucene query objects
+- keep any normalization/lowering logic internal to the Lucene compiler rather than exposing a second rewritten CQL layer
+
+This is the simplest fit for the current codebase.
+
+## Suggested Datatype Scope
+
+First pass:
+
+- `xsd:date`
+- `xsd:dateTime`
+
+Possible later extensions:
+
+- `xsd:gYear`
+- `xsd:gYearMonth`
+
+The first implementation should stay narrow and explicit.
+
+## Normalization Rules
+
+### `xsd:dateTime`
+
+Parse to an instant and store epoch milliseconds in UTC.
+
+### `xsd:date`
+
+Treat as a calendar date and store **UTC midnight epoch milliseconds**.
+
+Using milliseconds for both `xsd:date` and `xsd:dateTime` allows a single shared numeric representation type and simplifies cross-type comparisons.
+
+### Timezones and Validation
+
+- Literals without a timezone offset are treated as UTC.
+- If an indexed value fails date parsing, the numeric `__epoch` companion is omitted (making it un-searchable by range), but the lexical form and metadata are still stored.
+
+### Round-trip
+
+Round-trip output must not be reconstructed from the normalized numeric value alone.
+
+Instead, emit:
+
+- original lexical form
+- original datatype URI
+
+This preserves the user's original representation and avoids timezone/formatting loss.
+
+## Multi-valued Fields
+
+For multi-valued date fields, the implementation must ensure consistent alignment between the stored lexical values, the metadata fields (`__datatype`), and the numeric companion fields (`__epoch`). This ensures that the N-th value returned in a result set correctly corresponds to its original datatype and numeric value.
+
+## Proposed Public Configuration Shape
+
+Minimum recommended additions:
+
+- `idx:storeLiteralMetadata true`
+- dedicated date-like field types:
+  - `idx:DateField`
+  - `idx:DateTimeField`
+
+### Configuration Enforcement
+
+To ensure round-trip fidelity, `idx:DateField` and `idx:DateTimeField` **require** `idx:storeLiteralMetadata true` to be enabled for that field (or globally). If a date-like field is configured without literal metadata storage, the configuration should be rejected at startup.
+
+## Internal Representation Proposal
+
+For a date-like configured field:
+
+1. Preserve original lexical form in the stored primary field
+2. Preserve datatype metadata in a companion stored field
+3. Write a numeric companion field for query/range/sort/facet behavior (UTC epoch millis)
+
+Example companion naming:
+
+- `<field>`
+- `<field>__datatype`
+- `<field>__lang`
+- `<field>__epoch`
+
+## Implementation Outline
+
+### Phase 1: literal metadata support
+
+- extend field definition/configuration with `idx:storeLiteralMetadata`
+- preserve datatype URI and language tag alongside stored lexical values when configured
+- update result emission paths to reconstruct RDF literals from stored metadata rather than field-type-only heuristics
+
+### Phase 2: date-like field support
+
+- add explicit date-like field types
+- parse RDF date-like literals into normalized numeric companion values (UTC epoch millis)
+- compile date comparisons and `between` against the numeric companion field
+- keep result output sourced from stored lexical value + stored datatype metadata
+- enforce `storeLiteralMetadata` for these types
+
+### Phase 3: tests and docs
+
+Add coverage for:
+
+- round-trip of `xsd:date`
+- round-trip of `xsd:dateTime`
+- date range queries using `between`
+- date comparisons using `>=`, `<=`, `<`, `>`
+- behavior when date parsing fails
+- behavior for language-tagged literals when metadata storage is enabled
+
+## Migration and Compatibility
+
+No backwards compatibility is required for this change. Existing indexes may need to be deleted and recreated to take advantage of the new date-like field types and metadata storage.
+
+## Open Design Questions
+
+1. Should date equality be semantic only, or should we also support explicit lexical equality later?
+2. Should we preserve IRI-vs-literal term kind explicitly in metadata, or continue relying on field structure plus literal metadata for now?
+3. If temporal CQL operators are added, should all date-like fields be modeled internally as degenerate intervals (`start == end`) to keep instant and interval logic uniform?
+
+## Recommendation
+
+Adopt the following as the baseline design:
+
+- add `idx:storeLiteralMetadata true`
+- add explicit date-like field types and **enforce** metadata storage for them
+- store date-like values in two representations:
+  - lexical form for exact round-trip
+  - numeric companion (UTC epoch millis) for query behavior
+- if temporal CQL operators are added, compile them directly to Lucene boolean/range queries
+- model instants as degenerate intervals for future temporal operator support
+- reconstruct result literals from stored lexical form plus stored datatype/lang metadata

--- a/jena-benchmarks/jena-benchmarks-shadedJena480/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena480/pom.xml
@@ -81,10 +81,24 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>early-jar</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>shade-benchmark-fixture</id>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -121,6 +135,30 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-shaded-classes</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.outputDirectory}" />
+                                <unzip src="${project.build.directory}/${project.build.finalName}.jar"
+                                       dest="${project.build.outputDirectory}">
+                                    <patternset>
+                                        <exclude name="META-INF/**" />
+                                    </patternset>
+                                </unzip>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/jena-benchmarks/jena-benchmarks-shadedJena510/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena510/pom.xml
@@ -86,10 +86,24 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>early-jar</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>shade-benchmark-fixture</id>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -127,6 +141,30 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-shaded-classes</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.outputDirectory}" />
+                                <unzip src="${project.build.directory}/${project.build.finalName}.jar"
+                                       dest="${project.build.outputDirectory}">
+                                    <patternset>
+                                        <exclude name="META-INF/**" />
+                                    </patternset>
+                                </unzip>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/jena-benchmarks/jena-benchmarks-shadedJena550/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena550/pom.xml
@@ -91,10 +91,24 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>early-jar</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>shade-benchmark-fixture</id>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -132,6 +146,30 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-shaded-classes</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.outputDirectory}" />
+                                <unzip src="${project.build.directory}/${project.build.finalName}.jar"
+                                       dest="${project.build.outputDirectory}">
+                                    <patternset>
+                                        <exclude name="META-INF/**" />
+                                    </patternset>
+                                </unzip>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>

--- a/jena-benchmarks/pom.xml
+++ b/jena-benchmarks/pom.xml
@@ -50,10 +50,10 @@
   </licenses>
 
   <modules>
-    <module>jena-benchmarks-jmh</module>
     <module>jena-benchmarks-shadedJena480</module>
     <module>jena-benchmarks-shadedJena510</module>
     <module>jena-benchmarks-shadedJena550</module>
+    <module>jena-benchmarks-jmh</module>
   </modules>
 
 </project>

--- a/jena-text/src/main/java/org/apache/jena/query/text/LiteralFieldSupport.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/LiteralFieldSupport.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+
+import org.apache.jena.datatypes.TypeMapper;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+
+public final class LiteralFieldSupport {
+    static final String DATATYPE_SUFFIX = "__datatype";
+    static final String LANG_SUFFIX = "__lang";
+    static final String EPOCH_SUFFIX = "__epoch";
+
+    private LiteralFieldSupport() {}
+
+    public static String datatypeField(String fieldName) {
+        return fieldName + DATATYPE_SUFFIX;
+    }
+
+    public static String langField(String fieldName) {
+        return fieldName + LANG_SUFFIX;
+    }
+
+    public static String epochField(String fieldName) {
+        return fieldName + EPOCH_SUFFIX;
+    }
+
+    public static String queryFieldName(FieldDef fieldDef) {
+        return fieldDef != null && fieldDef.isDateLike()
+            ? epochField(fieldDef.getFieldName())
+            : fieldDef != null ? fieldDef.getFieldName() : null;
+    }
+
+    public static Long toEpochMillis(FieldType fieldType, Object rawValue) {
+        if (rawValue == null) {
+            return null;
+        }
+        String lexical = rawValue instanceof Node node && node.isLiteral()
+            ? node.getLiteralLexicalForm()
+            : String.valueOf(rawValue);
+        try {
+            return switch (fieldType) {
+                case DATE -> parseDateEpochMillis(lexical);
+                case DATETIME -> parseDateTimeEpochMillis(lexical);
+                default -> null;
+            };
+        } catch (DateTimeException ex) {
+            return null;
+        }
+    }
+
+    public static Node reconstructNode(FieldDef fieldDef, String lexical, String datatypeUri, String language) {
+        if (lexical == null || fieldDef == null) {
+            return null;
+        }
+        String dt = blankToNull(datatypeUri);
+        String lang = blankToNull(language);
+        if (lang != null) {
+            return NodeFactory.createLiteralLang(lexical, lang);
+        }
+        if (dt != null) {
+            return NodeFactory.createLiteralDT(lexical, TypeMapper.getInstance().getSafeTypeByName(dt));
+        }
+        return switch (fieldDef.getFieldType()) {
+            case KEYWORD -> ShaclTextIndexLucene.looksLikeUri(lexical)
+                ? NodeFactory.createURI(lexical)
+                : NodeFactory.createLiteralString(lexical);
+            case TEXT -> NodeFactory.createLiteralString(lexical);
+            case INT -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDinteger);
+            case LONG -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong);
+            case DOUBLE -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdouble);
+            case DATE -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdate);
+            case DATETIME -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime);
+            case LATLON -> null;
+        };
+    }
+
+    public static String blankToNull(String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+
+    private static long parseDateEpochMillis(String lexical) {
+        TemporalAccessor parsed = DateTimeFormatter.ISO_DATE.parse(lexical);
+        LocalDate date = LocalDate.from(parsed);
+        return date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+    }
+
+    private static long parseDateTimeEpochMillis(String lexical) {
+        try {
+            return OffsetDateTime.parse(lexical, DateTimeFormatter.ISO_DATE_TIME)
+                .toInstant().toEpochMilli();
+        } catch (DateTimeException ex) {
+            LocalDateTime localDateTime = LocalDateTime.parse(lexical, DateTimeFormatter.ISO_DATE_TIME);
+            return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        }
+    }
+}

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
@@ -81,7 +81,7 @@ final class ShaclEntityBuilder {
         if (path != null && fieldDef.hasComplexPath()) {
             Iterator<Node> iter = PathEval.eval(graph, subject, path, null);
             while (iter.hasNext()) {
-                Object value = nodeToValue(iter.next(), fieldDef.getFieldType());
+                Object value = nodeToValue(iter.next(), fieldDef.getFieldType(), fieldDef.preservesLiteralMetadata());
                 if (value != null) {
                     values.add(value);
                 }
@@ -94,7 +94,7 @@ final class ShaclEntityBuilder {
                 .mapWith(t -> t.getObject());
             try {
                 while (iter.hasNext()) {
-                    Object value = nodeToValue(iter.next(), fieldDef.getFieldType());
+                    Object value = nodeToValue(iter.next(), fieldDef.getFieldType(), fieldDef.preservesLiteralMetadata());
                     if (value != null) {
                         values.add(value);
                     }
@@ -110,7 +110,7 @@ final class ShaclEntityBuilder {
                 .mapWith(t -> t.getObject());
             try {
                 while (iter.hasNext()) {
-                    Object value = nodeToValue(iter.next(), fieldDef.getFieldType());
+                    Object value = nodeToValue(iter.next(), fieldDef.getFieldType(), fieldDef.preservesLiteralMetadata());
                     if (value != null) {
                         values.add(value);
                     }
@@ -135,7 +135,14 @@ final class ShaclEntityBuilder {
     }
 
     static Object nodeToValue(Node obj, FieldType fieldType) {
+        return nodeToValue(obj, fieldType, false);
+    }
+
+    static Object nodeToValue(Node obj, FieldType fieldType, boolean preserveLiteralMetadata) {
         if (obj.isLiteral()) {
+            if (preserveLiteralMetadata || fieldType == FieldType.DATE || fieldType == FieldType.DATETIME) {
+                return obj;
+            }
             return switch (fieldType) {
                 case INT -> {
                     try {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -36,7 +36,7 @@ import org.apache.lucene.analysis.Analyzer;
 public class ShaclIndexMapping {
 
     public enum FieldType {
-        TEXT, KEYWORD, INT, LONG, DOUBLE, LATLON
+        TEXT, KEYWORD, INT, LONG, DOUBLE, DATE, DATETIME, LATLON
     }
 
     private static final String FIELD_IRI_PREFIX = "urn:jena:lucene:field#";
@@ -52,6 +52,7 @@ public class ShaclIndexMapping {
         private final boolean sortable;
         private final boolean multiValued;
         private final boolean defaultSearch;
+        private final boolean storeLiteralMetadata;
         private final Set<Node> predicates;
         private final Path path;
         private final Node fieldIRI;
@@ -62,7 +63,7 @@ public class ShaclIndexMapping {
                         boolean sortable, boolean multiValued, boolean defaultSearch,
                         Set<Node> predicates) {
             this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
-                 sortable, multiValued, defaultSearch, predicates, null, null, null);
+                 sortable, multiValued, defaultSearch, false, predicates, null, null, null);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
@@ -70,7 +71,7 @@ public class ShaclIndexMapping {
                         boolean sortable, boolean multiValued, boolean defaultSearch,
                         Set<Node> predicates, Path path) {
             this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
-                 sortable, multiValued, defaultSearch, predicates, path, null, null);
+                 sortable, multiValued, defaultSearch, false, predicates, path, null, null);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
@@ -78,7 +79,7 @@ public class ShaclIndexMapping {
                         boolean sortable, boolean multiValued, boolean defaultSearch,
                         Set<Node> predicates, Path path, Node fieldIRI) {
             this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
-                 sortable, multiValued, defaultSearch, predicates, path, fieldIRI, null);
+                 sortable, multiValued, defaultSearch, false, predicates, path, fieldIRI, null);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
@@ -87,13 +88,24 @@ public class ShaclIndexMapping {
                         boolean sortable, boolean multiValued, boolean defaultSearch,
                         Set<Node> predicates, Path path, Node fieldIRI) {
             this(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed, facetable,
-                sortable, multiValued, defaultSearch, predicates, path, fieldIRI, null);
+                sortable, multiValued, defaultSearch, false, predicates, path, fieldIRI, null);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         Analyzer queryAnalyzer,
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
+                        boolean storeLiteralMetadata,
+                        Set<Node> predicates, Path path, Node fieldIRI) {
+            this(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed, facetable,
+                sortable, multiValued, defaultSearch, storeLiteralMetadata, predicates, path, fieldIRI, null);
+        }
+
+        public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
+                        Analyzer queryAnalyzer,
+                        boolean stored, boolean indexed, boolean facetable,
+                        boolean sortable, boolean multiValued, boolean defaultSearch,
+                        boolean storeLiteralMetadata,
                         Set<Node> predicates, Path path, Node fieldIRI, String nestedName) {
             this.fieldName = Objects.requireNonNull(fieldName);
             this.fieldType = fieldType != null ? fieldType : FieldType.TEXT;
@@ -105,6 +117,7 @@ public class ShaclIndexMapping {
             this.sortable = sortable;
             this.multiValued = multiValued;
             this.defaultSearch = defaultSearch;
+            this.storeLiteralMetadata = storeLiteralMetadata;
             this.predicates = predicates != null ? Collections.unmodifiableSet(new LinkedHashSet<>(predicates)) : Collections.emptySet();
             this.path = path;
             this.fieldIRI = fieldIRI != null ? fieldIRI
@@ -122,11 +135,14 @@ public class ShaclIndexMapping {
         public boolean isSortable()         { return sortable; }
         public boolean isMultiValued()      { return multiValued; }
         public boolean isDefaultSearch()    { return defaultSearch; }
+        public boolean isStoreLiteralMetadata() { return storeLiteralMetadata; }
         public Set<Node> getPredicates()    { return predicates; }
         public Node getFieldIRI()            { return fieldIRI; }
         public String getNestedName()       { return nestedName; }
         public boolean isNestedScoped()     { return nestedName != null; }
         public boolean isRootScoped()       { return nestedName == null; }
+        public boolean isDateLike()         { return fieldType == FieldType.DATE || fieldType == FieldType.DATETIME; }
+        public boolean preservesLiteralMetadata() { return storeLiteralMetadata || isDateLike(); }
 
         /** The structured path for this field. Null for simple predicate fields (backward compat). */
         public Path getPath()              { return path; }
@@ -141,7 +157,8 @@ public class ShaclIndexMapping {
                 return this;
             }
             return new FieldDef(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed,
-                facetable, sortable, multiValued, defaultSearch, predicates, path, fieldIRI, nestedName);
+                facetable, sortable, multiValued, defaultSearch, storeLiteralMetadata,
+                predicates, path, fieldIRI, nestedName);
         }
 
         @Override
@@ -353,6 +370,7 @@ public class ShaclIndexMapping {
 
     public ShaclIndexMapping(List<IndexProfile> profiles) {
         this.profiles = Collections.unmodifiableList(new ArrayList<>(profiles));
+        validateLiteralMetadataRequirements();
         validateFieldNameUniqueness();
         validateFieldScopeUniqueness();
 
@@ -385,6 +403,18 @@ public class ShaclIndexMapping {
 
     public List<IndexProfile> getProfiles() {
         return profiles;
+    }
+
+    private void validateLiteralMetadataRequirements() {
+        for (IndexProfile profile : profiles) {
+            for (FieldDef field : profile.getFields()) {
+                if (field.isDateLike() && !field.isStoreLiteralMetadata()) {
+                    throw new TextIndexException(
+                        "Field " + field.getFieldIRI().getURI() + " uses " + field.getFieldType()
+                        + " and requires idx:storeLiteralMetadata true");
+                }
+            }
+        }
     }
 
     public boolean isRelevantPredicate(Node p) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -28,6 +28,7 @@ import org.apache.jena.geosparql.implementation.GeometryWrapper;
 import org.apache.jena.geosparql.implementation.datatype.WKTDatatype;
 import org.apache.jena.geosparql.implementation.parsers.wkt.WKTReader;
 import org.apache.jena.geosparql.implementation.vocabulary.SRS_URI;
+import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -246,7 +247,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
     private static boolean isNumericField(ShaclIndexMapping.FieldDef fieldDef) {
         if (fieldDef == null) return false;
         return switch (fieldDef.getFieldType()) {
-            case INT, LONG, DOUBLE -> true;
+            case INT, LONG, DOUBLE, DATE, DATETIME -> true;
             default -> false;
         };
     }
@@ -440,8 +441,8 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                 if (fd != null) {
                     String[] storedValues = doc.getValues(fd.getFieldName());
                     if (storedValues != null && storedValues.length > 0) {
-                        String selected = selectStoredValue(fd.getFieldName(), storedValues, textQuery);
-                        valueNode = fieldValueToNode(fd, selected);
+                        SelectedStoredValue selected = selectStoredValue(fd.getFieldName(), storedValues, textQuery);
+                        valueNode = fieldValueToNode(doc, fd, selected);
                     }
                 }
 
@@ -460,8 +461,8 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                         if (fd != null) {
                             String[] storedValues = doc.getValues(fieldName);
                             if (storedValues != null && storedValues.length > 0) {
-                                String selected = selectStoredValue(fieldName, storedValues, textQuery);
-                                valueNode = fieldValueToNode(fd, selected);
+                                SelectedStoredValue selected = selectStoredValue(fieldName, storedValues, textQuery);
+                                valueNode = fieldValueToNode(doc, fd, selected);
                             }
                         }
                         fieldMatches.add(new FieldMatch(fieldIRI, valueNode, null));
@@ -476,18 +477,11 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
     /**
      * Convert a stored field value to an appropriate RDF node based on field type.
      */
-    private Node fieldValueToNode(ShaclIndexMapping.FieldDef fd, String value) {
-        if (value == null || fd == null) return null;
-        return switch (fd.getFieldType()) {
-            case KEYWORD -> looksLikeUri(value)
-                ? NodeFactory.createURI(value)
-                : NodeFactory.createLiteralString(value);
-            case TEXT    -> NodeFactory.createLiteralString(value);
-            case INT     -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDinteger);
-            case LONG    -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDlong);
-            case DOUBLE  -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDdouble);
-            case LATLON  -> null;
-        };
+    private Node fieldValueToNode(Document doc, ShaclIndexMapping.FieldDef fd, SelectedStoredValue selectedValue) {
+        if (selectedValue == null || selectedValue.value() == null || fd == null) return null;
+        return LiteralFieldSupport.reconstructNode(fd, selectedValue.value(),
+            alignedStoredValue(doc, LiteralFieldSupport.datatypeField(fd.getFieldName()), selectedValue.index()),
+            alignedStoredValue(doc, LiteralFieldSupport.langField(fd.getFieldName()), selectedValue.index()));
     }
 
     // ---- Document building ----
@@ -620,6 +614,11 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
     }
 
     private void addFieldToDoc(Document doc, ShaclIndexMapping.FieldDef fieldDef, Object value) {
+        if (value instanceof Node node) {
+            addNodeFieldToDoc(doc, fieldDef, node);
+            return;
+        }
+
         String fieldName = fieldDef.getFieldName();
         Field.Store store =
             fieldDef.isStored() ? Field.Store.YES : Field.Store.NO;
@@ -691,6 +690,13 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                 break;
             }
 
+            case DATE:
+            case DATETIME:
+                if (fieldDef.isStored()) {
+                    doc.add(new StoredField(fieldName, value.toString()));
+                }
+                break;
+
             case LATLON: {
                 String wktValue = value.toString();
                 List<IndexableField> spatialFields = parseWktToLuceneFields(fieldName, wktValue, fieldDef.isStored());
@@ -699,6 +705,134 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                 }
                 break;
             }
+        }
+    }
+
+    private void addNodeFieldToDoc(Document doc, ShaclIndexMapping.FieldDef fieldDef, Node node) {
+        if (!node.isLiteral()) {
+            addFieldToDoc(doc, fieldDef, node.isURI() ? node.getURI() : node.toString());
+            return;
+        }
+
+        String fieldName = fieldDef.getFieldName();
+        String lexical = node.getLiteralLexicalForm();
+        if (fieldDef.preservesLiteralMetadata()) {
+            doc.add(new StoredField(LiteralFieldSupport.datatypeField(fieldName),
+                Optional.ofNullable(node.getLiteralDatatypeURI()).orElse("")));
+            doc.add(new StoredField(LiteralFieldSupport.langField(fieldName), node.getLiteralLanguage()));
+        }
+
+        switch (fieldDef.getFieldType()) {
+            case TEXT -> {
+                if (fieldDef.isIndexed()) {
+                    FieldType ft = fieldDef.isStored() ? TextField.TYPE_STORED : TextField.TYPE_NOT_STORED;
+                    doc.add(new Field(fieldName, lexical, ft));
+                } else if (fieldDef.isStored()) {
+                    doc.add(new StoredField(fieldName, lexical));
+                }
+            }
+            case KEYWORD -> {
+                Field.Store store = fieldDef.isStored() ? Field.Store.YES : Field.Store.NO;
+                if (fieldDef.isIndexed()) {
+                    doc.add(new StringField(fieldName, lexical, store));
+                } else if (fieldDef.isStored()) {
+                    doc.add(new StoredField(fieldName, lexical));
+                }
+                if (fieldDef.isFacetable() && !lexical.isEmpty()) {
+                    doc.add(new SortedSetDocValuesFacetField(fieldName, lexical));
+                }
+                if (fieldDef.isSortable()) {
+                    doc.add(new SortedDocValuesField(fieldName, new BytesRef(lexical)));
+                }
+            }
+            case INT -> addIntegerLiteralField(doc, fieldDef, lexical);
+            case LONG -> addLongLiteralField(doc, fieldDef, lexical);
+            case DOUBLE -> addDoubleLiteralField(doc, fieldDef, lexical);
+            case DATE, DATETIME -> addTemporalLiteralField(doc, fieldDef, lexical);
+            case LATLON -> {
+                List<IndexableField> spatialFields = parseWktToLuceneFields(fieldName, lexical, fieldDef.isStored());
+                for (IndexableField f : spatialFields) {
+                    doc.add(f);
+                }
+            }
+        }
+    }
+
+    private void addIntegerLiteralField(Document doc, ShaclIndexMapping.FieldDef fieldDef, String lexical) {
+        Integer intVal = parseInteger(lexical);
+        if (intVal == null) {
+            log.warn("Failed to parse INT literal for field '{}': {}", fieldDef.getFieldName(), lexical);
+            if (fieldDef.isStored()) {
+                doc.add(new StoredField(fieldDef.getFieldName(), lexical));
+            }
+            return;
+        }
+        if (fieldDef.isIndexed()) {
+            doc.add(new IntPoint(fieldDef.getFieldName(), intVal));
+        }
+        if (fieldDef.isStored()) {
+            doc.add(new StoredField(fieldDef.getFieldName(), lexical));
+        }
+        if (fieldDef.isFacetable() || fieldDef.isSortable()) {
+            doc.add(new SortedNumericDocValuesField(fieldDef.getFieldName(), intVal));
+        }
+    }
+
+    private void addLongLiteralField(Document doc, ShaclIndexMapping.FieldDef fieldDef, String lexical) {
+        Long longVal = parseLong(lexical);
+        if (longVal == null) {
+            log.warn("Failed to parse LONG literal for field '{}': {}", fieldDef.getFieldName(), lexical);
+            if (fieldDef.isStored()) {
+                doc.add(new StoredField(fieldDef.getFieldName(), lexical));
+            }
+            return;
+        }
+        if (fieldDef.isIndexed()) {
+            doc.add(new LongPoint(fieldDef.getFieldName(), longVal));
+        }
+        if (fieldDef.isStored()) {
+            doc.add(new StoredField(fieldDef.getFieldName(), lexical));
+        }
+        if (fieldDef.isFacetable() || fieldDef.isSortable()) {
+            doc.add(new SortedNumericDocValuesField(fieldDef.getFieldName(), longVal));
+        }
+    }
+
+    private void addDoubleLiteralField(Document doc, ShaclIndexMapping.FieldDef fieldDef, String lexical) {
+        Double dblVal = parseDouble(lexical);
+        if (dblVal == null) {
+            log.warn("Failed to parse DOUBLE literal for field '{}': {}", fieldDef.getFieldName(), lexical);
+            if (fieldDef.isStored()) {
+                doc.add(new StoredField(fieldDef.getFieldName(), lexical));
+            }
+            return;
+        }
+        if (fieldDef.isIndexed()) {
+            doc.add(new DoublePoint(fieldDef.getFieldName(), dblVal));
+        }
+        if (fieldDef.isStored()) {
+            doc.add(new StoredField(fieldDef.getFieldName(), lexical));
+        }
+        if (fieldDef.isFacetable() || fieldDef.isSortable()) {
+            doc.add(new SortedNumericDocValuesField(fieldDef.getFieldName(), NumericUtils.doubleToSortableLong(dblVal)));
+        }
+    }
+
+    private void addTemporalLiteralField(Document doc, ShaclIndexMapping.FieldDef fieldDef, String lexical) {
+        if (fieldDef.isStored()) {
+            doc.add(new StoredField(fieldDef.getFieldName(), lexical));
+        }
+        Long epoch = LiteralFieldSupport.toEpochMillis(fieldDef.getFieldType(), lexical);
+        if (epoch == null) {
+            log.warn("Failed to parse {} literal for field '{}': {}", fieldDef.getFieldType(), fieldDef.getFieldName(), lexical);
+            return;
+        }
+        String epochFieldName = LiteralFieldSupport.epochField(fieldDef.getFieldName());
+        if (fieldDef.isIndexed()) {
+            doc.add(new LongPoint(epochFieldName, epoch));
+        }
+        if (fieldDef.isFacetable() || fieldDef.isSortable()) {
+            doc.add(new SortedNumericDocValuesField(epochFieldName, epoch));
         }
     }
 
@@ -997,14 +1131,17 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
             if (fieldDef == null) {
                 throw new TextIndexException("Unknown range facet field: " + spec.fieldIri());
             }
-            String fieldName = fieldDef.getFieldName();
+            String fieldName = fieldDef.isDateLike()
+                ? LiteralFieldSupport.epochField(fieldDef.getFieldName())
+                : fieldDef.getFieldName();
             List<FacetValue> buckets = switch (fieldDef.getFieldType()) {
                 case INT -> collectIntRangeFacetResults(fieldName, spec.boundaries(), collector, maxValues, minCount);
                 case LONG -> collectLongRangeFacetResults(fieldName, spec.boundaries(), collector, maxValues, minCount);
                 case DOUBLE -> collectDoubleRangeFacetResults(fieldName, spec.boundaries(), collector, maxValues, minCount);
+                case DATE, DATETIME -> collectDateRangeFacetResults(fieldDef, collector, spec.boundaries(), maxValues, minCount);
                 default -> throw new TextIndexException("Range facet field '" + spec.fieldIri() + "' is not numeric");
             };
-            result.put(fieldName, buckets);
+            result.put(fieldDef.getFieldName(), buckets);
         }
     }
 
@@ -1035,6 +1172,15 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
         return extractRangeBuckets(counts.getAllChildren(fieldName), boundaries, maxValues, minCount);
     }
 
+    private List<FacetValue> collectDateRangeFacetResults(ShaclIndexMapping.FieldDef fieldDef,
+            FacetsCollector fc, List<String> boundaries, int maxValues, int minCount) throws IOException {
+        String fieldName = LiteralFieldSupport.epochField(fieldDef.getFieldName());
+        List<LongRange> ranges = buildTemporalRanges(boundaries, fieldDef.getFieldType());
+        LongRangeFacetCounts counts = new LongRangeFacetCounts(
+            fieldName, MultiLongValuesSource.fromLongField(fieldName), fc, ranges.toArray(LongRange[]::new));
+        return extractRangeBuckets(counts.getAllChildren(fieldName), boundaries, maxValues, minCount);
+    }
+
     private static List<LongRange> buildLongRanges(List<String> boundaries, boolean intField) {
         List<LongRange> ranges = new ArrayList<>();
         for (int i = 0; i < boundaries.size() - 1; i++) {
@@ -1059,6 +1205,20 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
             boolean minInclusive = true;
             boolean maxInclusive = high == null;
             ranges.add(new DoubleRange(Integer.toString(i), min, minInclusive, max, maxInclusive));
+        }
+        return ranges;
+    }
+
+    private static List<LongRange> buildTemporalRanges(List<String> boundaries, ShaclIndexMapping.FieldType fieldType) {
+        List<LongRange> ranges = new ArrayList<>();
+        for (int i = 0; i < boundaries.size() - 1; i++) {
+            String low = boundaries.get(i);
+            String high = boundaries.get(i + 1);
+            long min = low != null ? requireEpoch(fieldType, low) : Long.MIN_VALUE;
+            long max = high != null ? requireEpoch(fieldType, high) : Long.MAX_VALUE;
+            boolean minInclusive = true;
+            boolean maxInclusive = high == null;
+            ranges.add(new LongRange(Integer.toString(i), min, minInclusive, max, maxInclusive));
         }
         return ranges;
     }
@@ -1301,33 +1461,27 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
         for (String fieldName : resolvedFields) {
             String[] storedValues = doc.getValues(fieldName);
             if (storedValues == null || storedValues.length == 0) continue;
-            String storedValue = selectStoredValue(fieldName, storedValues, valueQuery);
+            SelectedStoredValue storedValue = selectStoredValue(fieldName, storedValues, valueQuery);
             ShaclIndexMapping.FieldDef fd = shaclMapping.findFieldByName(fieldName);
             if (fd == null) continue;
-            return switch (fd.getFieldType()) {
-                case KEYWORD -> looksLikeUri(storedValue)
-                    ? NodeFactory.createURI(storedValue)
-                    : NodeFactory.createLiteralString(storedValue);
-                case TEXT    -> NodeFactory.createLiteralString(storedValue);
-                case INT     -> NodeFactory.createLiteralDT(storedValue, XSDDatatype.XSDinteger);
-                case LONG    -> NodeFactory.createLiteralDT(storedValue, XSDDatatype.XSDlong);
-                case DOUBLE  -> NodeFactory.createLiteralDT(storedValue, XSDDatatype.XSDdouble);
-                case LATLON  -> null;
-            };
+            return LiteralFieldSupport.reconstructNode(fd, storedValue.value(),
+                alignedStoredValue(doc, LiteralFieldSupport.datatypeField(fieldName), storedValue.index()),
+                alignedStoredValue(doc, LiteralFieldSupport.langField(fieldName), storedValue.index()));
         }
         return null;
     }
 
-    private String selectStoredValue(String fieldName, String[] storedValues, Query valueQuery) {
+    private SelectedStoredValue selectStoredValue(String fieldName, String[] storedValues, Query valueQuery) {
         if (storedValues.length == 1 || valueQuery == null) {
-            return storedValues[0];
+            return new SelectedStoredValue(0, storedValues[0]);
         }
-        for (String storedValue : storedValues) {
+        for (int i = 0; i < storedValues.length; i++) {
+            String storedValue = storedValues[i];
             if (storedValue != null && matchesStoredValue(fieldName, storedValue, valueQuery)) {
-                return storedValue;
+                return new SelectedStoredValue(i, storedValue);
             }
         }
-        return storedValues[0];
+        return new SelectedStoredValue(0, storedValues[0]);
     }
 
     private boolean matchesStoredValue(String fieldName, String storedValue, Query valueQuery) {
@@ -1348,8 +1502,50 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
         }
     }
 
-    private static boolean looksLikeUri(String value) {
+    static boolean looksLikeUri(String value) {
         return value.contains("://") || value.startsWith("urn:");
+    }
+
+    private record SelectedStoredValue(int index, String value) {}
+
+    private static String alignedStoredValue(Document doc, String fieldName, int index) {
+        String[] values = doc.getValues(fieldName);
+        if (values == null || index < 0 || index >= values.length) {
+            return null;
+        }
+        return values[index];
+    }
+
+    private static Integer parseInteger(String lexical) {
+        try {
+            return Integer.parseInt(lexical);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private static Long parseLong(String lexical) {
+        try {
+            return Long.parseLong(lexical);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private static Double parseDouble(String lexical) {
+        try {
+            return Double.parseDouble(lexical);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private static long requireEpoch(ShaclIndexMapping.FieldType fieldType, String lexical) {
+        Long epoch = LiteralFieldSupport.toEpochMillis(fieldType, lexical);
+        if (epoch == null) {
+            throw new TextIndexException("Failed to parse " + fieldType + " value: " + lexical);
+        }
+        return epoch;
     }
 
     private Node resolveFieldNode(List<String> resolvedFields) {
@@ -1675,13 +1871,14 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
 
             // Resolve field identifier (IRI) to Lucene field name
             ShaclIndexMapping.FieldDef fd = shaclMapping.findField(spec.field());
-            String luceneFieldName = fd != null ? fd.getFieldName() : spec.field();
+            String luceneFieldName = fd != null ? LiteralFieldSupport.queryFieldName(fd) : spec.field();
             if (fd != null) {
                 sortType = switch (fd.getFieldType()) {
                     case KEYWORD -> SortField.Type.STRING;
                     case INT -> SortField.Type.INT;
                     case LONG -> SortField.Type.LONG;
                     case DOUBLE -> SortField.Type.DOUBLE;
+                    case DATE, DATETIME -> SortField.Type.LONG;
                     case TEXT -> throw new TextIndexException(
                         "Cannot sort on TEXT field '" + spec.field() + "'. Use KEYWORD for sortable fields.");
                     case LATLON -> throw new TextIndexException(

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
@@ -235,6 +235,8 @@ public class TextFacetPF extends PropertyFunctionBase {
             case INT     -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDinteger);
             case LONG    -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDlong);
             case DOUBLE  -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDdouble);
+            case DATE    -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDdate);
+            case DATETIME -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDdateTime);
             case LATLON  -> NodeFactory.createLiteralString(value);
         };
     }
@@ -334,8 +336,10 @@ public class TextFacetPF extends PropertyFunctionBase {
                     boundaries.add(null);
                 } else if (rangeValue.isNumber()) {
                     boundaries.add(rangeValue.getAsNumber().value().toString());
+                } else if (rangeValue.isString()) {
+                    boundaries.add(rangeValue.getAsString().value());
                 } else {
-                    throw new QueryExecException("Range boundaries must be numeric or null");
+                    throw new QueryExecException("Range boundaries must be numeric, string, or null");
                 }
             }
             rangeFields.add(new FacetRequest.RangeFacetSpec(field, boundaries));
@@ -399,6 +403,7 @@ public class TextFacetPF extends PropertyFunctionBase {
                         throw new QueryExecException("DOUBLE range boundaries must be finite");
                     }
                 }
+                case DATE, DATETIME -> LiteralFieldSupport.toEpochMillis(fd.getFieldType(), boundary);
                 default -> throw new QueryExecException("Range object field <" + spec.fieldIri() + "> is not numeric; use a string facet target instead");
             }
             if (i > 0 && boundaries.get(i - 1) != null) {
@@ -414,13 +419,16 @@ public class TextFacetPF extends PropertyFunctionBase {
             case INT -> Integer.compare(Integer.parseInt(left), Integer.parseInt(right));
             case LONG -> Long.compare(Long.parseLong(left), Long.parseLong(right));
             case DOUBLE -> Double.compare(Double.parseDouble(left), Double.parseDouble(right));
+            case DATE, DATETIME -> Long.compare(
+                LiteralFieldSupport.toEpochMillis(fd.getFieldType(), left),
+                LiteralFieldSupport.toEpochMillis(fd.getFieldType(), right));
             default -> throw new IllegalArgumentException("Field is not numeric: " + fd.getFieldName());
         };
     }
 
     private static boolean isNumericField(ShaclIndexMapping.FieldDef fd) {
         return switch (fd.getFieldType()) {
-            case INT, LONG, DOUBLE -> true;
+            case INT, LONG, DOUBLE, DATE, DATETIME -> true;
             default -> false;
         };
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
@@ -48,6 +48,8 @@ public class IndexVocab {
     public static final Resource IntField       = Vocab.resource(NS, "IntField");
     public static final Resource LongField      = Vocab.resource(NS, "LongField");
     public static final Resource DoubleField    = Vocab.resource(NS, "DoubleField");
+    public static final Resource DateField      = Vocab.resource(NS, "DateField");
+    public static final Resource DateTimeField  = Vocab.resource(NS, "DateTimeField");
     public static final Resource LatLonField    = Vocab.resource(NS, "LatLonField");
 
     // Shape-level properties
@@ -67,6 +69,7 @@ public class IndexVocab {
     public static final Property pSortable      = Vocab.property(NS, "sortable");
     public static final Property pMultiValued   = Vocab.property(NS, "multiValued");
     public static final Property pDefaultSearch = Vocab.property(NS, "defaultSearch");
+    public static final Property pStoreLiteralMetadata = Vocab.property(NS, "storeLiteralMetadata");
     public static final Property pPath          = Vocab.property(NS, "path");
     public static final Property pJoinPath      = Vocab.property(NS, "joinPath");
     public static final Property pProperty      = Vocab.property(NS, "property");

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
@@ -381,6 +381,7 @@ public class ShaclIndexAssembler {
         boolean sortable = getOptionalBoolean(fieldRes, IndexVocab.pSortable, false);
         boolean multiValued = getOptionalBoolean(fieldRes, IndexVocab.pMultiValued, false);
         boolean defaultSearch = getOptionalBoolean(fieldRes, IndexVocab.pDefaultSearch, false);
+        boolean storeLiteralMetadata = getOptionalBoolean(fieldRes, IndexVocab.pStoreLiteralMetadata, false);
 
         // Parse path: from sh:path or idx:path
         Path path = extractPath(fieldRes);
@@ -396,7 +397,8 @@ public class ShaclIndexAssembler {
 
         log.debug("Parsed field: {} type={} path={} facetable={}", fieldName, fieldType, path, facetable);
         return new FieldDef(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed,
-                           facetable, sortable, multiValued, defaultSearch, predicates, path, fieldIRI);
+                           facetable, sortable, multiValued, defaultSearch, storeLiteralMetadata,
+                           predicates, path, fieldIRI);
     }
 
     /**
@@ -600,6 +602,8 @@ public class ShaclIndexAssembler {
         if (IndexVocab.IntField.getURI().equals(uri)) return FieldType.INT;
         if (IndexVocab.LongField.getURI().equals(uri)) return FieldType.LONG;
         if (IndexVocab.DoubleField.getURI().equals(uri)) return FieldType.DOUBLE;
+        if (IndexVocab.DateField.getURI().equals(uri)) return FieldType.DATE;
+        if (IndexVocab.DateTimeField.getURI().equals(uri)) return FieldType.DATETIME;
         if (IndexVocab.LatLonField.getURI().equals(uri)) return FieldType.LATLON;
         throw new TextIndexException("Unknown idx:fieldType: " + uri);
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlParser.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlParser.java
@@ -39,7 +39,7 @@ import org.apache.jena.query.text.TextIndexException;
  * {"op": "=", "args": [{"property": "state"}, "WA"]}
  * {"op": "and", "args": [{...}, {...}]}
  * {"op": "in", "args": [{"property": "state"}, ["WA","OR"]]}
- * {"op": "between", "args": [{"property": "year"}, [2020, 2025]]}
+ * {"op": "between", "args": [{"property": "year"}, 2020, 2025]}
  * {"op": "like", "args": [{"property": "name"}, "Gold%"]}
  * </pre>
  */
@@ -132,17 +132,13 @@ public class CqlParser {
     }
 
     private static CqlExpression.CqlBetween parseBetween(JsonArray args) {
-        if (args.size() != 2) {
-            throw new TextIndexException("CQL2 'between' requires exactly 2 arguments, got " + args.size());
+        if (args.size() == 3) {
+            String property = extractProperty(args.get(0));
+            Object lower = extractValue(args.get(1));
+            Object upper = extractValue(args.get(2));
+            return new CqlExpression.CqlBetween(property, lower, upper);
         }
-        String property = extractProperty(args.get(0));
-        JsonArray bounds = args.get(1).getAsArray();
-        if (bounds.size() != 2) {
-            throw new TextIndexException("CQL2 'between' bounds array must have exactly 2 elements");
-        }
-        Object lower = extractValue(bounds.get(0));
-        Object upper = extractValue(bounds.get(1));
-        return new CqlExpression.CqlBetween(property, lower, upper);
+        throw new TextIndexException("CQL2 'between' requires exactly 3 arguments, got " + args.size());
     }
 
     private static CqlExpression.CqlLike parseLike(JsonArray args) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.apache.jena.atlas.json.JSON;
 import org.apache.jena.atlas.json.JsonArray;
 import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.query.text.LiteralFieldSupport;
 import org.apache.jena.query.text.ShaclIndexMapping;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
@@ -257,18 +258,18 @@ public class CqlToLuceneCompiler {
         FieldType ft = field.getFieldType();
 
         Query q = switch (op) {
-            case "=" -> buildEqualQuery(field.getFieldName(), ft, value);
+            case "=" -> buildEqualQuery(field, value);
             case "<>" -> {
-                Query eq = buildEqualQuery(field.getFieldName(), ft, value);
+                Query eq = buildEqualQuery(field, value);
                 yield new BooleanQuery.Builder()
                     .add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST)
                     .add(eq, BooleanClause.Occur.MUST_NOT)
                     .build();
             }
-            case "<" -> buildRangeQuery(field.getFieldName(), ft, null, value, false, false);
-            case "<=" -> buildRangeQuery(field.getFieldName(), ft, null, value, false, true);
-            case ">" -> buildRangeQuery(field.getFieldName(), ft, value, null, false, false);
-            case ">=" -> buildRangeQuery(field.getFieldName(), ft, value, null, true, false);
+            case "<" -> buildRangeQuery(field, null, value, false, false);
+            case "<=" -> buildRangeQuery(field, null, value, false, true);
+            case ">" -> buildRangeQuery(field, value, null, false, false);
+            case ">=" -> buildRangeQuery(field, value, null, true, false);
             default -> null;
         };
 
@@ -322,7 +323,7 @@ public class CqlToLuceneCompiler {
 
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
         for (Object v : in.values()) {
-            Query eq = buildEqualQuery(fieldName, ft, v);
+            Query eq = buildEqualQuery(field, v);
             bq.add(eq, BooleanClause.Occur.SHOULD);
         }
         bq.setMinimumNumberShouldMatch(1);
@@ -335,8 +336,7 @@ public class CqlToLuceneCompiler {
             return new CompileResult(null, btw);
         }
 
-        Query q = buildRangeQuery(field.getFieldName(), field.getFieldType(),
-            btw.lower(), btw.upper(), true, true);
+        Query q = buildRangeQuery(field, btw.lower(), btw.upper(), true, true);
         if (q == null) {
             return new CompileResult(null, btw);
         }
@@ -421,19 +421,25 @@ public class CqlToLuceneCompiler {
         }
     }
 
-    private Query buildEqualQuery(String fieldName, FieldType ft, Object value) {
+    private Query buildEqualQuery(FieldDef field, Object value) {
+        String fieldName = field.getFieldName();
+        FieldType ft = field.getFieldType();
         return switch (ft) {
             case KEYWORD, TEXT -> new TermQuery(new Term(fieldName, String.valueOf(value)));
             case INT -> IntPoint.newExactQuery(fieldName, toInt(value));
             case LONG -> LongPoint.newExactQuery(fieldName, toLong(value));
             case DOUBLE -> DoublePoint.newExactQuery(fieldName, toDouble(value));
+            case DATE, DATETIME -> LongPoint.newExactQuery(
+                LiteralFieldSupport.epochField(fieldName),
+                toEpochMillis(ft, value));
             case LATLON -> throw new TextIndexException("Equality queries not supported on LATLON field '" + fieldName + "'");
         };
     }
 
-    private Query buildRangeQuery(String fieldName, FieldType ft,
-                                  Object lower, Object upper,
+    private Query buildRangeQuery(FieldDef field, Object lower, Object upper,
                                   boolean lowerInclusive, boolean upperInclusive) {
+        String fieldName = field.getFieldName();
+        FieldType ft = field.getFieldType();
         return switch (ft) {
             case INT -> {
                 int lo = lower != null ? (lowerInclusive ? toInt(lower) : Math.addExact(toInt(lower), 1)) : Integer.MIN_VALUE;
@@ -453,6 +459,15 @@ public class CqlToLuceneCompiler {
                     ? (upperInclusive ? toDouble(upper) : Math.nextDown(toDouble(upper)))
                     : Double.POSITIVE_INFINITY;
                 yield DoublePoint.newRangeQuery(fieldName, lo, hi);
+            }
+            case DATE, DATETIME -> {
+                long lo = lower != null
+                    ? (lowerInclusive ? toEpochMillis(ft, lower) : Math.addExact(toEpochMillis(ft, lower), 1L))
+                    : Long.MIN_VALUE;
+                long hi = upper != null
+                    ? (upperInclusive ? toEpochMillis(ft, upper) : Math.addExact(toEpochMillis(ft, upper), -1L))
+                    : Long.MAX_VALUE;
+                yield LongPoint.newRangeQuery(LiteralFieldSupport.epochField(fieldName), lo, hi);
             }
             case KEYWORD, TEXT -> null; // Range queries on keywords not supported
             case LATLON -> null; // Range queries not applicable to spatial fields
@@ -476,5 +491,13 @@ public class CqlToLuceneCompiler {
     private static double toDouble(Object v) {
         if (v instanceof Number n) return n.doubleValue();
         return Double.parseDouble(String.valueOf(v));
+    }
+
+    private static long toEpochMillis(FieldType fieldType, Object value) {
+        Long epoch = LiteralFieldSupport.toEpochMillis(fieldType, value);
+        if (epoch == null) {
+            throw new TextIndexException("Could not normalize temporal value '" + value + "' for " + fieldType);
+        }
+        return epoch;
     }
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.query.text.cql.CqlExpression;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestDateLiteralRoundTrip {
+
+    private static final String NS = "http://example.org/";
+    private static final String FP = "urn:jena:lucene:field#";
+    private static final Node EVENT_CLASS = NodeFactory.createURI(NS + "Event");
+    private static final Node LABEL_PRED = RDFS.label.asNode();
+    private static final Node EVENT_DATE_PRED = NodeFactory.createURI(NS + "eventDate");
+    private static final Node EVENT_TS_PRED = NodeFactory.createURI(NS + "eventTimestamp");
+    private static final Node NOTE_PRED = NodeFactory.createURI(NS + "note");
+
+    private Dataset dataset;
+    private ShaclTextIndexLucene textIndex;
+
+    @Before
+    public void setUp() {
+        FieldDef labelField = new FieldDef("label", FieldType.TEXT, null,
+            true, true, false, false, false, true, Collections.singleton(LABEL_PRED));
+        FieldDef dateField = new FieldDef("eventDate", FieldType.DATE, null, null,
+            true, true, false, true, false, false, true, Collections.singleton(EVENT_DATE_PRED), null, null);
+        FieldDef tsField = new FieldDef("eventTimestamp", FieldType.DATETIME, null, null,
+            true, true, false, true, false, false, true, Collections.singleton(EVENT_TS_PRED), null, null);
+        FieldDef noteField = new FieldDef("note", FieldType.TEXT, null, null,
+            true, true, false, false, false, false, true, Collections.singleton(NOTE_PRED), null, null);
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + "EventShape"),
+            Collections.singleton(EVENT_CLASS),
+            "uri", "docType",
+            Arrays.asList(labelField, dateField, tsField, noteField));
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setValueStored(true);
+
+        textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(baseDs.asDatasetGraph(), textIndex, mapping);
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            addEvent(model, "event-1", "Alpha launch", "2024-03-04", "2024-03-04T10:15:30+10:00", "English note", "en");
+            addEvent(model, "event-2", "Beta launch", "2025-01-10", "2025-01-10T05:00:00Z", "French note", "fr");
+            addInvalidDateEvent(model, "event-3", "Broken launch", "2024-13-40");
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    @Test
+    public void testDateBetweenReturnsTypedDateLiteral() {
+        CqlExpression filter = new CqlExpression.CqlBetween(FP + "eventDate", "2024-01-01", "2024-12-31");
+        List<TextHit> results = textIndex.queryWithCql(List.of(FP + "eventDate"), null, filter, null, null, null, 10, null);
+
+        assertEquals(1, results.size());
+        assertEquals(NS + "event-1", results.get(0).getNode().getURI());
+        assertEquals(NodeFactory.createLiteralDT("2024-03-04", org.apache.jena.datatypes.xsd.XSDDatatype.XSDdate),
+            results.get(0).getLiteral());
+    }
+
+    @Test
+    public void testDateTimeComparisonReturnsTypedDateTimeLiteral() {
+        CqlExpression filter = new CqlExpression.CqlComparison(">=", FP + "eventTimestamp", "2025-01-01T00:00:00Z");
+        List<TextHit> results = textIndex.queryWithCql(List.of(FP + "eventTimestamp"), null, filter, null, null, null, 10, null);
+
+        assertEquals(1, results.size());
+        assertEquals(NS + "event-2", results.get(0).getNode().getURI());
+        assertEquals(NodeFactory.createLiteralDT("2025-01-10T05:00:00Z", org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime),
+            results.get(0).getLiteral());
+    }
+
+    @Test
+    public void testLanguageTaggedLiteralRoundTripsFromStoredMetadata() {
+        List<TextHit> results = textIndex.queryWithCql(List.of(FP + "note"), "English", null, null, null, null, 10, null);
+
+        assertEquals(1, results.size());
+        assertEquals(NodeFactory.createLiteralLang("English note", "en"), results.get(0).getLiteral());
+    }
+
+    @Test
+    public void testInvalidDateDoesNotParticipateInRangeQuery() {
+        CqlExpression filter = new CqlExpression.CqlComparison(">=", FP + "eventDate", "2024-01-01");
+        List<TextHit> results = textIndex.queryWithCql(List.of(FP + "eventDate"), null, filter, null, null, null, 10, null);
+
+        Set<String> uris = new HashSet<>();
+        for (TextHit hit : results) {
+            uris.add(hit.getNode().getURI());
+        }
+        assertFalse(uris.contains(NS + "event-3"));
+    }
+
+    private void addEvent(Model model, String localId, String label, String date, String timestamp, String note, String lang) {
+        Resource event = ResourceFactory.createResource(NS + localId);
+        model.add(event, RDF.type, ResourceFactory.createResource(NS + "Event"));
+        model.add(event, RDFS.label, label);
+        model.addLiteral(event, ResourceFactory.createProperty(NS, "eventDate"),
+            ResourceFactory.createTypedLiteral(date, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdate));
+        model.addLiteral(event, ResourceFactory.createProperty(NS, "eventTimestamp"),
+            ResourceFactory.createTypedLiteral(timestamp, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime));
+        model.add(event, ResourceFactory.createProperty(NS, "note"),
+            ResourceFactory.createLangLiteral(note, lang));
+    }
+
+    private void addInvalidDateEvent(Model model, String localId, String label, String invalidDate) {
+        Resource event = ResourceFactory.createResource(NS + localId);
+        model.add(event, RDF.type, ResourceFactory.createResource(NS + "Event"));
+        model.add(event, RDFS.label, label);
+        model.addLiteral(event, ResourceFactory.createProperty(NS, "eventDate"),
+            ResourceFactory.createTypedLiteral(invalidDate, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdate));
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
@@ -54,6 +54,7 @@ public class TestTextFacetPF {
     private static final Node CATEGORY_PRED = NodeFactory.createURI(NS + "category");
     private static final Node AUTHOR_PRED = NodeFactory.createURI(NS + "author");
     private static final Node YEAR_PRED = NodeFactory.createURI(NS + "year");
+    private static final Node PUBLISHED_ON_PRED = NodeFactory.createURI(NS + "publishedOn");
 
     private Dataset dataset;
 
@@ -76,12 +77,14 @@ public class TestTextFacetPF {
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
             true, true, true, true, true, false,
             Collections.singleton(YEAR_PRED));
+        FieldDef publishedOnField = new FieldDef("publishedOn", FieldType.DATE, null, null,
+            true, true, true, true, false, false, true, Collections.singleton(PUBLISHED_ON_PRED), null, null);
 
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, authorField, yearField));
+            Arrays.asList(titleField, categoryField, authorField, yearField, publishedOnField));
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -107,23 +110,25 @@ public class TestTextFacetPF {
         dataset.begin(ReadWrite.WRITE);
         try {
             Model model = dataset.getDefaultModel();
-            addBook(model, "doc1", "Introduction to Machine Learning", NS + "category/technology", NS + "author/Smith", 2018, 2020);
-            addBook(model, "doc2", "Deep Learning Neural Networks", NS + "category/technology", NS + "author/Jones", 2021);
-            addBook(model, "doc3", "Machine Learning for Beginners", NS + "category/technology", NS + "author/Smith", 2022);
-            addBook(model, "doc4", "Learning About Quantum Physics", NS + "category/science", NS + "author/Wilson", 2019);
-            addBook(model, "doc5", "Machine Learning in Biology", NS + "category/science", NS + "author/Smith", 2024);
+            addBook(model, "doc1", "Introduction to Machine Learning", NS + "category/technology", NS + "author/Smith", "2018-03-02", 2018, 2020);
+            addBook(model, "doc2", "Deep Learning Neural Networks", NS + "category/technology", NS + "author/Jones", "2021-06-15", 2021);
+            addBook(model, "doc3", "Machine Learning for Beginners", NS + "category/technology", NS + "author/Smith", "2022-09-10", 2022);
+            addBook(model, "doc4", "Learning About Quantum Physics", NS + "category/science", NS + "author/Wilson", "2019-01-20", 2019);
+            addBook(model, "doc5", "Machine Learning in Biology", NS + "category/science", NS + "author/Smith", "2024-02-11", 2024);
             dataset.commit();
         } finally {
             dataset.end();
         }
     }
 
-    private void addBook(Model model, String id, String title, String categoryUri, String authorUri, int... years) {
+    private void addBook(Model model, String id, String title, String categoryUri, String authorUri, String publishedOn, int... years) {
         Resource book = ResourceFactory.createResource(NS + id);
         model.add(book, RDF.type, ResourceFactory.createResource(NS + "Book"));
         model.add(book, ResourceFactory.createProperty(NS + "title"), title);
         model.add(book, ResourceFactory.createProperty(NS + "category"), ResourceFactory.createResource(categoryUri));
         model.add(book, ResourceFactory.createProperty(NS + "author"), ResourceFactory.createResource(authorUri));
+        model.addLiteral(book, ResourceFactory.createProperty(NS + "publishedOn"),
+            ResourceFactory.createTypedLiteral(publishedOn, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdate));
         for (int year : years) {
             model.add(book, ResourceFactory.createProperty(NS + "year"), ResourceFactory.createTypedLiteral(year));
         }
@@ -503,6 +508,33 @@ public class TestTextFacetPF {
                 fail("Expected non-numeric range request to be rejected");
             } catch (QueryExecException ex) {
                 assertTrue(ex.getMessage().contains("is not numeric"));
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testTemporalRangeFacetStringBoundariesAccepted() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?f ?v ?low ?high ?c WHERE {\n" +
+            "  (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"learning\" '[{\"field\":\"" + FP + "publishedOn\",\"ranges\":[null,\"2019-01-01\",\"2023-01-01\",null]}]' \"\" 10 0)\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                int rangeRows = 0;
+                while (rs.hasNext()) {
+                    QuerySolution sol = rs.next();
+                    assertEquals(FP + "publishedOn", sol.getResource("f").getURI());
+                    assertFalse(sol.contains("v"));
+                    assertTrue(sol.contains("low") || sol.contains("high"));
+                    assertTrue(sol.getLiteral("c").getLong() > 0);
+                    rangeRows++;
+                }
+                assertEquals(3, rangeRows);
             }
         } finally {
             dataset.end();

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
@@ -27,6 +27,7 @@ import org.apache.jena.assembler.Assembler;
 import org.apache.jena.assembler.exceptions.AssemblerException;
 import org.apache.jena.query.text.ShaclIndexMapping;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.TextIndexException;
 import org.apache.jena.query.text.ShaclTextIndexLucene;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -214,6 +215,32 @@ public class TestShaclAssembler {
         } finally {
             index.close();
         }
+    }
+
+    @Test
+    public void testDateFieldRequiresLiteralMetadata() {
+        Model model = createModel();
+
+        Resource bookShape = model.createResource(EX + "BookShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
+            .addProperty(
+                model.createProperty(SH, "property"),
+                model.createResource()
+                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "eventDate")
+                    .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.DateField)
+                    .addProperty(model.createProperty(SH, "path"), model.createResource(EX + "eventDate"))
+            );
+
+        RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, shapesList);
+
+        AssemblerException ex = assertThrows(AssemblerException.class,
+            () -> Assembler.general().open(indexSpec));
+        assertTrue(ex.getCause() instanceof TextIndexException);
+        assertTrue(ex.getCause().getMessage().contains("requires idx:storeLiteralMetadata true"));
     }
 
     @Test

--- a/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlParser.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlParser.java
@@ -127,13 +127,20 @@ public class TestCqlParser {
     @Test
     public void testParseBetween() {
         CqlExpression expr = CqlParser.parse(
-            "{\"op\":\"between\",\"args\":[{\"property\":\"year\"},[2020,2025]]}");
+            "{\"op\":\"between\",\"args\":[{\"property\":\"year\"},2020,2025]}");
 
         assertInstanceOf(CqlExpression.CqlBetween.class, expr);
         CqlExpression.CqlBetween btw = (CqlExpression.CqlBetween) expr;
         assertEquals("year", btw.property());
         assertEquals(2020, btw.lower());
         assertEquals(2025, btw.upper());
+    }
+
+    @Test
+    public void testParseBetweenArrayFormRejected() {
+        TextIndexException ex = assertThrows(TextIndexException.class, () ->
+            CqlParser.parse("{\"op\":\"between\",\"args\":[{\"property\":\"year\"},[2020,2025]]}"));
+        assertTrue(ex.getMessage().contains("requires exactly 3 arguments"));
     }
 
     @Test

--- a/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
@@ -246,6 +246,48 @@ public class TestCqlToLuceneCompiler {
     }
 
     @Test
+    public void testDateEqualityUsesTemporalCompanionField() {
+        FieldDef eventDateField = new FieldDef("eventDate", FieldType.DATE, null, null,
+            true, true, false, true, false, false, true, Collections.emptySet(), null, null);
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI("http://example.org/DateShape"),
+            Collections.singleton(NodeFactory.createURI("http://example.org/Event")),
+            "uri", "docType",
+            Collections.singletonList(eventDateField));
+
+        CqlToLuceneCompiler dateCompiler =
+            new CqlToLuceneCompiler(new ShaclIndexMapping(Collections.singletonList(profile)));
+
+        CqlExpression expr = new CqlExpression.CqlComparison("=", FP + "eventDate", "2024-03-01");
+        CqlToLuceneCompiler.CompileResult r = dateCompiler.compile(expr);
+
+        assertNotNull(r.pushed());
+        assertNull(r.residual());
+        assertTrue(r.pushed().toString().contains("eventDate__epoch"));
+    }
+
+    @Test
+    public void testDateBetweenUsesTemporalCompanionField() {
+        FieldDef eventDateField = new FieldDef("eventDate", FieldType.DATE, null, null,
+            true, true, false, true, false, false, true, Collections.emptySet(), null, null);
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI("http://example.org/DateShape"),
+            Collections.singleton(NodeFactory.createURI("http://example.org/Event")),
+            "uri", "docType",
+            Collections.singletonList(eventDateField));
+
+        CqlToLuceneCompiler dateCompiler =
+            new CqlToLuceneCompiler(new ShaclIndexMapping(Collections.singletonList(profile)));
+
+        CqlExpression expr = new CqlExpression.CqlBetween(FP + "eventDate", "2024-01-01", "2024-12-31");
+        CqlToLuceneCompiler.CompileResult r = dateCompiler.compile(expr);
+
+        assertNotNull(r.pushed());
+        assertNull(r.residual());
+        assertTrue(r.pushed().toString().contains("eventDate__epoch"));
+    }
+
+    @Test
     public void testLikeKeyword() {
         CqlExpression like = new CqlExpression.CqlLike(FP + "name", "Gold%");
         CqlToLuceneCompiler.CompileResult r = compiler.compile(like);


### PR DESCRIPTION
## Summary

This PR implements round-trip preservation for typed literals in the Lucene text index, with a focus on xsd:date and xsd:dateTime, and extends the demo so the new behavior is visible and testable end to end.

It adds stored literal metadata and temporal field support in jena-text, aligns CQL between handling to the 3-argument spec form, expands demo data/config with date, datetime, datatype, and lang-tag examples, and upgrades the demo UI with dedicated
temporal controls plus per-result Turtle inspection.

## Main Changes

- add date/dateTime field support to SHACL text index mapping and assembly
- preserve lexical literal metadata so indexed literals can round-trip back with original datatype/lang information
- support temporal pushdown and round-trip reconstruction for stored literals
- make luc:facet accept string range boundaries for temporal facet ranges
- enforce strict 3-argument CQL between parsing and align the demo UI to emit that form only

## Demo Updates

- add demo config/data for publishedOn, indexedAt, and extra literals using non-default datatypes and language tags
- add demo queries/tests covering date range filtering and literal metadata behavior
- add dedicated temporal range controls in the sidebar with editable from / to inputs and a dual-thumb range slider
- add a ttl toggle on each result card that runs a DESCRIBE and shows prefixed Turtle for the resource
- improve SPARQL request quoting and error handling in the demo app

## Verification

Ran targeted jena-text tests during development, including:

mvn -pl jena-text -DskipITs -Dtest=TestCqlParser,TestCqlToLuceneCompiler,TestTextFacetPF,TestDateLiteralRoundTrip,TestShaclAssembler test

Also verified demo app JS syntax with:

node --check demo/app-static/app.js

## Notes

- temporal support currently uses the existing comparison/range path for indexed instants; fuller CQL temporal operators can be added later
- benchmark module failures seen in full-repo builds are unrelated to this feature work and were not intended to be part of this PR