### PR TITLE
Support shared canonical SHACL fields and fix facet indexing

### DIFF
--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -525,18 +525,23 @@ function extractConfig(store) {
     const hierarchyDimensions = new Map();
 
     function registerField(shape, propNode, { includeFacetField = true, includePredicateMapping = true } = {}) {
-        const fieldName = getLiteral(store, propNode, IDX + 'fieldName');
-        const fieldType = getObject(store, propNode, IDX + 'fieldType');
+        // Support new occurrence model: blank node with idx:field reference to canonical field resource.
+        // Fall back to reading metadata directly from propNode for the old inline model.
+        const fieldRef = getObject(store, propNode, IDX + 'field');
+        const fieldNode = fieldRef || propNode;
+
+        const fieldName = getLiteral(store, fieldNode, IDX + 'fieldName');
+        const fieldType = getObject(store, fieldNode, IDX + 'fieldType');
         const pathNode = getObject(store, propNode, SH + 'path');
         if (!fieldName || !fieldType) return;
 
-        const facetable = getLiteral(store, propNode, IDX + 'facetable') === 'true';
-        const multiValued = getLiteral(store, propNode, IDX + 'multiValued') === 'true';
-        const defaultSearch = getLiteral(store, propNode, IDX + 'defaultSearch') === 'true';
-        const sortable = getLiteral(store, propNode, IDX + 'sortable') === 'true';
+        const facetable = getLiteral(store, fieldNode, IDX + 'facetable') === 'true';
+        const multiValued = getLiteral(store, fieldNode, IDX + 'multiValued') === 'true';
+        const defaultSearch = getLiteral(store, fieldNode, IDX + 'defaultSearch') === 'true';
+        const sortable = getLiteral(store, fieldNode, IDX + 'sortable') === 'true';
         const pathStr = pathNode ? pathToString(store, pathNode) : '?';
 
-        const fieldIRI = propNode.termType === 'NamedNode' ? propNode.value : null;
+        const fieldIRI = fieldNode.termType === 'NamedNode' ? fieldNode.value : null;
 
         const fieldTypeShort = shortName(fieldType.value);
         const isNumeric = isNumericFieldType(fieldType.value);

--- a/demo/drillhole/config.ttl
+++ b/demo/drillhole/config.ttl
@@ -1,6 +1,7 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
 PREFIX :        <#>
+PREFIX field:   <urn:jena:lucene:field#>
 PREFIX fuseki:  <http://jena.apache.org/fuseki#>
 PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
@@ -40,52 +41,49 @@ PREFIX exg:     <http://example.com/>
     text:storeValues true ;
     text:maxFacetHits 100000 .
 
+## --- Field definitions (canonical, path-free) ---
+
+## Entity type label via sequence path: rdf:type -> rdfs:label
+field:entityType
+    idx:fieldName "entityType" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
+## Observation label (site + sample ID)
+field:title
+    idx:fieldName "title" ;
+    idx:fieldType idx:TextField ;
+    idx:defaultSearch true .
+
+## Element being measured via sequence path: sosa:observedProperty -> rdfs:label
+## e.g. "Au", "Cu", "Fe", "Pb" (122 unique values)
+field:element
+    idx:fieldName "element" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
+## Analytical method via sequence path: sosa:usedProcedure -> rdfs:label
+## e.g. "XRF", "ICP-MS", "Fire Assay" (765 unique values)
+field:procedure
+    idx:fieldName "procedure" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
+## Laboratory via sequence path: sosa:madeBySensor -> rdfs:label
+## e.g. "ALS", "Genalysis", "SGS" (293 unique values)
+field:lab
+    idx:fieldName "lab" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
 ## --- GSWA Geochemistry Analysis Shape ---
 ## Each entity is a sosa:Observation typed as exg:GeochemistryAnalysis.
 ## 100K entities per file, 200 files available.
 
 :GeochemAnalysisShape
     sh:targetClass exg:GeochemistryAnalysis ;
-
-    ## Entity type label via sequence path: rdf:type -> rdfs:label
-    sh:property [
-        idx:fieldName "entityType" ;
-        idx:fieldType idx:KeywordField ;
-        idx:facetable true ;
-        sh:path ( rdf:type rdfs:label ) ;
-    ] ;
-
-    ## Observation label (site + sample ID)
-    sh:property [
-        idx:fieldName "title" ;
-        idx:fieldType idx:TextField ;
-        idx:defaultSearch true ;
-        sh:path rdfs:label ;
-    ] ;
-
-    ## Element being measured via sequence path: sosa:observedProperty -> rdfs:label
-    ## e.g. "Au", "Cu", "Fe", "Pb" (122 unique values)
-    sh:property [
-        idx:fieldName "element" ;
-        idx:fieldType idx:KeywordField ;
-        idx:facetable true ;
-        sh:path ( sosa:observedProperty rdfs:label ) ;
-    ] ;
-
-    ## Analytical method via sequence path: sosa:usedProcedure -> rdfs:label
-    ## e.g. "XRF", "ICP-MS", "Fire Assay" (765 unique values)
-    sh:property [
-        idx:fieldName "procedure" ;
-        idx:fieldType idx:KeywordField ;
-        idx:facetable true ;
-        sh:path ( sosa:usedProcedure rdfs:label ) ;
-    ] ;
-
-    ## Laboratory via sequence path: sosa:madeBySensor -> rdfs:label
-    ## e.g. "ALS", "Genalysis", "SGS" (293 unique values)
-    sh:property [
-        idx:fieldName "lab" ;
-        idx:fieldType idx:KeywordField ;
-        idx:facetable true ;
-        sh:path ( sosa:madeBySensor rdfs:label ) ;
-    ] .
+    sh:property [ idx:field field:entityType ; sh:path ( rdf:type rdfs:label ) ] ;
+    sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
+    sh:property [ idx:field field:element ; sh:path ( sosa:observedProperty rdfs:label ) ] ;
+    sh:property [ idx:field field:procedure ; sh:path ( sosa:usedProcedure rdfs:label ) ] ;
+    sh:property [ idx:field field:lab ; sh:path ( sosa:madeBySensor rdfs:label ) ] .

--- a/demo/test/config.ttl
+++ b/demo/test/config.ttl
@@ -42,112 +42,96 @@ PREFIX schema:  <https://schema.org/>
     text:maxFacetHits 50000 ;
     idx:fusekiBase "http://localhost:3030" .
 
-## --- Field definitions (named resources — IRIs used in SPARQL bindings) ---
+## --- Field definitions (canonical, path-free) ---
 
 field:entityType
     idx:fieldName "entityType" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path rdf:type .
+    idx:facetable true .
 
 field:title
     idx:fieldName "title" ;
     idx:fieldType idx:TextField ;
-    idx:defaultSearch true ;
-    sh:path rdfs:label .
+    idx:defaultSearch true .
 
 field:description
     idx:fieldName "description" ;
-    idx:fieldType idx:TextField ;
-    sh:path <http://purl.org/dc/terms/description> .
+    idx:fieldType idx:TextField .
 
 field:commodity
     idx:fieldName "commodity" ;
     idx:fieldType idx:KeywordField ;
     idx:facetable true ;
-    idx:multiValued true ;
-    sh:path ex:commodity .
+    idx:multiValued true .
 
 field:state
     idx:fieldName "state" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:state .
+    idx:facetable true .
 
 field:operator
     idx:fieldName "operator" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:operator .
+    idx:facetable true .
 
 field:status
     idx:fieldName "status" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:status .
+    idx:facetable true .
 
 field:year
     idx:fieldName "year" ;
     idx:fieldType idx:IntField ;
     idx:sortable true ;
-    idx:facetable true ;
-    sh:path ex:year .
+    idx:facetable true .
 
 field:publishedOn
     idx:fieldName "publishedOn" ;
     idx:fieldType idx:DateField ;
     idx:sortable true ;
     idx:facetable true ;
-    idx:storeLiteralMetadata true ;
-    sh:path ex:publishedOn .
+    idx:storeLiteralMetadata true .
 
 field:indexedAt
     idx:fieldName "indexedAt" ;
     idx:fieldType idx:DateTimeField ;
     idx:sortable true ;
-    idx:storeLiteralMetadata true ;
-    sh:path ex:indexedAt .
+    idx:storeLiteralMetadata true .
 
 field:reviewNote
     idx:fieldName "reviewNote" ;
     idx:fieldType idx:TextField ;
     idx:multiValued true ;
-    idx:storeLiteralMetadata true ;
-    sh:path ex:reviewNote .
+    idx:storeLiteralMetadata true .
 
 field:qaPassed
     idx:fieldName "qaPassed" ;
     idx:fieldType idx:KeywordField ;
     idx:facetable true ;
-    idx:storeLiteralMetadata true ;
-    sh:path ex:qaPassed .
+    idx:storeLiteralMetadata true .
 
 field:confidenceScore
     idx:fieldName "confidenceScore" ;
     idx:fieldType idx:DoubleField ;
     idx:facetable true ;
     idx:sortable true ;
-    idx:storeLiteralMetadata true ;
-    sh:path ex:confidenceScore .
+    idx:storeLiteralMetadata true .
 
 field:authorName
     idx:fieldName "authorName" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ( ex:authoredBy ex:name ) .
+    idx:facetable true .
 
 field:authoredByUri
     idx:fieldName "authoredByUri" ;
     idx:fieldType idx:KeywordField ;
-    idx:multiValued true ;
-    sh:path [ sh:inversePath ex:authored ] .
+    idx:multiValued true .
 
 field:depth
     idx:fieldName "depth" ;
     idx:fieldType idx:IntField ;
     idx:sortable true ;
-    idx:facetable true ;
-    sh:path ex:depth .
+    idx:facetable true .
 
 field:identifier
     idx:fieldName "identifier" ;
@@ -155,85 +139,80 @@ field:identifier
     idx:multiValued true ;
     idx:defaultSearch true ;
     idx:analyzer [ a text:EdgeNGramAnalyzer ] ;
-    idx:queryAnalyzer [ a text:LowerCaseKeywordAnalyzer ] ;
-    sh:path ex:identifier .
+    idx:queryAnalyzer [ a text:LowerCaseKeywordAnalyzer ] .
 
 field:identifierType
     idx:fieldName "identifierType" ;
     idx:fieldType idx:KeywordField ;
     idx:facetable true ;
-    idx:multiValued true ;
-    sh:path schema:propertyID .
+    idx:multiValued true .
 
 field:identifierValueExact
     idx:fieldName "identifierValueExact" ;
     idx:fieldType idx:KeywordField ;
     idx:facetable true ;
-    idx:multiValued true ;
-    sh:path schema:value .
+    idx:multiValued true .
 
 field:identifierValueText
     idx:fieldName "identifierValueText" ;
     idx:fieldType idx:TextField ;
     idx:multiValued true ;
     idx:analyzer [ a text:EdgeNGramAnalyzer ] ;
-    idx:queryAnalyzer [ a text:LowerCaseKeywordAnalyzer ] ;
-    sh:path schema:value .
+    idx:queryAnalyzer [ a text:LowerCaseKeywordAnalyzer ] .
 
 field:location
     idx:fieldName "location" ;
-    idx:fieldType idx:LatLonField ;
-    sh:path <http://www.opengis.net/ont/geosparql#asWKT> .
+    idx:fieldType idx:LatLonField .
 
 ## --- Shapes ---
 
 :MiningReportShape
     sh:targetClass ex:MiningReport ;
-    sh:property field:entityType ;
-    sh:property field:title ;
-    sh:property field:identifier ;
-    sh:property field:description ;
-    sh:property field:commodity ;
-    sh:property field:state ;
-    sh:property field:operator ;
-    sh:property field:status ;
-    sh:property field:year ;
-    sh:property field:publishedOn ;
-    sh:property field:indexedAt ;
-    sh:property field:reviewNote ;
-    sh:property field:qaPassed ;
-    sh:property field:confidenceScore ;
-    sh:property field:authorName ;
-    sh:property field:authoredByUri ;
+    sh:property [ idx:field field:entityType ; sh:path rdf:type ] ;
+    sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
+    sh:property [ idx:field field:identifier ; sh:path ex:identifier ] ;
+    sh:property [ idx:field field:description ; sh:path <http://purl.org/dc/terms/description> ] ;
+    sh:property [ idx:field field:commodity ; sh:path ex:commodity ] ;
+    sh:property [ idx:field field:state ; sh:path ex:state ] ;
+    sh:property [ idx:field field:operator ; sh:path ex:operator ] ;
+    sh:property [ idx:field field:status ; sh:path ex:status ] ;
+    sh:property [ idx:field field:year ; sh:path ex:year ] ;
+    sh:property [ idx:field field:publishedOn ; sh:path ex:publishedOn ] ;
+    sh:property [ idx:field field:indexedAt ; sh:path ex:indexedAt ] ;
+    sh:property [ idx:field field:reviewNote ; sh:path ex:reviewNote ] ;
+    sh:property [ idx:field field:qaPassed ; sh:path ex:qaPassed ] ;
+    sh:property [ idx:field field:confidenceScore ; sh:path ex:confidenceScore ] ;
+    sh:property [ idx:field field:authorName ; sh:path ( ex:authoredBy ex:name ) ] ;
+    sh:property [ idx:field field:authoredByUri ; sh:path [ sh:inversePath ex:authored ] ] ;
     idx:facetHierarchy ( field:state field:commodity ) .
 
 :BoreholeShape
     sh:targetClass ex:Borehole ;
-    sh:property field:entityType ;
-    sh:property field:title ;
-    sh:property field:identifier ;
-    sh:property field:description ;
-    sh:property field:commodity ;
-    sh:property field:state ;
-    sh:property field:depth ;
-    sh:property field:location ;
+    sh:property [ idx:field field:entityType ; sh:path rdf:type ] ;
+    sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
+    sh:property [ idx:field field:identifier ; sh:path ex:identifier ] ;
+    sh:property [ idx:field field:description ; sh:path <http://purl.org/dc/terms/description> ] ;
+    sh:property [ idx:field field:commodity ; sh:path ex:commodity ] ;
+    sh:property [ idx:field field:state ; sh:path ex:state ] ;
+    sh:property [ idx:field field:depth ; sh:path ex:depth ] ;
+    sh:property [ idx:field field:location ; sh:path <http://www.opengis.net/ont/geosparql#asWKT> ] ;
     idx:nested [
         idx:joinPath schema:identifier ;
-        idx:property field:identifierType ;
-        idx:property field:identifierValueExact ;
-        idx:property field:identifierValueText ;
+        idx:property [ idx:field field:identifierType ; sh:path schema:propertyID ] ;
+        idx:property [ idx:field field:identifierValueExact ; sh:path schema:value ] ;
+        idx:property [ idx:field field:identifierValueText ; sh:path schema:value ] ;
         idx:facetHierarchy ( field:identifierType field:identifierValueExact ) ;
     ] ;
     idx:facetHierarchy ( field:state field:commodity ) .
 
 :SiteShape
     sh:targetClass ex:Site ;
-    sh:property field:entityType ;
-    sh:property field:title ;
-    sh:property field:identifier ;
-    sh:property field:description ;
-    sh:property field:commodity ;
-    sh:property field:state ;
-    sh:property field:status ;
-    sh:property field:location ;
+    sh:property [ idx:field field:entityType ; sh:path rdf:type ] ;
+    sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
+    sh:property [ idx:field field:identifier ; sh:path ex:identifier ] ;
+    sh:property [ idx:field field:description ; sh:path <http://purl.org/dc/terms/description> ] ;
+    sh:property [ idx:field field:commodity ; sh:path ex:commodity ] ;
+    sh:property [ idx:field field:state ; sh:path ex:state ] ;
+    sh:property [ idx:field field:status ; sh:path ex:status ] ;
+    sh:property [ idx:field field:location ; sh:path <http://www.opengis.net/ont/geosparql#asWKT> ] ;
     idx:facetHierarchy ( field:state field:commodity ) .

--- a/docs/2026-04-09_fan_in_shared_field_occurrence_design.md
+++ b/docs/2026-04-09_fan_in_shared_field_occurrence_design.md
@@ -1,0 +1,725 @@
+---
+title: "shared field occurrence design"
+date: "2026-04-09"
+---
+
+# 2026-04-09 Shared Field Occurrence Design
+
+## Status
+
+This note proposes a simplification of the current SHACL-driven field model.
+
+The core change is to separate:
+
+- the canonical field identity used by queries and UI
+- the per-shape occurrence that describes how a value is reached
+
+## Problem
+
+The current model makes one resource do too many jobs at once.
+
+Today a field resource effectively serves as all of the following:
+
+- the public field IRI
+- the Lucene field definition
+- the path definition
+- the shape-local occurrence
+
+That works for simple cases, but it becomes awkward when many different shapes should contribute values to the same logical field through different paths.
+
+Example intent:
+
+- a `Survey` child reaches its parent borehole via `^schema:about`
+- a `Well` child reaches its parent borehole via `dcterms:hasPart`
+- both should populate one shared field such as `field:hasParent`
+
+In the current model, reusing one field IRI for multiple path definitions is not natural because the parser and mapping assume the field definition itself owns the path.
+
+## Proposed Model
+
+Split the model into two layers.
+
+### 1. Canonical field resource
+
+The canonical field resource defines the shared identity and shared Lucene/index behaviour.
+
+Example:
+
+```turtle
+@prefix idx:   <urn:jena:lucene:index#> .
+@prefix field: <urn:jena:lucene:field#> .
+
+field:hasParent
+    idx:fieldName "hasParent" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true ;
+    idx:stored true ;
+    idx:multiValued true .
+```
+
+This resource is the thing the query layer refers to.
+
+### 2. Property occurrence node
+
+Each `sh:property` is a shape-local occurrence that says how that shape populates the canonical field.
+
+Example:
+
+```turtle
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix ex:     <http://example.org/> .
+@prefix schema: <https://schema.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+shape:SurveyShape
+    sh:targetClass ex:Survey ;
+    sh:property [
+        idx:field field:hasParent ;
+        sh:path [ sh:inversePath schema:about ] ;
+        sh:class ex:Borehole ;
+    ] .
+
+shape:WellShape
+    sh:targetClass ex:Well ;
+    sh:property [
+        idx:field field:hasParent ;
+        sh:path dcterms:hasPart ;
+        sh:class ex:Borehole ;
+    ] .
+```
+
+This means:
+
+- `field:hasParent` is the shared field identity
+- each blank node is one field occurrence
+- the occurrence supplies the path
+- optional occurrence-level constraints restrict which reached nodes are indexed
+
+## What The New Design Supports
+
+This model supports:
+
+- one canonical field being populated from many different shapes
+- different `sh:path` values per contributing shape
+- reuse of shared field metadata such as type, analyzers, faceting, and storage flags
+- occurrence-level filtering of path endpoints through simple supported constraints
+- a stable public field IRI even when the underlying paths differ
+
+This model makes it natural to describe a field as a reusable concept instead of as a single path-bound definition.
+
+## Example: Fan-in to a Shared `hasRelated` Field
+
+This example shows two shapes with different target classes and different paths, each contributing to one shared keyword field.
+
+The field concept is "related objects" — a loose grouping that means something different per shape but should be queryable and facetable as a single dimension.
+
+### Canonical field
+
+```turtle
+@prefix idx:   <urn:jena:lucene:index#> .
+@prefix field: <urn:jena:lucene:field#> .
+
+field:hasRelated
+    idx:fieldName "hasRelated" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable  true ;
+    idx:stored     true ;
+    idx:multiValued true .
+```
+
+The field stores the IRI of each related resource. It is declared once and is shared across all shapes that reference it.
+
+### Shapes
+
+```turtle
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix idx:   <urn:jena:lucene:index#> .
+@prefix field: <urn:jena:lucene:field#> .
+@prefix ex:    <http://example.org/> .
+
+shape:ArticleShape
+    sh:targetClass ex:Article ;
+    sh:property [
+        idx:field field:hasRelated ;
+        sh:path   ex:cites ;
+        sh:class  ex:Report ;
+    ] .
+
+shape:ProjectShape
+    sh:targetClass ex:Project ;
+    sh:property [
+        idx:field field:hasRelated ;
+        sh:path   ex:involves ;
+        sh:class  ex:Organisation ;
+    ] .
+```
+
+`ex:Article` entities reach related resources via `ex:cites` and keep only those of class `ex:Report`.
+
+`ex:Project` entities reach related resources via `ex:involves` and keep only those of class `ex:Organisation`.
+
+Both occurrences write surviving IRIs into the same `hasRelated` Lucene field.
+
+### Example data
+
+```turtle
+ex:article1  a ex:Article ;
+    ex:cites ex:report1, ex:dataset1 .
+
+ex:report1   a ex:Report .
+ex:dataset1  a ex:Dataset .
+
+ex:project1  a ex:Project ;
+    ex:involves ex:org1, ex:person1 .
+
+ex:org1      a ex:Organisation .
+ex:person1   a ex:Person .
+```
+
+### What gets indexed
+
+| Document | Field | Indexed values | Notes |
+|---|---|---|---|
+| `ex:article1` | `hasRelated` | `ex:report1` | `ex:dataset1` dropped — not `sh:class ex:Report` |
+| `ex:project1` | `hasRelated` | `ex:org1` | `ex:person1` dropped — not `sh:class ex:Organisation` |
+
+`ex:dataset1` and `ex:person1` are reachable via the configured paths but do not satisfy the `sh:class` constraint on their respective occurrences, so they are not indexed.
+
+### Querying
+
+A filter query finds all entities related to a specific resource, regardless of which shape produced the relationship:
+
+```sparql
+PREFIX luc: <urn:jena:lucene:>
+
+SELECT ?hit ?entity WHERE {
+    (?hit ?entity ?score ?totalHits)
+        luc:query (
+            "default"
+            "default"
+            ""
+            '{"op":"=","args":[{"property":"urn:jena:lucene:field#hasRelated"},
+                               "http://example.org/report1"]}'
+            ""
+            -1
+        ) .
+}
+```
+
+This returns `ex:article1`. Filtering by `ex:org1` would return `ex:project1`. In both cases the query is identical in shape — only the filter value changes. The query has no knowledge of which shape or path produced the value.
+
+A facet query over the same field returns counts across all contributing shapes at once:
+
+```sparql
+PREFIX luc: <urn:jena:lucene:>
+
+SELECT ?value ?count WHERE {
+    luc:facet (
+        "default"
+        "default"
+        ""
+        ""
+        "urn:jena:lucene:field#hasRelated"
+        -1
+    ) ?value ?count .
+}
+```
+
+This would return `ex:report1` and `ex:org1` as facet values with a count of 1 each, even though they come from entirely different shapes and paths.
+
+## Relationship To Nested Child Scopes
+
+This model does not replace the nested child-record design.
+
+The two designs address different concerns:
+
+- the shared-field model separates canonical field identity from occurrence/path
+- the nested model separates root scope from correlated child scope
+
+Those concerns compose cleanly.
+
+Use the shared-field model to define what a field is.
+
+Use `idx:nested` when a shape needs to index a repeated correlated child record such as:
+
+- identifiers
+- qualified attributions
+- observations
+- location assessments
+
+In other words:
+
+- canonical fields define Lucene behaviour and public field identity
+- occurrences define how a scope populates a canonical field
+- `idx:nested` defines an additional child scope relative to the parent document
+
+## Relationship To Hierarchies
+
+Hierarchies should remain derived scope-level definitions, not separate extracted fields.
+
+That means the merged model is:
+
+- canonical fields are the reusable field definitions
+- occurrences populate those canonical fields in either root scope or nested scope
+- `idx:facetHierarchy` defines a hierarchy over canonical fields that already exist in that scope
+
+This is important because a hierarchy is not just another field occurrence.
+
+It does not introduce a new extracted value. Instead it defines how correlated field values should be emitted into the taxonomy index for drill-down and counting.
+
+### Recommendation
+
+Do not model the hierarchy as a fourth peer field under `sh:property`.
+
+For the identifier case, keep:
+
+- one keyword field for the top-level identifier kind, such as company/anumber/mnumber
+- one keyword field for the identifier value used for drill-down and exact filtering
+- one text field for the identifier value used for prefix search / typeahead
+- one hierarchy definition over the two keyword fields
+
+So the identifier pattern is best understood as:
+
+- three canonical fields
+- one derived hierarchy dimension
+
+and not:
+
+- four separate fields
+
+## Why `idx:joinPath` Should Remain Distinct
+
+`idx:joinPath` and `sh:path` may look similar, but they do different jobs.
+
+- `idx:joinPath` establishes a correlated child scope
+- `sh:path` extracts field values within the current scope
+
+That distinction should remain explicit.
+
+For example, in the identifier case:
+
+- `idx:joinPath schema:identifier` means "enumerate identifier child records"
+- `sh:path schema:propertyID` means "within one identifier child, extract the type"
+- `sh:path schema:value` means "within one identifier child, extract the value"
+
+Using `sh:path` on `idx:nested` would blur the difference between:
+
+- entering a repeated correlated child-record context
+- extracting one field value from the current context
+
+Keeping `idx:joinPath` distinct also matches the current implementation model:
+
+- nested indexing iterates child records first
+- change propagation treats join paths specially
+- future block-join execution will also need that distinction
+
+So the recommended split is:
+
+- `idx:joinPath` for scope creation
+- `sh:path` for field occurrences
+
+## Why Move To This Model
+
+The proposed split improves both the public RDF model and the implementation model.
+
+Benefits:
+
+- the canonical field resource becomes reusable
+- path definitions become local to the shape that needs them
+- the public field identity stops being tied to one specific path
+- the parser no longer has to overload one RDF node with both reusable metadata and local traversal rules
+- the design aligns more closely with SHACL property-shape structure
+
+This also avoids the awkward current situation where reusing one field identity across several path variants feels like trying to reuse the wrong abstraction.
+
+## Occurrence Constraints
+
+The occurrence node is the right place to attach path-endpoint restrictions such as:
+
+- `sh:class`
+- `sh:nodeKind`
+- `sh:datatype`
+
+These should be interpreted as index-time filtering constraints, not as full SHACL validation.
+
+These three constraints should be supported in the initial implementation.
+
+Reason:
+
+- they are local to the reached node or value
+- they are simple to evaluate during indexing
+- they greatly improve practical expressiveness for fan-in fields
+- they avoid the much larger complexity jump that comes with nested shape evaluation
+
+Example:
+
+```turtle
+sh:property [
+    idx:field field:hasParent ;
+    sh:path [ sh:inversePath schema:about ] ;
+    sh:class ex:Borehole ;
+] .
+```
+
+This means:
+
+- evaluate the path
+- keep only reached nodes that satisfy the supported constraints
+- index the surviving values into the shared field
+
+### Recommendation On `sh:node`
+
+Full `sh:node` support should not be part of the first implementation.
+
+Reason:
+
+- `sh:class` and similar simple constraints are local and cheap
+- `sh:node` implies nested shape evaluation
+- that significantly complicates both indexing and incremental change propagation
+
+Initial support should include:
+
+- `sh:class`
+- `sh:nodeKind`
+- `sh:datatype`
+
+and should remain limited to constraints that can be checked locally.
+
+## Current Model Versus Proposed Model
+
+### Current model
+
+A field resource owns:
+
+- `idx:fieldName`
+- `idx:fieldType`
+- analyzers and flags
+- `sh:path`
+- implicit field IRI
+
+That coupling is reflected in the parser:
+
+- [`ShaclIndexAssembler.java#L351`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java#L351) parses one resource as one field definition
+- [`ShaclIndexAssembler.java#L386`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java#L386) requires the path on that same resource
+- [`ShaclIndexAssembler.java#L395`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java#L395) treats the field resource URI as the field IRI
+
+### Proposed model
+
+Canonical field resource owns:
+
+- field IRI
+- field name
+- type
+- analyzers
+- faceting/search/sort/store metadata
+
+Property occurrence owns:
+
+- `idx:field` reference to the canonical field
+- `sh:path`
+- optional supported constraints such as `sh:class`
+
+This is a better separation of concerns:
+
+- field identity is stable
+- path is local to a specific shape occurrence
+- one canonical field can be populated from many occurrences
+
+## Lucene Naming
+
+Lucene currently uses `idx:fieldName`, not the field IRI, as the actual field key:
+
+- [`ShaclTextIndexLucene.java#L622`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java#L622)
+- [`ShaclTextIndexLucene.java#L717`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java#L717)
+
+The query layer already treats field IRIs as the public contract and resolves them to field names:
+
+- [`ShaclTextIndexLucene.java#L217`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java#L217)
+- [`ShaclTextIndexLucene.java#L265`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java#L265)
+
+So the proposed model fits the current public direction well.
+
+The design does not require Lucene field names to become IRIs. That remains an independent choice.
+
+## Required Internal Refactor
+
+The current implementation needs an explicit distinction between canonical fields and occurrences.
+
+### New conceptual model
+
+- `FieldDef`: canonical field metadata
+- `FieldOccurrence`: one shape-local use of a field, with path and supported constraints
+
+Each profile should then hold:
+
+- a list of canonical fields reachable in that profile
+- a list of root occurrences
+- nested definitions containing nested occurrences
+
+### Why this is required
+
+Today indexing walks `FieldDef` directly and extracts values from `fieldDef.getPath()`:
+
+- [`ShaclEntityBuilder.java#L47`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java#L47)
+- [`ShaclEntityBuilder.java#L77`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java#L77)
+
+That is incompatible with a design where the canonical field is path-free and the occurrence owns the path.
+
+## Incremental Change Propagation Risk
+
+This is the main technical complication introduced by occurrence-level constraints.
+
+The current change listener mainly tracks:
+
+- root `rdf:type`
+- predicates that appear in field paths
+- nested join predicates
+
+See:
+
+- [`ShaclTextDocProducer.java#L80`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java#L80)
+- [`ShaclTextDocProducer.java#L175`](/home/david/PycharmProjects/jena-facet/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java#L175)
+
+If an occurrence uses `sh:class ex:Borehole`, then a related node changing type may affect whether the parent value should be indexed, even if the path triples themselves did not change.
+
+Example:
+
+1. child document reaches node `X` via the configured path
+2. `X` gains or loses `rdf:type ex:Borehole`
+3. the child document should be rebuilt because `field:hasParent` membership changed
+
+The current listener does not have a general model for that dependency.
+
+### Consequence
+
+Occurrence-level constraints require expanding the dependency graph beyond path predicates alone.
+
+At minimum:
+
+- `sh:class` implies dependency on `rdf:type` of the reached node
+- simple node-kind or datatype constraints imply dependency on the endpoint value kind
+
+This is manageable, but it must be designed explicitly.
+
+## Per-Document Dedupe
+
+The fan-in model does not imply deduping result rows across documents.
+
+Many child documents may legitimately share the same parent value. That is the intended behaviour.
+
+The dedupe concern is only within a single document:
+
+- if multiple occurrences on the same child document yield the same parent ID
+- the document should ideally index that parent value once for that field
+
+Why:
+
+- stored values stay cleaner
+- facet counts are less likely to be distorted
+- explanations and match reporting are less noisy
+
+So the design should use set semantics per document per field, not global dedupe across documents.
+
+## Gaps This Design Introduces
+
+Compared to the current code, the proposed model creates the following implementation gaps:
+
+- the assembler must parse property occurrences separately from canonical field resources
+- field lookup by IRI must resolve to the canonical field, not to one arbitrary occurrence
+- indexing must evaluate occurrences and emit values into the canonical field name
+- change propagation must understand occurrence constraints
+- hierarchy definitions must choose whether they target canonical fields or occurrences
+
+## Recommendation For Hierarchies
+
+For the first version of this model:
+
+- use canonical field IRIs in ordinary field references and query APIs
+- keep hierarchy definitions referring to canonical fields unless a concrete ambiguity appears
+- keep hierarchies as scope-level derived definitions rather than separate field occurrences
+
+If a future case requires multiple distinct occurrences of the same canonical field inside one correlated hierarchy context, then occurrence-level hierarchy references can be added later.
+
+The current relationship-tab use case does not require that complexity.
+
+## Merged Identifier Example
+
+The following example shows how the shared-field design composes with `idx:nested`.
+
+Canonical fields:
+
+```turtle
+@prefix idx:    <urn:jena:lucene:index#> .
+@prefix field:  <urn:jena:lucene:field#> .
+@prefix text:   <http://jena.apache.org/text#> .
+
+field:identifierType
+    idx:fieldName "identifierType" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
+field:identifierValueExact
+    idx:fieldName "identifierValueExact" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
+field:identifierValueText
+    idx:fieldName "identifierValueText" ;
+    idx:fieldType idx:TextField ;
+    idx:analyzer [ a text:EdgeNGramAnalyzer ] ;
+    idx:queryAnalyzer [ a text:LowerCaseKeywordAnalyzer ] .
+```
+
+Shape with nested identifier scope:
+
+```turtle
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix ex:     <http://example.org/> .
+@prefix schema: <https://schema.org/> .
+
+shape:BoreholeShape
+    sh:targetClass ex:Borehole ;
+    idx:nested [
+        idx:joinPath schema:identifier ;
+
+        idx:property [
+            idx:field field:identifierType ;
+            sh:path schema:propertyID ;
+        ] ;
+
+        idx:property [
+            idx:field field:identifierValueExact ;
+            sh:path schema:value ;
+        ] ;
+
+        idx:property [
+            idx:field field:identifierValueText ;
+            sh:path schema:value ;
+        ] ;
+
+        idx:facetHierarchy ( field:identifierType field:identifierValueExact ) ;
+    ] .
+```
+
+This says:
+
+- one child scope is created for each `schema:identifier` node
+- the two keyword fields are used for correlated hierarchy tuples
+- the text field is available for flattened prefix/typeahead search
+- the hierarchy remains a derived definition over the keyword fields, not a separate fourth field
+
+## Proposed Parser Rules
+
+### Canonical field resource
+
+Supported properties:
+
+- `idx:fieldName`
+- `idx:fieldType`
+- `idx:analyzer`
+- `idx:queryAnalyzer`
+- `idx:stored`
+- `idx:indexed`
+- `idx:facetable`
+- `idx:sortable`
+- `idx:multiValued`
+- `idx:defaultSearch`
+- `idx:storeLiteralMetadata`
+
+Not supported on canonical field resource:
+
+- `sh:path`
+
+### Property occurrence node
+
+Required:
+
+- `idx:field`
+- `sh:path`
+
+Optional initially:
+
+- `sh:class`
+- `sh:nodeKind`
+- `sh:datatype`
+
+Not supported initially:
+
+- full `sh:node`
+- general SHACL validation semantics
+
+### Nested scope block
+
+Required:
+
+- `idx:joinPath`
+
+Optional:
+
+- `idx:property` for child-scope occurrences
+- `idx:facetHierarchy` for hierarchies over child-scope canonical fields
+
+`idx:joinPath` should remain distinct from `sh:path`.
+
+It establishes the child scope itself rather than extracting one field value.
+
+## Suggested Internal API Shape
+
+Illustrative only:
+
+```java
+record FieldDef(
+    Node fieldIri,
+    String fieldName,
+    FieldType fieldType,
+    ...
+) {}
+
+record FieldOccurrence(
+    FieldDef field,
+    Path path,
+    Node requiredClass,
+    NodeKind nodeKind,
+    Node datatype,
+    String nestedName
+) {}
+```
+
+The entity builder then:
+
+1. iterates occurrences
+2. evaluates the occurrence path
+3. applies supported constraints
+4. converts surviving nodes to values using the canonical field type
+5. inserts those values under the canonical field name
+
+## Migration Direction
+
+This note intentionally ignores backward compatibility.
+
+The clean direction is:
+
+- canonical field resources are reusable definitions
+- `sh:property` blank nodes are occurrences
+- `idx:property` blank nodes inside `idx:nested` are also occurrences
+- `idx:nested` continues to define correlated child scope boundaries
+- field resources no longer carry `sh:path`
+
+That is simpler for users and cleaner internally than trying to preserve the current overloaded field-resource model.
+
+## Decision
+
+Adopt the shared canonical field plus property occurrence model.
+
+Specifically:
+
+- use one canonical field IRI for the shared field concept
+- allow many property occurrences to contribute to that field through different paths
+- support `sh:class`, `sh:nodeKind`, and `sh:datatype` in the first implementation
+- keep `idx:nested` for repeated correlated child records
+- keep `idx:joinPath` as the scope-forming path for nested child records
+- keep hierarchies as derived scope-level definitions over canonical fields rather than separate field occurrences
+- treat per-document values as sets for that field
+- defer full `sh:node` support until there is a strong need
+
+This is a better fit than the current field-resource-equals-path-definition design.

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
@@ -26,13 +26,12 @@ import java.util.*;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.ShaclIndexMapping.NestedDef;
-import org.apache.jena.sparql.path.P_Link;
-import org.apache.jena.sparql.path.Path;
 import org.apache.jena.sparql.path.eval.PathEval;
-import org.apache.jena.util.iterator.ExtendedIterator;
+import org.apache.jena.vocabulary.RDF;
 
 /**
  * Builds parent entities and nested child records from a graph and a parsed index profile.
@@ -43,95 +42,99 @@ final class ShaclEntityBuilder {
 
     static Entity buildEntity(Graph graph, Node subject, String entityUri, IndexProfile profile) {
         Entity entity = new Entity(entityUri, null);
+        Map<String, LinkedHashSet<Object>> docValues = new LinkedHashMap<>();
 
-        for (FieldDef fieldDef : profile.getFields()) {
-            if (fieldDef.isNestedScoped()) {
-                continue;
-            }
-            addFieldValues(entity, fieldDef.getFieldName(), extractFieldValues(graph, subject, fieldDef));
+        for (FieldOccurrence occurrence : profile.getRootOccurrences()) {
+            addValues(docValues, occurrence.getField().getFieldName(),
+                extractOccurrenceValues(graph, subject, occurrence));
         }
 
         for (NestedDef nestedDef : profile.getNestedDefs()) {
             Iterator<Node> childIter = PathEval.eval(graph, subject, nestedDef.getJoinPath(), null);
             while (childIter.hasNext()) {
                 Node child = childIter.next();
-                Entity.NestedRecord record = new Entity.NestedRecord();
-                boolean hasValues = false;
-                for (FieldDef fieldDef : nestedDef.getFields()) {
-                    List<Object> values = extractFieldValues(graph, child, fieldDef);
+                Map<String, LinkedHashSet<Object>> recordValues = new LinkedHashMap<>();
+
+                for (FieldOccurrence occurrence : nestedDef.getOccurrences()) {
+                    List<Object> values = extractOccurrenceValues(graph, child, occurrence);
                     if (!values.isEmpty()) {
-                        hasValues = true;
-                        addFieldValues(entity, fieldDef.getFieldName(), values);
-                        addFieldValues(record, fieldDef.getFieldName(), values);
+                        addValues(docValues, occurrence.getField().getFieldName(), values);
+                        addValues(recordValues, occurrence.getField().getFieldName(), values);
                     }
                 }
-                if (hasValues) {
-                    entity.addNestedRecord(nestedDef.getNestedName(), record);
+
+                if (!recordValues.isEmpty()) {
+                    entity.addNestedRecord(nestedDef.getNestedName(), toNestedRecord(recordValues));
                 }
+            }
+        }
+
+        for (Map.Entry<String, LinkedHashSet<Object>> entry : docValues.entrySet()) {
+            for (Object value : entry.getValue()) {
+                entity.addValue(entry.getKey(), value);
             }
         }
 
         return entity;
     }
 
-    private static List<Object> extractFieldValues(Graph graph, Node subject, FieldDef fieldDef) {
-        List<Object> values = new ArrayList<>();
-        Path path = fieldDef.getPath();
-
-        if (path != null && fieldDef.hasComplexPath()) {
-            Iterator<Node> iter = PathEval.eval(graph, subject, path, null);
-            while (iter.hasNext()) {
-                Object value = nodeToValue(iter.next(), fieldDef.getFieldType(), fieldDef.preservesLiteralMetadata());
-                if (value != null) {
-                    values.add(value);
-                }
-            }
-            return values;
-        }
-
-        if (path instanceof P_Link pLink) {
-            ExtendedIterator<Node> iter = graph.find(subject, pLink.getNode(), Node.ANY)
-                .mapWith(t -> t.getObject());
-            try {
-                while (iter.hasNext()) {
-                    Object value = nodeToValue(iter.next(), fieldDef.getFieldType(), fieldDef.preservesLiteralMetadata());
-                    if (value != null) {
-                        values.add(value);
-                    }
-                }
-            } finally {
-                iter.close();
-            }
-            return values;
-        }
-
-        for (Node predicate : fieldDef.getPredicates()) {
-            ExtendedIterator<Node> iter = graph.find(subject, predicate, Node.ANY)
-                .mapWith(t -> t.getObject());
-            try {
-                while (iter.hasNext()) {
-                    Object value = nodeToValue(iter.next(), fieldDef.getFieldType(), fieldDef.preservesLiteralMetadata());
-                    if (value != null) {
-                        values.add(value);
-                    }
-                }
-            } finally {
-                iter.close();
+    private static Entity.NestedRecord toNestedRecord(Map<String, LinkedHashSet<Object>> recordValues) {
+        Entity.NestedRecord record = new Entity.NestedRecord();
+        for (Map.Entry<String, LinkedHashSet<Object>> entry : recordValues.entrySet()) {
+            for (Object value : entry.getValue()) {
+                record.addValue(entry.getKey(), value);
             }
         }
-        return values;
+        return record;
     }
 
-    private static void addFieldValues(Entity entity, String fieldName, List<Object> values) {
-        for (Object value : values) {
-            entity.addValue(fieldName, value);
+    private static void addValues(Map<String, LinkedHashSet<Object>> target, String fieldName, List<Object> values) {
+        if (values.isEmpty()) {
+            return;
         }
+        target.computeIfAbsent(fieldName, key -> new LinkedHashSet<>()).addAll(values);
     }
 
-    private static void addFieldValues(Entity.NestedRecord record, String fieldName, List<Object> values) {
-        for (Object value : values) {
-            record.addValue(fieldName, value);
+    private static List<Object> extractOccurrenceValues(Graph graph, Node subject, FieldOccurrence occurrence) {
+        LinkedHashSet<Object> values = new LinkedHashSet<>();
+        Iterator<Node> iter = PathEval.eval(graph, subject, occurrence.getPath(), null);
+        while (iter.hasNext()) {
+            Node endpoint = iter.next();
+            if (!satisfiesConstraints(graph, endpoint, occurrence)) {
+                continue;
+            }
+            Object value = nodeToValue(endpoint, occurrence.getField().getFieldType(),
+                occurrence.getField().preservesLiteralMetadata());
+            if (value != null) {
+                values.add(value);
+            }
         }
+        return new ArrayList<>(values);
+    }
+
+    private static boolean satisfiesConstraints(Graph graph, Node endpoint, FieldOccurrence occurrence) {
+        if (occurrence.getRequiredClass() != null) {
+            if (!endpoint.isBlank() && !endpoint.isURI()) {
+                return false;
+            }
+            if (!graph.find(endpoint, RDF.type.asNode(), occurrence.getRequiredClass()).hasNext()) {
+                return false;
+            }
+        }
+        if (occurrence.getNodeKindConstraint() != null
+                && !occurrence.getNodeKindConstraint().matches(endpoint)) {
+            return false;
+        }
+        if (occurrence.getDatatype() != null) {
+            if (!endpoint.isLiteral()) {
+                return false;
+            }
+            String datatypeUri = endpoint.getLiteralDatatypeURI();
+            if (!Objects.equals(datatypeUri, occurrence.getDatatype().getURI())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     static Object nodeToValue(Node obj, FieldType fieldType) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -25,13 +25,14 @@ import java.util.*;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.path.P_Link;
 import org.apache.jena.sparql.path.Path;
 import org.apache.lucene.analysis.Analyzer;
 
 /**
- * Parsed representation of SHACL-like index shapes for entity-per-document indexing.
- * Pure data model — no RDF parsing or Lucene indexing logic.
+ * Parsed representation of SHACL-driven index shapes.
+ * <p>
+ * Canonical fields carry Lucene/index metadata only. Field extraction is modeled
+ * separately as root or nested field occurrences.
  */
 public class ShaclIndexMapping {
 
@@ -39,9 +40,30 @@ public class ShaclIndexMapping {
         TEXT, KEYWORD, INT, LONG, DOUBLE, DATE, DATETIME, LATLON
     }
 
+    public enum NodeKindConstraint {
+        IRI,
+        BLANK_NODE,
+        LITERAL,
+        BLANK_NODE_OR_IRI,
+        BLANK_NODE_OR_LITERAL,
+        IRI_OR_LITERAL;
+
+        public boolean matches(Node node) {
+            return switch (this) {
+                case IRI -> node != null && node.isURI();
+                case BLANK_NODE -> node != null && node.isBlank();
+                case LITERAL -> node != null && node.isLiteral();
+                case BLANK_NODE_OR_IRI -> node != null && (node.isBlank() || node.isURI());
+                case BLANK_NODE_OR_LITERAL -> node != null && (node.isBlank() || node.isLiteral());
+                case IRI_OR_LITERAL -> node != null && (node.isURI() || node.isLiteral());
+            };
+        }
+    }
+
     private static final String FIELD_IRI_PREFIX = "urn:jena:lucene:field#";
 
     public static class FieldDef {
+        private final Node fieldIRI;
         private final String fieldName;
         private final FieldType fieldType;
         private final Analyzer analyzer;
@@ -53,42 +75,53 @@ public class ShaclIndexMapping {
         private final boolean multiValued;
         private final boolean defaultSearch;
         private final boolean storeLiteralMetadata;
-        private final Set<Node> predicates;
-        private final Path path;
-        private final Node fieldIRI;
-        private final String nestedName;
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         boolean stored, boolean indexed, boolean facetable,
-                        boolean sortable, boolean multiValued, boolean defaultSearch,
-                        Set<Node> predicates) {
+                        boolean sortable, boolean multiValued, boolean defaultSearch) {
             this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
-                 sortable, multiValued, defaultSearch, false, predicates, null, null, null);
+                sortable, multiValued, defaultSearch, false, null);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
-                        Set<Node> predicates, Path path) {
+                        Set<Node> ignoredPredicates) {
             this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
-                 sortable, multiValued, defaultSearch, false, predicates, path, null, null);
+                sortable, multiValued, defaultSearch, false, null);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
-                        Set<Node> predicates, Path path, Node fieldIRI) {
+                        Set<Node> ignoredPredicates, Path ignoredPath) {
             this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
-                 sortable, multiValued, defaultSearch, false, predicates, path, fieldIRI, null);
+                sortable, multiValued, defaultSearch, false, null);
+        }
+
+        public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
+                        boolean stored, boolean indexed, boolean facetable,
+                        boolean sortable, boolean multiValued, boolean defaultSearch,
+                        Set<Node> ignoredPredicates, Path ignoredPath, Node fieldIRI) {
+            this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
+                sortable, multiValued, defaultSearch, false, fieldIRI);
+        }
+
+        public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
+                        Analyzer queryAnalyzer,
+                        boolean stored, boolean indexed, boolean facetable,
+                        boolean sortable, boolean multiValued, boolean defaultSearch) {
+            this(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed, facetable,
+                sortable, multiValued, defaultSearch, false, null);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         Analyzer queryAnalyzer,
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
-                        Set<Node> predicates, Path path, Node fieldIRI) {
+                        Set<Node> ignoredPredicates, Path ignoredPath, Node fieldIRI) {
             this(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed, facetable,
-                sortable, multiValued, defaultSearch, false, predicates, path, fieldIRI, null);
+                sortable, multiValued, defaultSearch, false, fieldIRI);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
@@ -96,17 +129,16 @@ public class ShaclIndexMapping {
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
                         boolean storeLiteralMetadata,
-                        Set<Node> predicates, Path path, Node fieldIRI) {
+                        Set<Node> ignoredPredicates, Path ignoredPath, Node fieldIRI) {
             this(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed, facetable,
-                sortable, multiValued, defaultSearch, storeLiteralMetadata, predicates, path, fieldIRI, null);
+                sortable, multiValued, defaultSearch, storeLiteralMetadata, fieldIRI);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         Analyzer queryAnalyzer,
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
-                        boolean storeLiteralMetadata,
-                        Set<Node> predicates, Path path, Node fieldIRI, String nestedName) {
+                        boolean storeLiteralMetadata, Node fieldIRI) {
             this.fieldName = Objects.requireNonNull(fieldName);
             this.fieldType = fieldType != null ? fieldType : FieldType.TEXT;
             this.analyzer = analyzer;
@@ -118,64 +150,42 @@ public class ShaclIndexMapping {
             this.multiValued = multiValued;
             this.defaultSearch = defaultSearch;
             this.storeLiteralMetadata = storeLiteralMetadata;
-            this.predicates = predicates != null ? Collections.unmodifiableSet(new LinkedHashSet<>(predicates)) : Collections.emptySet();
-            this.path = path;
-            this.fieldIRI = fieldIRI != null ? fieldIRI
-                : NodeFactory.createURI(FIELD_IRI_PREFIX + fieldName);
-            this.nestedName = nestedName;
+            this.fieldIRI = fieldIRI != null ? fieldIRI : NodeFactory.createURI(FIELD_IRI_PREFIX + fieldName);
         }
 
-        public String getFieldName()       { return fieldName; }
-        public FieldType getFieldType()     { return fieldType; }
-        public Analyzer getAnalyzer()       { return analyzer; }
-        public Analyzer getQueryAnalyzer()  { return queryAnalyzer; }
-        public boolean isStored()           { return stored; }
-        public boolean isIndexed()          { return indexed; }
-        public boolean isFacetable()        { return facetable; }
-        public boolean isSortable()         { return sortable; }
-        public boolean isMultiValued()      { return multiValued; }
-        public boolean isDefaultSearch()    { return defaultSearch; }
-        public boolean isStoreLiteralMetadata() { return storeLiteralMetadata; }
-        public Set<Node> getPredicates()    { return predicates; }
         public Node getFieldIRI()            { return fieldIRI; }
-        public String getNestedName()       { return nestedName; }
-        public boolean isNestedScoped()     { return nestedName != null; }
-        public boolean isRootScoped()       { return nestedName == null; }
-        public boolean isDateLike()         { return fieldType == FieldType.DATE || fieldType == FieldType.DATETIME; }
+        public String getFieldName()         { return fieldName; }
+        public FieldType getFieldType()      { return fieldType; }
+        public Analyzer getAnalyzer()        { return analyzer; }
+        public Analyzer getQueryAnalyzer()   { return queryAnalyzer; }
+        public boolean isStored()            { return stored; }
+        public boolean isIndexed()           { return indexed; }
+        public boolean isFacetable()         { return facetable; }
+        public boolean isSortable()          { return sortable; }
+        public boolean isMultiValued()       { return multiValued; }
+        public boolean isDefaultSearch()     { return defaultSearch; }
+        public boolean isStoreLiteralMetadata() { return storeLiteralMetadata; }
+        public boolean isDateLike()          { return fieldType == FieldType.DATE || fieldType == FieldType.DATETIME; }
         public boolean preservesLiteralMetadata() { return storeLiteralMetadata || isDateLike(); }
 
-        /** The structured path for this field. Null for simple predicate fields (backward compat). */
-        public Path getPath()              { return path; }
-
-        /** True if this field uses a complex path (sequence, inverse, or nested). */
-        public boolean hasComplexPath() {
-            return path != null && !(path instanceof P_Link);
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof FieldDef fieldDef)) return false;
+            return fieldIRI.equals(fieldDef.fieldIRI);
         }
 
-        public FieldDef withNestedName(String nestedName) {
-            if (Objects.equals(this.nestedName, nestedName)) {
-                return this;
-            }
-            return new FieldDef(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed,
-                facetable, sortable, multiValued, defaultSearch, storeLiteralMetadata,
-                predicates, path, fieldIRI, nestedName);
+        @Override
+        public int hashCode() {
+            return fieldIRI.hashCode();
         }
 
         @Override
         public String toString() {
-            return nestedName == null
-                ? fieldName + "(" + fieldType + ")"
-                : fieldName + "(" + fieldType + "@" + nestedName + ")";
+            return fieldName + "(" + fieldType + ")";
         }
     }
 
-    /**
-     * Defines a hierarchical facet dimension composed of ordered field levels.
-     * Each level is a {@link FieldDef} whose values form path components in a Lucene taxonomy.
-     * <p>
-     * Example: a hierarchy of (type, subtype) where type="Water Bore" and subtype="BH123456"
-     * produces a Lucene {@code FacetField("type_hierarchy", "Water Bore", "BH123456")}.
-     */
     public static class HierarchyDef {
         private final String dimensionName;
         private final List<FieldDef> levels;
@@ -188,22 +198,12 @@ public class ShaclIndexMapping {
             this.levels = Collections.unmodifiableList(new ArrayList<>(levels));
         }
 
-        public String getDimensionName()   { return dimensionName; }
-        public List<FieldDef> getLevels()   { return levels; }
-        public int getDepth()              { return levels.size(); }
-
-        /** Get the FieldDef for a specific level (0-based). */
-        public FieldDef getLevel(int index) { return levels.get(index); }
-
-        /** Check if a FieldDef is part of this hierarchy. */
-        public boolean containsField(FieldDef field) {
-            return levels.contains(field);
-        }
-
-        /** Get the level index of a field, or -1 if not in this hierarchy. */
-        public int getLevelIndex(FieldDef field) {
-            return levels.indexOf(field);
-        }
+        public String getDimensionName()     { return dimensionName; }
+        public List<FieldDef> getLevels()    { return levels; }
+        public int getDepth()                { return levels.size(); }
+        public FieldDef getLevel(int index)  { return levels.get(index); }
+        public boolean containsField(FieldDef field) { return levels.contains(field); }
+        public int getLevelIndex(FieldDef field)     { return levels.indexOf(field); }
 
         @Override
         public String toString() {
@@ -212,7 +212,7 @@ public class ShaclIndexMapping {
     }
 
     /**
-     * One simple step in a nested join path.
+     * One simple predicate step.
      * A forward step follows {@code subject --predicate--> object}.
      * An inverse step follows {@code object --predicate--> subject}.
      */
@@ -225,8 +225,8 @@ public class ShaclIndexMapping {
             this.inverse = inverse;
         }
 
-        public Node getPredicate()        { return predicate; }
-        public boolean isInverse()        { return inverse; }
+        public Node getPredicate()          { return predicate; }
+        public boolean isInverse()          { return inverse; }
 
         @Override
         public String toString() {
@@ -234,25 +234,81 @@ public class ShaclIndexMapping {
         }
     }
 
+    public static class FieldOccurrence {
+        private final FieldDef field;
+        private final Path path;
+        private final List<List<JoinStep>> pathVariants;
+        private final Set<Node> predicates;
+        private final Node requiredClass;
+        private final NodeKindConstraint nodeKindConstraint;
+        private final Node datatype;
+        private final String nestedName;
+
+        public FieldOccurrence(FieldDef field, Path path, List<List<JoinStep>> pathVariants,
+                               Set<Node> predicates, Node requiredClass,
+                               NodeKindConstraint nodeKindConstraint, Node datatype,
+                               String nestedName) {
+            this.field = Objects.requireNonNull(field);
+            this.path = Objects.requireNonNull(path);
+            this.pathVariants = pathVariants != null
+                ? deepUnmodifiable(pathVariants)
+                : Collections.emptyList();
+            this.predicates = predicates != null
+                ? Collections.unmodifiableSet(new LinkedHashSet<>(predicates))
+                : Collections.emptySet();
+            this.requiredClass = requiredClass;
+            this.nodeKindConstraint = nodeKindConstraint;
+            this.datatype = datatype;
+            this.nestedName = nestedName;
+            if (this.pathVariants.isEmpty()) {
+                throw new IllegalArgumentException("FieldOccurrence must contain at least one predicate path variant");
+            }
+        }
+
+        public FieldDef getField()                { return field; }
+        public Path getPath()                     { return path; }
+        public List<List<JoinStep>> getPathVariants() { return pathVariants; }
+        public Set<Node> getPredicates()          { return predicates; }
+        public Node getRequiredClass()            { return requiredClass; }
+        public NodeKindConstraint getNodeKindConstraint() { return nodeKindConstraint; }
+        public Node getDatatype()                 { return datatype; }
+        public String getNestedName()             { return nestedName; }
+        public boolean isNestedScoped()           { return nestedName != null; }
+        public boolean isRootScoped()             { return nestedName == null; }
+        public boolean requiresTypeConstraint()   { return requiredClass != null; }
+
+        @Override
+        public String toString() {
+            return nestedName == null
+                ? field.getFieldName() + " <- " + path
+                : field.getFieldName() + "@" + nestedName + " <- " + path;
+        }
+
+        private static List<List<JoinStep>> deepUnmodifiable(List<List<JoinStep>> variants) {
+            List<List<JoinStep>> copy = new ArrayList<>(variants.size());
+            for (List<JoinStep> variant : variants) {
+                copy.add(Collections.unmodifiableList(new ArrayList<>(variant)));
+            }
+            return Collections.unmodifiableList(copy);
+        }
+    }
+
     /**
-     * Defines a repeated correlated child collection whose fields are evaluated
-     * relative to the child node reached from the parent entity.
+     * Defines a repeated correlated child collection whose occurrences are evaluated
+     * relative to child nodes reached from the parent entity.
      */
     public static class NestedDef {
         private final String nestedName;
         private final Path joinPath;
         private final List<JoinStep> joinSteps;
         private final Set<Node> joinPredicates;
+        private final List<FieldOccurrence> occurrences;
         private final List<FieldDef> fields;
         private final List<HierarchyDef> hierarchies;
 
-        public NestedDef(String nestedName, Path joinPath, Set<Node> joinPredicates,
-                         List<FieldDef> fields, List<HierarchyDef> hierarchies) {
-            this(nestedName, joinPath, defaultJoinSteps(joinPath), joinPredicates, fields, hierarchies);
-        }
-
         public NestedDef(String nestedName, Path joinPath, List<JoinStep> joinSteps,
-                         Set<Node> joinPredicates, List<FieldDef> fields, List<HierarchyDef> hierarchies) {
+                         Set<Node> joinPredicates, List<FieldOccurrence> occurrences,
+                         List<HierarchyDef> hierarchies) {
             this.nestedName = Objects.requireNonNull(nestedName);
             this.joinPath = Objects.requireNonNull(joinPath);
             this.joinSteps = joinSteps != null
@@ -261,38 +317,32 @@ public class ShaclIndexMapping {
             this.joinPredicates = joinPredicates != null
                 ? Collections.unmodifiableSet(new LinkedHashSet<>(joinPredicates))
                 : Collections.emptySet();
-            this.fields = fields != null
-                ? Collections.unmodifiableList(new ArrayList<>(fields))
+            this.occurrences = occurrences != null
+                ? Collections.unmodifiableList(new ArrayList<>(occurrences))
                 : Collections.emptyList();
+            this.fields = Collections.unmodifiableList(distinctFields(this.occurrences));
             this.hierarchies = hierarchies != null
                 ? Collections.unmodifiableList(new ArrayList<>(hierarchies))
                 : Collections.emptyList();
-            if (this.fields.isEmpty()) {
-                throw new IllegalArgumentException("NestedDef must contain at least one field");
+            if (this.occurrences.isEmpty()) {
+                throw new IllegalArgumentException("NestedDef must contain at least one occurrence");
             }
             if (this.joinSteps.isEmpty()) {
                 throw new IllegalArgumentException("NestedDef must contain at least one join step");
             }
         }
 
-        public String getNestedName()       { return nestedName; }
-        public Path getJoinPath()           { return joinPath; }
-        public List<JoinStep> getJoinSteps() { return joinSteps; }
-        public Set<Node> getJoinPredicates() { return joinPredicates; }
-        public List<FieldDef> getFields()   { return fields; }
+        public String getNestedName()             { return nestedName; }
+        public Path getJoinPath()                 { return joinPath; }
+        public List<JoinStep> getJoinSteps()      { return joinSteps; }
+        public Set<Node> getJoinPredicates()      { return joinPredicates; }
+        public List<FieldOccurrence> getOccurrences() { return occurrences; }
+        public List<FieldDef> getFields()         { return fields; }
         public List<HierarchyDef> getHierarchies() { return hierarchies; }
 
         @Override
         public String toString() {
-            return "NestedDef(" + nestedName + ", joinPath=" + joinPath + ", fields=" + fields + ")";
-        }
-
-        private static List<JoinStep> defaultJoinSteps(Path joinPath) {
-            if (joinPath instanceof P_Link link) {
-                return Collections.singletonList(new JoinStep(link.getNode(), false));
-            }
-            throw new IllegalArgumentException(
-                "NestedDef constructor without join steps only supports simple predicate join paths: " + joinPath);
+            return "NestedDef(" + nestedName + ", joinPath=" + joinPath + ", occurrences=" + occurrences + ")";
         }
     }
 
@@ -302,6 +352,7 @@ public class ShaclIndexMapping {
         private final String docIdField;
         private final String discriminatorField;
         private final List<FieldDef> fields;
+        private final List<FieldOccurrence> rootOccurrences;
         private final List<HierarchyDef> hierarchies;
         private final List<NestedDef> nestedDefs;
 
@@ -309,36 +360,56 @@ public class ShaclIndexMapping {
                             String docIdField, String discriminatorField,
                             List<FieldDef> fields) {
             this(shapeNode, targetClasses, docIdField, discriminatorField, fields,
-                Collections.emptyList(), Collections.emptyList());
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         }
 
         public IndexProfile(Node shapeNode, Set<Node> targetClasses,
                             String docIdField, String discriminatorField,
                             List<FieldDef> fields, List<HierarchyDef> hierarchies) {
             this(shapeNode, targetClasses, docIdField, discriminatorField, fields,
-                hierarchies, Collections.emptyList());
+                Collections.emptyList(), hierarchies, Collections.emptyList());
         }
 
         public IndexProfile(Node shapeNode, Set<Node> targetClasses,
                             String docIdField, String discriminatorField,
                             List<FieldDef> fields, List<HierarchyDef> hierarchies,
                             List<NestedDef> nestedDefs) {
-            this.shapeNode = shapeNode;
-            this.targetClasses = targetClasses != null ? Collections.unmodifiableSet(new LinkedHashSet<>(targetClasses)) : Collections.emptySet();
-            this.docIdField = docIdField != null ? docIdField : "uri";
-            this.discriminatorField = discriminatorField != null ? discriminatorField : "docType";
-            this.fields = fields != null ? Collections.unmodifiableList(new ArrayList<>(fields)) : Collections.emptyList();
-            this.hierarchies = hierarchies != null ? Collections.unmodifiableList(new ArrayList<>(hierarchies)) : Collections.emptyList();
-            this.nestedDefs = nestedDefs != null ? Collections.unmodifiableList(new ArrayList<>(nestedDefs)) : Collections.emptyList();
+            this(shapeNode, targetClasses, docIdField, discriminatorField, fields,
+                Collections.emptyList(), hierarchies, nestedDefs);
         }
 
-        public Node getShapeNode()          { return shapeNode; }
-        public Set<Node> getTargetClasses() { return targetClasses; }
-        public String getDocIdField()       { return docIdField; }
-        public String getDiscriminatorField() { return discriminatorField; }
-        public List<FieldDef> getFields()   { return fields; }
+        public IndexProfile(Node shapeNode, Set<Node> targetClasses,
+                            String docIdField, String discriminatorField,
+                            List<FieldDef> fields, List<FieldOccurrence> rootOccurrences,
+                            List<HierarchyDef> hierarchies, List<NestedDef> nestedDefs) {
+            this.shapeNode = Objects.requireNonNull(shapeNode);
+            this.targetClasses = targetClasses != null
+                ? Collections.unmodifiableSet(new LinkedHashSet<>(targetClasses))
+                : Collections.emptySet();
+            this.docIdField = docIdField != null ? docIdField : "uri";
+            this.discriminatorField = discriminatorField != null ? discriminatorField : "docType";
+            this.fields = fields != null
+                ? Collections.unmodifiableList(new ArrayList<>(fields))
+                : Collections.emptyList();
+            this.rootOccurrences = rootOccurrences != null
+                ? Collections.unmodifiableList(new ArrayList<>(rootOccurrences))
+                : Collections.emptyList();
+            this.hierarchies = hierarchies != null
+                ? Collections.unmodifiableList(new ArrayList<>(hierarchies))
+                : Collections.emptyList();
+            this.nestedDefs = nestedDefs != null
+                ? Collections.unmodifiableList(new ArrayList<>(nestedDefs))
+                : Collections.emptyList();
+        }
+
+        public Node getShapeNode()               { return shapeNode; }
+        public Set<Node> getTargetClasses()      { return targetClasses; }
+        public String getDocIdField()            { return docIdField; }
+        public String getDiscriminatorField()    { return discriminatorField; }
+        public List<FieldDef> getFields()        { return fields; }
+        public List<FieldOccurrence> getRootOccurrences() { return rootOccurrences; }
         public List<HierarchyDef> getHierarchies() { return hierarchies; }
-        public List<NestedDef> getNestedDefs() { return nestedDefs; }
+        public List<NestedDef> getNestedDefs()   { return nestedDefs; }
 
         @Override
         public String toString() {
@@ -346,22 +417,27 @@ public class ShaclIndexMapping {
         }
     }
 
-    /** A (profile, field) pair returned from predicate lookups. */
-    public static class ProfileField {
+    /** A (profile, occurrence, nested scope) tuple used by change tracking lookups. */
+    public static class ProfileOccurrence {
         private final IndexProfile profile;
-        private final FieldDef field;
+        private final FieldOccurrence occurrence;
+        private final NestedDef nestedDef;
 
-        public ProfileField(IndexProfile profile, FieldDef field) {
-            this.profile = profile;
-            this.field = field;
+        public ProfileOccurrence(IndexProfile profile, FieldOccurrence occurrence, NestedDef nestedDef) {
+            this.profile = Objects.requireNonNull(profile);
+            this.occurrence = Objects.requireNonNull(occurrence);
+            this.nestedDef = nestedDef;
         }
 
-        public IndexProfile getProfile()    { return profile; }
-        public FieldDef getField()          { return field; }
+        public IndexProfile getProfile()         { return profile; }
+        public FieldOccurrence getOccurrence()   { return occurrence; }
+        public NestedDef getNestedDef()          { return nestedDef; }
+        public boolean isNestedScoped()          { return nestedDef != null; }
     }
 
     private final List<IndexProfile> profiles;
-    private final Map<Node, List<ProfileField>> predicateLookup;
+    private final Map<Node, List<ProfileOccurrence>> predicateLookup;
+    private final Map<Node, List<ProfileOccurrence>> classConstraintLookup;
     private final Map<Node, List<IndexProfile>> classLookup;
     private final Set<Node> topLevelPredicates;
     private final Set<Node> nestedChildPredicates;
@@ -372,80 +448,49 @@ public class ShaclIndexMapping {
         this.profiles = Collections.unmodifiableList(new ArrayList<>(profiles));
         validateLiteralMetadataRequirements();
         validateFieldNameUniqueness();
-        validateFieldScopeUniqueness();
 
-        // Build predicate → (profile, field) lookup
-        Map<Node, List<ProfileField>> predMap = new HashMap<>();
-        for (IndexProfile profile : profiles) {
-            for (FieldDef field : profile.getFields()) {
-                for (Node pred : field.getPredicates()) {
-                    predMap.computeIfAbsent(pred, k -> new ArrayList<>())
-                           .add(new ProfileField(profile, field));
-                }
-            }
-        }
-        this.predicateLookup = Collections.unmodifiableMap(predMap);
-        this.topLevelPredicates = buildTopLevelPredicates(profiles);
-        this.nestedChildPredicates = buildNestedChildPredicates(profiles);
-        this.nestedJoinPredicates = buildNestedJoinPredicates(profiles);
-        this.relevantPredicates = buildRelevantPredicates(topLevelPredicates, nestedChildPredicates, nestedJoinPredicates);
-
-        // Build targetClass → profiles lookup
-        Map<Node, List<IndexProfile>> clsMap = new HashMap<>();
-        for (IndexProfile profile : profiles) {
-            for (Node cls : profile.getTargetClasses()) {
-                clsMap.computeIfAbsent(cls, k -> new ArrayList<>())
-                      .add(profile);
-            }
-        }
-        this.classLookup = Collections.unmodifiableMap(clsMap);
+        this.predicateLookup = Collections.unmodifiableMap(buildPredicateLookup(this.profiles));
+        this.classConstraintLookup = Collections.unmodifiableMap(buildClassConstraintLookup(this.profiles));
+        this.topLevelPredicates = buildTopLevelPredicates(this.profiles);
+        this.nestedChildPredicates = buildNestedChildPredicates(this.profiles);
+        this.nestedJoinPredicates = buildNestedJoinPredicates(this.profiles);
+        this.relevantPredicates = buildRelevantPredicates(
+            topLevelPredicates, nestedChildPredicates, nestedJoinPredicates);
+        this.classLookup = Collections.unmodifiableMap(buildClassLookup(this.profiles));
     }
 
     public List<IndexProfile> getProfiles() {
         return profiles;
     }
 
-    private void validateLiteralMetadataRequirements() {
-        for (IndexProfile profile : profiles) {
-            for (FieldDef field : profile.getFields()) {
-                if (field.isDateLike() && !field.isStoreLiteralMetadata()) {
-                    throw new TextIndexException(
-                        "Field " + field.getFieldIRI().getURI() + " uses " + field.getFieldType()
-                        + " and requires idx:storeLiteralMetadata true");
-                }
-            }
-        }
+    public boolean isRelevantPredicate(Node predicate) {
+        return relevantPredicates.contains(predicate);
     }
 
-    public boolean isRelevantPredicate(Node p) {
-        return relevantPredicates.contains(p);
+    public boolean isTopLevelPredicate(Node predicate) {
+        return topLevelPredicates.contains(predicate);
     }
 
-    public boolean isTopLevelPredicate(Node p) {
-        return topLevelPredicates.contains(p);
+    public boolean isNestedChildPredicate(Node predicate) {
+        return nestedChildPredicates.contains(predicate);
     }
 
-    public boolean isNestedChildPredicate(Node p) {
-        return nestedChildPredicates.contains(p);
+    public boolean isNestedJoinPredicate(Node predicate) {
+        return nestedJoinPredicates.contains(predicate);
     }
 
-    public boolean isNestedJoinPredicate(Node p) {
-        return nestedJoinPredicates.contains(p);
+    public List<ProfileOccurrence> getOccurrencesForPredicate(Node predicate) {
+        return predicateLookup.getOrDefault(predicate, Collections.emptyList());
     }
 
-    public List<ProfileField> getProfilesForPredicate(Node p) {
-        return predicateLookup.getOrDefault(p, Collections.emptyList());
+    public List<ProfileOccurrence> getOccurrencesRequiringClass(Node cls) {
+        return classConstraintLookup.getOrDefault(cls, Collections.emptyList());
     }
 
     public List<IndexProfile> getProfilesForClass(Node cls) {
         return classLookup.getOrDefault(cls, Collections.emptyList());
     }
 
-    /**
-     * Find a FieldDef by field IRI across all profiles.
-     * Matches the exact IRI string against each field's IRI.
-     * Returns null if not found.
-     */
     public FieldDef findField(String fieldIRI) {
         for (IndexProfile profile : profiles) {
             for (FieldDef field : profile.getFields()) {
@@ -457,11 +502,6 @@ public class ShaclIndexMapping {
         return null;
     }
 
-    /**
-     * Find a FieldDef by Lucene field name across all profiles.
-     * This is for internal use where the Lucene field name is known.
-     * Returns null if not found.
-     */
     public FieldDef findFieldByName(String fieldName) {
         for (IndexProfile profile : profiles) {
             for (FieldDef field : profile.getFields()) {
@@ -473,10 +513,9 @@ public class ShaclIndexMapping {
         return null;
     }
 
-    /** Return all field names marked as defaultSearch across all profiles. */
     public List<String> getDefaultSearchFieldNames() {
         List<String> result = new ArrayList<>();
-        Set<String> seen = new HashSet<>();
+        Set<String> seen = new LinkedHashSet<>();
         for (IndexProfile profile : profiles) {
             for (FieldDef field : profile.getFields()) {
                 if (field.isDefaultSearch() && seen.add(field.getFieldName())) {
@@ -487,7 +526,6 @@ public class ShaclIndexMapping {
         return result;
     }
 
-    /** Return all field names across all profiles. */
     public Set<String> getAllFieldNames() {
         Set<String> result = new LinkedHashSet<>();
         for (IndexProfile profile : profiles) {
@@ -498,44 +536,9 @@ public class ShaclIndexMapping {
         return result;
     }
 
-    /**
-     * Validate that field names are consistent across profiles.
-     * The same field name may appear in multiple profiles (e.g. "title" in both
-     * BookShape and ArticleShape), but must have the same FieldType when shared.
-     */
-    private void validateFieldNameUniqueness() {
-        Map<String, FieldType> seen = new HashMap<>();
-        for (IndexProfile profile : profiles) {
-            for (FieldDef field : profile.getFields()) {
-                FieldType prev = seen.put(field.getFieldName(), field.getFieldType());
-                if (prev != null && prev != field.getFieldType()) {
-                    throw new TextIndexException(
-                        "Field name '" + field.getFieldName() +
-                        "' has conflicting types: " + prev + " vs " + field.getFieldType());
-                }
-            }
-        }
-    }
-
-    private void validateFieldScopeUniqueness() {
-        Map<String, String> seenScopes = new HashMap<>();
-        for (IndexProfile profile : profiles) {
-            for (FieldDef field : profile.getFields()) {
-                String iri = field.getFieldIRI().getURI();
-                String prevScope = seenScopes.putIfAbsent(iri, field.getNestedName());
-                if (prevScope != null && !Objects.equals(prevScope, field.getNestedName())) {
-                    throw new TextIndexException(
-                        "Field IRI '" + iri + "' is used in both root and nested scopes, or across multiple nested scopes. "
-                        + "Define separate field IRIs for each scope.");
-                }
-            }
-        }
-    }
-
-    /** Return all field names marked as facetable across all profiles. */
     public List<String> getFacetFieldNames() {
         List<String> result = new ArrayList<>();
-        Set<String> seen = new HashSet<>();
+        Set<String> seen = new LinkedHashSet<>();
         for (IndexProfile profile : profiles) {
             for (FieldDef field : profile.getFields()) {
                 if (field.isFacetable() && seen.add(field.getFieldName())) {
@@ -546,7 +549,6 @@ public class ShaclIndexMapping {
         return result;
     }
 
-    /** Return all hierarchy definitions across all profiles. */
     public List<HierarchyDef> getAllHierarchies() {
         List<HierarchyDef> result = new ArrayList<>();
         for (IndexProfile profile : profiles) {
@@ -558,18 +560,17 @@ public class ShaclIndexMapping {
         return result;
     }
 
-    /** Find a HierarchyDef by dimension name. */
     public HierarchyDef findHierarchy(String dimensionName) {
         for (IndexProfile profile : profiles) {
-            for (HierarchyDef h : profile.getHierarchies()) {
-                if (h.getDimensionName().equals(dimensionName)) {
-                    return h;
+            for (HierarchyDef hierarchy : profile.getHierarchies()) {
+                if (hierarchy.getDimensionName().equals(dimensionName)) {
+                    return hierarchy;
                 }
             }
             for (NestedDef nestedDef : profile.getNestedDefs()) {
-                for (HierarchyDef h : nestedDef.getHierarchies()) {
-                    if (h.getDimensionName().equals(dimensionName)) {
-                        return h;
+                for (HierarchyDef hierarchy : nestedDef.getHierarchies()) {
+                    if (hierarchy.getDimensionName().equals(dimensionName)) {
+                        return hierarchy;
                     }
                 }
             }
@@ -577,23 +578,21 @@ public class ShaclIndexMapping {
         return null;
     }
 
-    /**
-     * Find the HierarchyDef that contains a given field (by field IRI).
-     * Returns null if the field is not part of any hierarchy.
-     */
     public HierarchyDef findHierarchyForField(String fieldIRI) {
-        FieldDef fd = findField(fieldIRI);
-        if (fd == null) return null;
+        FieldDef field = findField(fieldIRI);
+        if (field == null) {
+            return null;
+        }
         for (IndexProfile profile : profiles) {
-            for (HierarchyDef h : profile.getHierarchies()) {
-                if (h.containsField(fd)) {
-                    return h;
+            for (HierarchyDef hierarchy : profile.getHierarchies()) {
+                if (hierarchy.containsField(field)) {
+                    return hierarchy;
                 }
             }
             for (NestedDef nestedDef : profile.getNestedDefs()) {
-                for (HierarchyDef h : nestedDef.getHierarchies()) {
-                    if (h.containsField(fd)) {
-                        return h;
+                for (HierarchyDef hierarchy : nestedDef.getHierarchies()) {
+                    if (hierarchy.containsField(field)) {
+                        return hierarchy;
                     }
                 }
             }
@@ -601,23 +600,21 @@ public class ShaclIndexMapping {
         return null;
     }
 
-    /** Return all hierarchy dimension names across all profiles. */
     public List<String> getHierarchyDimensionNames() {
         List<String> result = new ArrayList<>();
         for (IndexProfile profile : profiles) {
-            for (HierarchyDef h : profile.getHierarchies()) {
-                result.add(h.getDimensionName());
+            for (HierarchyDef hierarchy : profile.getHierarchies()) {
+                result.add(hierarchy.getDimensionName());
             }
             for (NestedDef nestedDef : profile.getNestedDefs()) {
-                for (HierarchyDef h : nestedDef.getHierarchies()) {
-                    result.add(h.getDimensionName());
+                for (HierarchyDef hierarchy : nestedDef.getHierarchies()) {
+                    result.add(hierarchy.getDimensionName());
                 }
             }
         }
         return result;
     }
 
-    /** Check if any hierarchies are defined. */
     public boolean hasHierarchies() {
         for (IndexProfile profile : profiles) {
             if (!profile.getHierarchies().isEmpty()) {
@@ -641,46 +638,139 @@ public class ShaclIndexMapping {
         return false;
     }
 
-    private static Set<Node> buildTopLevelPredicates(List<IndexProfile> profiles) {
-        Set<Node> preds = new LinkedHashSet<>();
+    private void validateLiteralMetadataRequirements() {
         for (IndexProfile profile : profiles) {
             for (FieldDef field : profile.getFields()) {
-                if (field.isRootScoped()) {
-                    preds.addAll(field.getPredicates());
+                if (field.isDateLike() && !field.isStoreLiteralMetadata()) {
+                    throw new TextIndexException(
+                        "Field " + field.getFieldIRI().getURI() + " uses " + field.getFieldType()
+                        + " and requires idx:storeLiteralMetadata true");
                 }
             }
         }
-        return Collections.unmodifiableSet(preds);
+    }
+
+    private void validateFieldNameUniqueness() {
+        Map<String, FieldType> seen = new HashMap<>();
+        for (IndexProfile profile : profiles) {
+            for (FieldDef field : profile.getFields()) {
+                FieldType prev = seen.put(field.getFieldName(), field.getFieldType());
+                if (prev != null && prev != field.getFieldType()) {
+                    throw new TextIndexException(
+                        "Field name '" + field.getFieldName()
+                        + "' has conflicting types: " + prev + " vs " + field.getFieldType());
+                }
+            }
+        }
+    }
+
+    private static Map<Node, List<ProfileOccurrence>> buildPredicateLookup(List<IndexProfile> profiles) {
+        Map<Node, List<ProfileOccurrence>> lookup = new LinkedHashMap<>();
+        for (IndexProfile profile : profiles) {
+            for (FieldOccurrence occurrence : profile.getRootOccurrences()) {
+                addOccurrenceLookup(lookup, profile, occurrence, null);
+            }
+            for (NestedDef nestedDef : profile.getNestedDefs()) {
+                for (FieldOccurrence occurrence : nestedDef.getOccurrences()) {
+                    addOccurrenceLookup(lookup, profile, occurrence, nestedDef);
+                }
+            }
+        }
+        return lookup;
+    }
+
+    private static void addOccurrenceLookup(Map<Node, List<ProfileOccurrence>> lookup,
+                                            IndexProfile profile, FieldOccurrence occurrence,
+                                            NestedDef nestedDef) {
+        ProfileOccurrence profileOccurrence = new ProfileOccurrence(profile, occurrence, nestedDef);
+        for (Node predicate : occurrence.getPredicates()) {
+            lookup.computeIfAbsent(predicate, k -> new ArrayList<>()).add(profileOccurrence);
+        }
+    }
+
+    private static Map<Node, List<ProfileOccurrence>> buildClassConstraintLookup(List<IndexProfile> profiles) {
+        Map<Node, List<ProfileOccurrence>> lookup = new LinkedHashMap<>();
+        for (IndexProfile profile : profiles) {
+            for (FieldOccurrence occurrence : profile.getRootOccurrences()) {
+                addClassConstraintLookup(lookup, profile, occurrence, null);
+            }
+            for (NestedDef nestedDef : profile.getNestedDefs()) {
+                for (FieldOccurrence occurrence : nestedDef.getOccurrences()) {
+                    addClassConstraintLookup(lookup, profile, occurrence, nestedDef);
+                }
+            }
+        }
+        return lookup;
+    }
+
+    private static void addClassConstraintLookup(Map<Node, List<ProfileOccurrence>> lookup,
+                                                 IndexProfile profile, FieldOccurrence occurrence,
+                                                 NestedDef nestedDef) {
+        if (!occurrence.requiresTypeConstraint()) {
+            return;
+        }
+        lookup.computeIfAbsent(occurrence.getRequiredClass(), k -> new ArrayList<>())
+            .add(new ProfileOccurrence(profile, occurrence, nestedDef));
+    }
+
+    private static Map<Node, List<IndexProfile>> buildClassLookup(List<IndexProfile> profiles) {
+        Map<Node, List<IndexProfile>> lookup = new LinkedHashMap<>();
+        for (IndexProfile profile : profiles) {
+            for (Node cls : profile.getTargetClasses()) {
+                lookup.computeIfAbsent(cls, k -> new ArrayList<>()).add(profile);
+            }
+        }
+        return lookup;
+    }
+
+    private static Set<Node> buildTopLevelPredicates(List<IndexProfile> profiles) {
+        Set<Node> predicates = new LinkedHashSet<>();
+        for (IndexProfile profile : profiles) {
+            for (FieldOccurrence occurrence : profile.getRootOccurrences()) {
+                predicates.addAll(occurrence.getPredicates());
+            }
+        }
+        return Collections.unmodifiableSet(predicates);
     }
 
     private static Set<Node> buildNestedChildPredicates(List<IndexProfile> profiles) {
-        Set<Node> preds = new LinkedHashSet<>();
+        Set<Node> predicates = new LinkedHashSet<>();
         for (IndexProfile profile : profiles) {
             for (NestedDef nestedDef : profile.getNestedDefs()) {
-                for (FieldDef field : nestedDef.getFields()) {
-                    preds.addAll(field.getPredicates());
+                for (FieldOccurrence occurrence : nestedDef.getOccurrences()) {
+                    predicates.addAll(occurrence.getPredicates());
                 }
             }
         }
-        return Collections.unmodifiableSet(preds);
+        return Collections.unmodifiableSet(predicates);
     }
 
     private static Set<Node> buildNestedJoinPredicates(List<IndexProfile> profiles) {
-        Set<Node> preds = new LinkedHashSet<>();
+        Set<Node> predicates = new LinkedHashSet<>();
         for (IndexProfile profile : profiles) {
             for (NestedDef nestedDef : profile.getNestedDefs()) {
-                preds.addAll(nestedDef.getJoinPredicates());
+                predicates.addAll(nestedDef.getJoinPredicates());
             }
         }
-        return Collections.unmodifiableSet(preds);
+        return Collections.unmodifiableSet(predicates);
     }
 
     private static Set<Node> buildRelevantPredicates(Set<Node> topLevelPredicates,
-            Set<Node> nestedChildPredicates, Set<Node> nestedJoinPredicates) {
-        Set<Node> preds = new LinkedHashSet<>();
-        preds.addAll(topLevelPredicates);
-        preds.addAll(nestedChildPredicates);
-        preds.addAll(nestedJoinPredicates);
-        return Collections.unmodifiableSet(preds);
+                                                     Set<Node> nestedChildPredicates,
+                                                     Set<Node> nestedJoinPredicates) {
+        Set<Node> predicates = new LinkedHashSet<>();
+        predicates.addAll(topLevelPredicates);
+        predicates.addAll(nestedChildPredicates);
+        predicates.addAll(nestedJoinPredicates);
+        return Collections.unmodifiableSet(predicates);
+    }
+
+    private static List<FieldDef> distinctFields(List<FieldOccurrence> occurrences) {
+        Map<String, FieldDef> fieldsByIri = new LinkedHashMap<>();
+        for (FieldOccurrence occurrence : occurrences) {
+            FieldDef field = occurrence.getField();
+            fieldsByIri.putIfAbsent(field.getFieldIRI().getURI(), field);
+        }
+        return new ArrayList<>(fieldsByIri.values());
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -86,23 +86,7 @@ public class ShaclIndexMapping {
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
-                        Set<Node> ignoredPredicates) {
-            this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
-                sortable, multiValued, defaultSearch, false, null);
-        }
-
-        public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
-                        boolean stored, boolean indexed, boolean facetable,
-                        boolean sortable, boolean multiValued, boolean defaultSearch,
-                        Set<Node> ignoredPredicates, Path ignoredPath) {
-            this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
-                sortable, multiValued, defaultSearch, false, null);
-        }
-
-        public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
-                        boolean stored, boolean indexed, boolean facetable,
-                        boolean sortable, boolean multiValued, boolean defaultSearch,
-                        Set<Node> ignoredPredicates, Path ignoredPath, Node fieldIRI) {
+                        Node fieldIRI) {
             this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
                 sortable, multiValued, defaultSearch, false, fieldIRI);
         }
@@ -119,18 +103,33 @@ public class ShaclIndexMapping {
                         Analyzer queryAnalyzer,
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
-                        Set<Node> ignoredPredicates, Path ignoredPath, Node fieldIRI) {
+                        Node fieldIRI) {
             this(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed, facetable,
                 sortable, multiValued, defaultSearch, false, fieldIRI);
+        }
+
+        public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
+                        boolean stored, boolean indexed, boolean facetable,
+                        boolean sortable, boolean multiValued, boolean defaultSearch,
+                        boolean storeLiteralMetadata) {
+            this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
+                sortable, multiValued, defaultSearch, storeLiteralMetadata, null);
         }
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         Analyzer queryAnalyzer,
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
-                        boolean storeLiteralMetadata,
-                        Set<Node> ignoredPredicates, Path ignoredPath, Node fieldIRI) {
+                        boolean storeLiteralMetadata) {
             this(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed, facetable,
+                sortable, multiValued, defaultSearch, storeLiteralMetadata, null);
+        }
+
+        public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
+                        boolean stored, boolean indexed, boolean facetable,
+                        boolean sortable, boolean multiValued, boolean defaultSearch,
+                        boolean storeLiteralMetadata, Node fieldIRI) {
+            this(fieldName, fieldType, analyzer, null, stored, indexed, facetable,
                 sortable, multiValued, defaultSearch, storeLiteralMetadata, fieldIRI);
         }
 
@@ -358,24 +357,17 @@ public class ShaclIndexMapping {
 
         public IndexProfile(Node shapeNode, Set<Node> targetClasses,
                             String docIdField, String discriminatorField,
-                            List<FieldDef> fields) {
+                            List<FieldDef> fields, List<FieldOccurrence> rootOccurrences) {
             this(shapeNode, targetClasses, docIdField, discriminatorField, fields,
-                Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+                rootOccurrences, Collections.emptyList(), Collections.emptyList());
         }
 
         public IndexProfile(Node shapeNode, Set<Node> targetClasses,
                             String docIdField, String discriminatorField,
-                            List<FieldDef> fields, List<HierarchyDef> hierarchies) {
+                            List<FieldDef> fields, List<FieldOccurrence> rootOccurrences,
+                            List<HierarchyDef> hierarchies) {
             this(shapeNode, targetClasses, docIdField, discriminatorField, fields,
-                Collections.emptyList(), hierarchies, Collections.emptyList());
-        }
-
-        public IndexProfile(Node shapeNode, Set<Node> targetClasses,
-                            String docIdField, String discriminatorField,
-                            List<FieldDef> fields, List<HierarchyDef> hierarchies,
-                            List<NestedDef> nestedDefs) {
-            this(shapeNode, targetClasses, docIdField, discriminatorField, fields,
-                Collections.emptyList(), hierarchies, nestedDefs);
+                rootOccurrences, hierarchies, Collections.emptyList());
         }
 
         public IndexProfile(Node shapeNode, Set<Node> targetClasses,
@@ -446,8 +438,10 @@ public class ShaclIndexMapping {
 
     public ShaclIndexMapping(List<IndexProfile> profiles) {
         this.profiles = Collections.unmodifiableList(new ArrayList<>(profiles));
+        validateProfilesHaveOccurrences();
         validateLiteralMetadataRequirements();
         validateFieldNameUniqueness();
+        validateHierarchyScopeConsistency();
 
         this.predicateLookup = Collections.unmodifiableMap(buildPredicateLookup(this.profiles));
         this.classConstraintLookup = Collections.unmodifiableMap(buildClassConstraintLookup(this.profiles));
@@ -650,6 +644,15 @@ public class ShaclIndexMapping {
         }
     }
 
+    private void validateProfilesHaveOccurrences() {
+        for (IndexProfile profile : profiles) {
+            if (profile.getRootOccurrences().isEmpty() && profile.getNestedDefs().isEmpty()) {
+                throw new TextIndexException(
+                    "Profile " + profile.getShapeNode() + " has no root or nested field occurrences");
+            }
+        }
+    }
+
     private void validateFieldNameUniqueness() {
         Map<String, FieldType> seen = new HashMap<>();
         for (IndexProfile profile : profiles) {
@@ -659,6 +662,30 @@ public class ShaclIndexMapping {
                     throw new TextIndexException(
                         "Field name '" + field.getFieldName()
                         + "' has conflicting types: " + prev + " vs " + field.getFieldType());
+                }
+            }
+        }
+    }
+
+    private void validateHierarchyScopeConsistency() {
+        for (IndexProfile profile : profiles) {
+            Set<FieldDef> rootFields = new LinkedHashSet<>(distinctFields(profile.getRootOccurrences()));
+            validateHierarchyScope(profile.getShapeNode(), profile.getHierarchies(), rootFields);
+            for (NestedDef nestedDef : profile.getNestedDefs()) {
+                validateHierarchyScope(profile.getShapeNode(), nestedDef.getHierarchies(),
+                    new LinkedHashSet<>(nestedDef.getFields()));
+            }
+        }
+    }
+
+    private void validateHierarchyScope(Node owner, List<HierarchyDef> hierarchies, Set<FieldDef> scopeFields) {
+        for (HierarchyDef hierarchy : hierarchies) {
+            for (FieldDef field : hierarchy.getLevels()) {
+                if (!scopeFields.contains(field)) {
+                    throw new TextIndexException(
+                        "Hierarchy '" + hierarchy.getDimensionName() + "' on " + owner
+                        + " references field " + field.getFieldIRI().getURI()
+                        + " outside its populated scope");
                 }
             }
         }

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java
@@ -25,23 +25,22 @@ import java.util.*;
 
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
-import org.apache.jena.query.text.ShaclIndexMapping.*;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
+import org.apache.jena.query.text.ShaclIndexMapping.NestedDef;
+import org.apache.jena.query.text.ShaclIndexMapping.ProfileOccurrence;
 import org.apache.jena.query.text.changes.TextQuadAction;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.graph.GraphUnionRead;
+import org.apache.jena.sparql.path.eval.PathEval;
 import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Entity-per-document change listener for SHACL-driven index profiles.
- * <p>
- * When a relevant triple changes, this producer rebuilds the entire Lucene document
- * for the affected entity by reading all triples from the base dataset.
- * <p>
- * The base dataset is already updated when {@code change()} fires because
- * {@code DatasetGraphTextMonitor.add()} calls {@code super.add()} before {@code record()}.
  */
 public class ShaclTextDocProducer implements TextDocProducer {
     private static final Logger log = LoggerFactory.getLogger(ShaclTextDocProducer.class);
@@ -78,124 +77,105 @@ public class ShaclTextDocProducer implements TextDocProducer {
 
     @Override
     public void change(TextQuadAction qaction, Node g, Node s, Node p, Node o) {
-        if (qaction != TextQuadAction.ADD && qaction != TextQuadAction.DELETE)
+        if (qaction != TextQuadAction.ADD && qaction != TextQuadAction.DELETE) {
             return;
+        }
 
         if (RDF_TYPE.equals(p)) {
-            // rdf:type change → may add/remove entity from a profile
-            handleTypeChange(qaction, s, o);
+            handleTypeChange(s, o);
         } else if (mapping.isRelevantPredicate(p)) {
-            Set<Node> entitiesToRebuild = new LinkedHashSet<>();
-            if (mapping.isTopLevelPredicate(p)) {
-                entitiesToRebuild.add(s);
-            }
-            if (mapping.isNestedChildPredicate(p) || mapping.isNestedJoinPredicate(p)) {
-                entitiesToRebuild.addAll(findParentEntitiesForNestedChange(s, p, o));
-            }
-            for (Node entity : entitiesToRebuild) {
+            for (Node entity : findEntitiesForPredicateChange(s, p, o)) {
                 rebuildEntityDocuments(entity);
             }
         }
-        // Else: irrelevant predicate, ignore
 
         if (!inTransaction.get()) {
             indexer.commit();
         }
     }
 
-    private void handleTypeChange(TextQuadAction qaction, Node subject, Node typeNode) {
-        List<IndexProfile> profiles = mapping.getProfilesForClass(typeNode);
-        if (profiles.isEmpty()) {
-            return; // Not a type we care about
+    private void handleTypeChange(Node subject, Node typeNode) {
+        Set<Node> entitiesToRebuild = new LinkedHashSet<>();
+        if (!mapping.getProfilesForClass(typeNode).isEmpty()) {
+            entitiesToRebuild.add(subject);
         }
 
-        if (qaction == TextQuadAction.ADD) {
-            // New type assertion → rebuild docs for matching profiles
-            rebuildEntityDocuments(subject);
-        } else if (qaction == TextQuadAction.DELETE) {
-            // Type removed — check if entity still has this type in the dataset
-            // If not, delete the corresponding profile document(s)
-            rebuildEntityDocuments(subject);
-        }
-    }
-
-    /**
-     * Rebuild all Lucene documents for the given entity by reading its current state
-     * from the base dataset.
-     */
-    private void rebuildEntityDocuments(Node subject) {
-        String entityUri = TextQueryFuncs.subjectToString(subject);
-        log.trace("rebuildEntityDocuments: {}", entityUri);
-
-        // Get rdf:type values for the entity across all graphs (default + named)
-        Set<Node> types = new HashSet<>();
-        Iterator<Quad> typeIter = baseDataset.find(Node.ANY, subject, RDF_TYPE, Node.ANY);
-        while (typeIter.hasNext()) {
-            types.add(typeIter.next().getObject());
-        }
-
-        // Find matching profiles
-        Set<IndexProfile> matchedProfiles = new LinkedHashSet<>();
-        for (Node type : types) {
-            matchedProfiles.addAll(mapping.getProfilesForClass(type));
-        }
-
-        if (matchedProfiles.isEmpty()) {
-            // No matching profiles — delete any existing docs for this entity
-            indexer.deleteEntityByUri(entityUri);
-            return;
-        }
-
-        // For each matching profile, build an Entity and update the index
-        for (IndexProfile profile : matchedProfiles) {
-            Entity entity = buildEntity(subject, entityUri, profile);
-            indexer.updateEntityForProfile(entity, profile);
-        }
-    }
-
-    /**
-     * Build an Entity by reading all relevant triples for the subject from the base dataset.
-     * Uses PathEval for complex paths (sequence, inverse); direct triple match for simple predicates.
-     */
-    private Entity buildEntity(Node subject, String entityUri, IndexProfile profile) {
-        return ShaclEntityBuilder.buildEntity(allGraphsView(), subject, entityUri, profile);
-    }
-
-    /**
-     * Return a read-only graph view that spans the default graph and all named graphs.
-     * This ensures the change listener finds data regardless of which graph it was added to.
-     */
-    private Graph allGraphsView() {
-        List<Node> graphNames = new ArrayList<>();
-        graphNames.add(Quad.defaultGraphIRI);
-        baseDataset.listGraphNodes().forEachRemaining(graphNames::add);
-        return new GraphUnionRead(baseDataset, graphNames);
-    }
-
-    private Set<Node> findParentEntitiesForNestedChange(Node changedSubject, Node changedPredicate, Node changedObject) {
         Graph graph = allGraphsView();
-        Set<Node> parents = new LinkedHashSet<>();
-        for (IndexProfile profile : mapping.getProfiles()) {
-            for (NestedDef nestedDef : profile.getNestedDefs()) {
-                boolean nestedChildPredicate = nestedDef.getFields().stream()
-                    .anyMatch(f -> f.getPredicates().contains(changedPredicate));
-                boolean nestedJoinPredicate = nestedDef.getJoinPredicates().contains(changedPredicate);
+        for (ProfileOccurrence profileOccurrence : mapping.getOccurrencesRequiringClass(typeNode)) {
+            Set<Node> scopeRoots = findScopeRootsForConstraintChange(graph, subject,
+                profileOccurrence.getOccurrence());
+            entitiesToRebuild.addAll(resolveEntityRoots(graph, profileOccurrence, scopeRoots));
+        }
 
-                if (nestedChildPredicate) {
-                    parents.addAll(reverseTraverseToParents(graph, Collections.singleton(changedSubject),
-                        nestedDef.getJoinSteps()));
-                }
-                if (nestedJoinPredicate) {
-                    parents.addAll(findParentsForJoinStepChange(graph, nestedDef, changedPredicate, changedSubject, changedObject));
+        for (Node entity : entitiesToRebuild) {
+            rebuildEntityDocuments(entity);
+        }
+    }
+
+    private Set<Node> findEntitiesForPredicateChange(Node changedSubject, Node changedPredicate, Node changedObject) {
+        Graph graph = allGraphsView();
+        Set<Node> entities = new LinkedHashSet<>();
+
+        for (ProfileOccurrence profileOccurrence : mapping.getOccurrencesForPredicate(changedPredicate)) {
+            Set<Node> scopeRoots = findScopeRootsForPredicateChange(
+                profileOccurrence.getOccurrence(), changedPredicate, changedSubject, changedObject, graph);
+            entities.addAll(resolveEntityRoots(graph, profileOccurrence, scopeRoots));
+        }
+
+        if (mapping.isNestedJoinPredicate(changedPredicate)) {
+            for (IndexProfile profile : mapping.getProfiles()) {
+                for (NestedDef nestedDef : profile.getNestedDefs()) {
+                    if (nestedDef.getJoinPredicates().contains(changedPredicate)) {
+                        entities.addAll(findParentsForJoinStepChange(
+                            graph, nestedDef, changedPredicate, changedSubject, changedObject));
+                    }
                 }
             }
         }
 
-        return parents;
+        return entities;
+    }
+
+    private Set<Node> resolveEntityRoots(Graph graph, ProfileOccurrence profileOccurrence, Set<Node> scopeRoots) {
+        if (scopeRoots.isEmpty()) {
+            return Collections.emptySet();
+        }
+        if (!profileOccurrence.isNestedScoped()) {
+            return scopeRoots;
+        }
+        return reverseTraverseToParents(graph, scopeRoots, profileOccurrence.getNestedDef().getJoinSteps());
+    }
+
+    private Set<Node> findScopeRootsForConstraintChange(Graph graph, Node endpoint, FieldOccurrence occurrence) {
+        Set<Node> roots = new LinkedHashSet<>();
+        Iterator<Node> iter = PathEval.evalReverse(graph, endpoint, occurrence.getPath(), null);
+        while (iter.hasNext()) {
+            roots.add(iter.next());
+        }
+        return roots;
+    }
+
+    private Set<Node> findScopeRootsForPredicateChange(FieldOccurrence occurrence, Node changedPredicate,
+                                                       Node changedSubject, Node changedObject, Graph graph) {
+        Set<Node> roots = new LinkedHashSet<>();
+        for (List<JoinStep> variant : occurrence.getPathVariants()) {
+            for (int i = 0; i < variant.size(); i++) {
+                JoinStep step = variant.get(i);
+                if (!step.getPredicate().equals(changedPredicate)) {
+                    continue;
+                }
+                Node stepStart = step.isInverse() ? changedObject : changedSubject;
+                if (stepStart == null) {
+                    continue;
+                }
+                roots.addAll(reverseTraverseToParents(graph, Collections.singleton(stepStart), variant.subList(0, i)));
+            }
+        }
+        return roots;
     }
 
     private Set<Node> findParentsForJoinStepChange(Graph graph, NestedDef nestedDef,
-            Node changedPredicate, Node changedSubject, Node changedObject) {
+                                                   Node changedPredicate, Node changedSubject, Node changedObject) {
         Set<Node> parents = new LinkedHashSet<>();
         List<JoinStep> joinSteps = nestedDef.getJoinSteps();
 
@@ -210,29 +190,65 @@ public class ShaclTextDocProducer implements TextDocProducer {
                 continue;
             }
 
-            parents.addAll(reverseTraverseToParents(graph, Collections.singleton(stepStart),
-                joinSteps.subList(0, i)));
+            parents.addAll(reverseTraverseToParents(graph, Collections.singleton(stepStart), joinSteps.subList(0, i)));
         }
 
         return parents;
     }
 
-    private Set<Node> reverseTraverseToParents(Graph graph, Collection<Node> startNodes, List<JoinStep> joinSteps) {
+    private Set<Node> reverseTraverseToParents(Graph graph, Collection<Node> startNodes, List<JoinStep> steps) {
         Set<Node> current = new LinkedHashSet<>(startNodes);
-        for (int i = joinSteps.size() - 1; i >= 0 && !current.isEmpty(); i--) {
-            JoinStep joinStep = joinSteps.get(i);
+        for (int i = steps.size() - 1; i >= 0 && !current.isEmpty(); i--) {
+            JoinStep step = steps.get(i);
             Set<Node> next = new LinkedHashSet<>();
             for (Node node : current) {
-                if (joinStep.isInverse()) {
-                    graph.find(node, joinStep.getPredicate(), Node.ANY)
+                if (step.isInverse()) {
+                    graph.find(node, step.getPredicate(), Node.ANY)
                         .forEachRemaining(t -> next.add(t.getObject()));
                 } else {
-                    graph.find(Node.ANY, joinStep.getPredicate(), node)
+                    graph.find(Node.ANY, step.getPredicate(), node)
                         .forEachRemaining(t -> next.add(t.getSubject()));
                 }
             }
             current = next;
         }
         return current;
+    }
+
+    private void rebuildEntityDocuments(Node subject) {
+        String entityUri = TextQueryFuncs.subjectToString(subject);
+        log.trace("rebuildEntityDocuments: {}", entityUri);
+
+        Set<Node> types = new HashSet<>();
+        Iterator<Quad> typeIter = baseDataset.find(Node.ANY, subject, RDF_TYPE, Node.ANY);
+        while (typeIter.hasNext()) {
+            types.add(typeIter.next().getObject());
+        }
+
+        Set<IndexProfile> matchedProfiles = new LinkedHashSet<>();
+        for (Node type : types) {
+            matchedProfiles.addAll(mapping.getProfilesForClass(type));
+        }
+
+        if (matchedProfiles.isEmpty()) {
+            indexer.deleteEntityByUri(entityUri);
+            return;
+        }
+
+        for (IndexProfile profile : matchedProfiles) {
+            Entity entity = buildEntity(subject, entityUri, profile);
+            indexer.updateEntityForProfile(entity, profile);
+        }
+    }
+
+    private Entity buildEntity(Node subject, String entityUri, IndexProfile profile) {
+        return ShaclEntityBuilder.buildEntity(allGraphsView(), subject, entityUri, profile);
+    }
+
+    private Graph allGraphsView() {
+        List<Node> graphNames = new ArrayList<>();
+        graphNames.add(Quad.defaultGraphIRI);
+        baseDataset.listGraphNodes().forEachRemaining(graphNames::add);
+        return new GraphUnionRead(baseDataset, graphNames);
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -538,31 +538,34 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
     private void addHierarchyFacetFields(Document doc, Entity entity,
             ShaclIndexMapping.IndexProfile profile) {
         for (ShaclIndexMapping.HierarchyDef hierarchy : profile.getHierarchies()) {
-            addDirectHierarchyFacetFields(doc, entity, hierarchy);
+            addDirectHierarchyFacetFields(doc, entity, profile, hierarchy);
         }
         for (ShaclIndexMapping.NestedDef nestedDef : profile.getNestedDefs()) {
             for (ShaclIndexMapping.HierarchyDef hierarchy : nestedDef.getHierarchies()) {
-                addNestedHierarchyFacetFields(doc, entity, nestedDef, hierarchy);
+                addNestedHierarchyFacetFields(doc, entity, profile, nestedDef, hierarchy);
             }
         }
     }
 
     private void addDirectHierarchyFacetFields(Document doc, Entity entity,
-            ShaclIndexMapping.HierarchyDef hierarchy) {
+            ShaclIndexMapping.IndexProfile profile, ShaclIndexMapping.HierarchyDef hierarchy) {
         List<List<String>> levelValues = new ArrayList<>();
         for (ShaclIndexMapping.FieldDef levelField : hierarchy.getLevels()) {
-            levelValues.add(asStringValues(entity.get(levelField.getFieldName())));
+            levelValues.add(asHierarchyFacetValues(entity.get(levelField.getFieldName()),
+                profile, entity, hierarchy, levelField));
         }
         addFacetPaths(doc, hierarchy.getDimensionName(), levelValues, 0, new ArrayList<>());
     }
 
     private void addNestedHierarchyFacetFields(Document doc, Entity entity,
-            ShaclIndexMapping.NestedDef nestedDef, ShaclIndexMapping.HierarchyDef hierarchy) {
+            ShaclIndexMapping.IndexProfile profile, ShaclIndexMapping.NestedDef nestedDef,
+            ShaclIndexMapping.HierarchyDef hierarchy) {
         for (Entity.NestedRecord record : entity.getNestedRecords(nestedDef.getNestedName())) {
             List<List<String>> levelValues = new ArrayList<>();
             boolean hasAnyValue = false;
             for (ShaclIndexMapping.FieldDef levelField : hierarchy.getLevels()) {
-                List<String> values = asStringValues(record.get(levelField.getFieldName()));
+                List<String> values = asHierarchyFacetValues(record.get(levelField.getFieldName()),
+                    profile, entity, hierarchy, levelField);
                 if (!values.isEmpty()) {
                     hasAnyValue = true;
                 }
@@ -590,6 +593,37 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
         return values;
     }
 
+    private List<String> asHierarchyFacetValues(Object value, ShaclIndexMapping.IndexProfile profile,
+            Entity entity, ShaclIndexMapping.HierarchyDef hierarchy, ShaclIndexMapping.FieldDef levelField) {
+        List<String> values = new ArrayList<>();
+        if (value instanceof List) {
+            @SuppressWarnings("unchecked")
+            List<Object> list = (List<Object>) value;
+            for (Object rawValue : list) {
+                addHierarchyFacetValue(values, rawValue, profile, entity, hierarchy, levelField);
+            }
+        } else {
+            addHierarchyFacetValue(values, value, profile, entity, hierarchy, levelField);
+        }
+        return values;
+    }
+
+    private void addHierarchyFacetValue(List<String> values, Object rawValue,
+            ShaclIndexMapping.IndexProfile profile, Entity entity,
+            ShaclIndexMapping.HierarchyDef hierarchy, ShaclIndexMapping.FieldDef levelField) {
+        if (rawValue == null) {
+            return;
+        }
+        String stringValue = rawValue.toString();
+        if (stringValue.isBlank()) {
+            log.warn("Skipping blank hierarchy facet component: profile='{}', entity='{}', dimension='{}', field='{}', rawValue='{}'",
+                profile.getShapeNode(), entity.getId(), hierarchy.getDimensionName(),
+                levelField.getFieldName(), rawValue);
+            return;
+        }
+        values.add(stringValue);
+    }
+
     private void addFacetPaths(Document doc, String dim, List<List<String>> levelValues,
             int level, List<String> currentPath) {
         if (level >= levelValues.size()) {
@@ -606,7 +640,19 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
             }
             return;
         }
-        for (String val : values) {
+        List<String> usableValues = new ArrayList<>();
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                usableValues.add(value);
+            }
+        }
+        if (usableValues.isEmpty()) {
+            if (!currentPath.isEmpty()) {
+                doc.add(new FacetField(dim, currentPath.toArray(new String[0])));
+            }
+            return;
+        }
+        for (String val : usableValues) {
             currentPath.add(val);
             addFacetPaths(doc, dim, levelValues, level + 1, currentPath);
             currentPath.remove(currentPath.size() - 1);
@@ -1429,7 +1475,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
             searcher.search(new MatchAllDocsQuery(), fc);
         }
 
-        TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDirectory);
+        TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
         Facets taxoFacets = new FastTaxonomyFacetCounts(TAXO_INDEX_FIELD, taxoReader, facetsConfig, fc);
 
         Map<String, Facets> dimToFacets = new HashMap<>();

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
@@ -36,47 +36,45 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Parses SHACL-like shape definitions from an RDF config into a {@link ShaclIndexMapping}.
- * <p>
- * Not an {@code AssemblerBase} subclass — called from {@link TextIndexLuceneAssembler}.
- * <p>
- * Uses standard Jena RDF API to read {@code sh:targetClass}, {@code sh:path},
- * {@code sh:alternativePath} — no jena-shacl dependency.
+ * Parses SHACL-like shape definitions from RDF into a {@link ShaclIndexMapping}.
  */
 public class ShaclIndexAssembler {
     private static final Logger log = LoggerFactory.getLogger(ShaclIndexAssembler.class);
 
-    // SHACL namespace — we only read config, not run validation
     private static final String SH = "http://www.w3.org/ns/shacl#";
+    private static final String SH_BLANK_NODE = SH + "BlankNode";
+    private static final String SH_IRI = SH + "IRI";
+    private static final String SH_LITERAL = SH + "Literal";
+    private static final String SH_BLANK_NODE_OR_IRI = SH + "BlankNodeOrIRI";
+    private static final String SH_BLANK_NODE_OR_LITERAL = SH + "BlankNodeOrLiteral";
+    private static final String SH_IRI_OR_LITERAL = SH + "IRIOrLiteral";
+
     private static final Property shTargetClass     = ResourceFactory.createProperty(SH, "targetClass");
     private static final Property shProperty        = ResourceFactory.createProperty(SH, "property");
     private static final Property shPath            = ResourceFactory.createProperty(SH, "path");
     private static final Property shAlternativePath = ResourceFactory.createProperty(SH, "alternativePath");
-    private static final Property shInversePath    = ResourceFactory.createProperty(SH, "inversePath");
+    private static final Property shInversePath     = ResourceFactory.createProperty(SH, "inversePath");
+    private static final Property shClass           = ResourceFactory.createProperty(SH, "class");
+    private static final Property shNodeKind        = ResourceFactory.createProperty(SH, "nodeKind");
+    private static final Property shDatatype        = ResourceFactory.createProperty(SH, "datatype");
 
-    private static final Node SH_INVERSE_PATH     = shInversePath.asNode();
-    private static final Node SH_ALTERNATIVE_PATH  = shAlternativePath.asNode();
+    private static final Node SH_INVERSE_PATH = shInversePath.asNode();
+    private static final Node SH_ALTERNATIVE_PATH = shAlternativePath.asNode();
     private static final Node RDF_FIRST = org.apache.jena.vocabulary.RDF.first.asNode();
-    private static final Node RDF_NIL  = org.apache.jena.vocabulary.RDF.nil.asNode();
+    private static final Node RDF_NIL = org.apache.jena.vocabulary.RDF.nil.asNode();
 
     private ShaclIndexAssembler() {}
 
-    /**
-     * Parse an RDF list of shape resources into a {@link ShaclIndexMapping}.
-     *
-     * @param a the assembler context (for resolving analyzer resources)
-     * @param shapesList the RDF resource that is the head of the shapes list
-     * @return parsed mapping
-     */
     public static ShaclIndexMapping parseShapes(Assembler a, Resource shapesList) {
         List<IndexProfile> profiles = new ArrayList<>();
+        Map<String, FieldDef> canonicalFields = new LinkedHashMap<>();
 
         RDFList rdfList = shapesList.as(RDFList.class);
         for (RDFNode item : rdfList.asJavaList()) {
             if (!item.isResource()) {
                 throw new TextIndexException("text:shapes list item is not a resource: " + item);
             }
-            profiles.add(parseProfile(a, item.asResource()));
+            profiles.add(parseProfile(a, item.asResource(), canonicalFields));
         }
 
         if (profiles.isEmpty()) {
@@ -86,10 +84,11 @@ public class ShaclIndexAssembler {
         return new ShaclIndexMapping(profiles);
     }
 
-    private static IndexProfile parseProfile(Assembler a, Resource shape) {
+    private static IndexProfile parseProfile(Assembler a, Resource shape,
+                                             Map<String, FieldDef> canonicalFields) {
         Node shapeNode = shape.asNode();
+        rejectLegacyShapeFieldList(shape);
 
-        // sh:targetClass
         Set<Node> targetClasses = new LinkedHashSet<>();
         StmtIterator tcIter = shape.listProperties(shTargetClass);
         while (tcIter.hasNext()) {
@@ -102,59 +101,48 @@ public class ShaclIndexAssembler {
             throw new TextIndexException("Shape " + shape + " has no sh:targetClass");
         }
 
-        // idx:docIdField (optional, default "uri")
         String docIdField = getOptionalString(shape, IndexVocab.pDocIdField);
-
-        // idx:discriminatorField (optional, default "docType")
         String discriminatorField = getOptionalString(shape, IndexVocab.pDiscriminatorField);
 
-        // Parse fields from idx:field list or sh:property
-        Map<String, FieldDef> fieldsByIRI = new LinkedHashMap<>();
+        Map<String, FieldDef> reachableFields = new LinkedHashMap<>();
+        List<FieldOccurrence> rootOccurrences = parseRootOccurrences(a, shape, canonicalFields, reachableFields);
+        List<NestedDef> nestedDefs = parseNestedDefs(a, shape, canonicalFields, reachableFields);
+        List<FieldDef> fields = new ArrayList<>(reachableFields.values());
 
-        // idx:field — an RDF list of field resources
-        Statement fieldStmt = shape.getProperty(IndexVocab.pField);
-        if (fieldStmt != null) {
-            RDFNode fieldNode = fieldStmt.getObject();
-            if (fieldNode.isResource()) {
-                try {
-                    RDFList fieldList = fieldNode.asResource().as(RDFList.class);
-                    for (RDFNode fn : fieldList.asJavaList()) {
-                        if (fn.isResource()) {
-                            resolveRootFieldDef(a, fn.asResource(), fieldsByIRI);
-                        }
-                    }
-                } catch (Exception e) {
-                    throw new TextIndexException("idx:field on " + shape + " is not a valid RDF list: " + e.getMessage());
-                }
-            }
+        if (rootOccurrences.isEmpty() && nestedDefs.isEmpty()) {
+            throw new TextIndexException("Shape " + shape + " has no field occurrences");
         }
 
-        // Also parse sh:property nodes (for shapes that use SHACL property shapes directly)
-        StmtIterator propIter = shape.listProperties(shProperty);
-        while (propIter.hasNext()) {
-            Resource propShape = propIter.next().getObject().asResource();
-            resolveRootFieldDef(a, propShape, fieldsByIRI);
-        }
-
-        List<NestedDef> nestedDefs = parseNestedDefs(a, shape, fieldsByIRI);
-        List<FieldDef> fields = new ArrayList<>(fieldsByIRI.values());
-
-        if (fields.isEmpty()) {
-            throw new TextIndexException("Shape " + shape + " has no fields (idx:field, sh:property, or idx:nested/idx:property)");
-        }
-
-        // Parse direct hierarchical facet definitions: idx:facetHierarchy
         List<HierarchyDef> hierarchies = parseHierarchies(shape, fields);
-
         return new IndexProfile(shapeNode, targetClasses, docIdField, discriminatorField,
-            fields, hierarchies, nestedDefs);
+            fields, rootOccurrences, hierarchies, nestedDefs);
     }
 
-    /**
-     * Parse {@code idx:nested} declarations on a shape.
-     */
+    private static void rejectLegacyShapeFieldList(Resource shape) {
+        if (shape.hasProperty(IndexVocab.pField)) {
+            throw new TextIndexException(
+                "Shape " + shape + " uses legacy idx:field. Root fields must now be declared as sh:property occurrences.");
+        }
+    }
+
+    private static List<FieldOccurrence> parseRootOccurrences(Assembler a, Resource shape,
+                                                              Map<String, FieldDef> canonicalFields,
+                                                              Map<String, FieldDef> reachableFields) {
+        List<FieldOccurrence> occurrences = new ArrayList<>();
+        StmtIterator propIter = shape.listProperties(shProperty);
+        while (propIter.hasNext()) {
+            RDFNode propNode = propIter.next().getObject();
+            if (!propNode.isResource()) {
+                throw new TextIndexException("sh:property on " + shape + " must be a resource");
+            }
+            occurrences.add(parseOccurrence(a, propNode.asResource(), canonicalFields, reachableFields, null));
+        }
+        return Collections.unmodifiableList(occurrences);
+    }
+
     private static List<NestedDef> parseNestedDefs(Assembler a, Resource shape,
-            Map<String, FieldDef> fieldsByIRI) {
+                                                   Map<String, FieldDef> canonicalFields,
+                                                   Map<String, FieldDef> reachableFields) {
         List<NestedDef> nestedDefs = new ArrayList<>();
 
         StmtIterator nestedIter = shape.listProperties(IndexVocab.pNested);
@@ -177,39 +165,32 @@ public class ShaclIndexAssembler {
                 throw new TextIndexException("Invalid idx:joinPath on " + shape + ": " + ex.getMessage(), ex);
             }
 
-            List<FieldDef> nestedFields = new ArrayList<>();
-            Set<String> seenFieldIRIs = new LinkedHashSet<>();
-
-            StmtIterator nestedFieldIter = nestedRes.listProperties(IndexVocab.pProperty);
-            while (nestedFieldIter.hasNext()) {
-                RDFNode fieldNode = nestedFieldIter.next().getObject();
-                if (!fieldNode.isResource()) {
+            List<FieldOccurrence> nestedOccurrences = new ArrayList<>();
+            StmtIterator occurrenceIter = nestedRes.listProperties(IndexVocab.pProperty);
+            while (occurrenceIter.hasNext()) {
+                RDFNode occurrenceNode = occurrenceIter.next().getObject();
+                if (!occurrenceNode.isResource()) {
                     throw new TextIndexException("idx:property inside idx:nested must be a resource on " + shape);
                 }
-                FieldDef fieldDef = resolveNestedFieldDef(a, fieldNode.asResource(), fieldsByIRI, nestedName);
-                if (seenFieldIRIs.add(fieldDef.getFieldIRI().getURI())) {
-                    nestedFields.add(fieldDef);
-                }
+                nestedOccurrences.add(parseOccurrence(
+                    a, occurrenceNode.asResource(), canonicalFields, reachableFields, nestedName));
             }
 
-            if (nestedFields.isEmpty()) {
-                throw new TextIndexException("idx:nested on " + shape + " must reference at least one idx:property");
+            if (nestedOccurrences.isEmpty()) {
+                throw new TextIndexException("idx:nested on " + shape + " must define at least one idx:property occurrence");
             }
 
+            List<FieldDef> nestedFields = distinctFields(nestedOccurrences);
             List<HierarchyDef> nestedHierarchies = parseHierarchies(nestedRes, nestedFields);
             nestedDefs.add(new NestedDef(nestedName, joinPath, joinSteps, extractJoinPredicates(joinSteps),
-                nestedFields, nestedHierarchies));
-            log.debug("Parsed nested definition: {} joinPath={} fields={}", nestedName, joinPath, nestedFields);
+                nestedOccurrences, nestedHierarchies));
+            log.debug("Parsed nested definition: {} joinPath={} occurrences={}",
+                nestedName, joinPath, nestedOccurrences);
         }
 
-        return nestedDefs;
+        return Collections.unmodifiableList(nestedDefs);
     }
 
-    /**
-     * Parse {@code idx:facetHierarchy} declarations on a shape or nested block.
-     * Each hierarchy is an RDF list of field resource IRIs that define the ordered levels.
-     * The dimension name is derived from the field names joined by "_".
-     */
     private static List<HierarchyDef> parseHierarchies(Resource owner, List<FieldDef> fields) {
         List<HierarchyDef> hierarchies = new ArrayList<>();
 
@@ -235,15 +216,17 @@ public class ShaclIndexAssembler {
                         "idx:facetHierarchy level must be a URI resource, got " + levelNode);
                 }
                 String levelIRI = levelNode.asResource().getURI();
-                FieldDef fd = findFieldByIRI(fields, levelIRI);
-                if (fd == null) {
+                FieldDef field = findFieldByIRI(fields, levelIRI);
+                if (field == null) {
                     throw new TextIndexException(
-                        "idx:facetHierarchy references unknown field IRI: " + levelIRI
-                        + ". All hierarchy levels must be declared on the same shape or nested block.");
+                        "idx:facetHierarchy references unknown canonical field IRI: " + levelIRI
+                        + ". Hierarchy levels must reference fields populated in the same scope.");
                 }
-                levels.add(fd);
-                if (dimNameBuilder.length() > 0) dimNameBuilder.append("_");
-                dimNameBuilder.append(fd.getFieldName());
+                levels.add(field);
+                if (dimNameBuilder.length() > 0) {
+                    dimNameBuilder.append("_");
+                }
+                dimNameBuilder.append(field.getFieldName());
             }
 
             String dimensionName = dimNameBuilder.toString();
@@ -251,46 +234,151 @@ public class ShaclIndexAssembler {
             log.debug("Parsed hierarchy: {} levels={}", dimensionName, levels);
         }
 
-        return hierarchies;
+        return Collections.unmodifiableList(hierarchies);
     }
 
-    private static FieldDef resolveRootFieldDef(Assembler a, Resource fieldRes,
-            Map<String, FieldDef> fieldsByIRI) {
-        FieldDef parsed = parseFieldDef(a, fieldRes).withNestedName(null);
+    private static FieldOccurrence parseOccurrence(Assembler a, Resource occurrenceRes,
+                                                   Map<String, FieldDef> canonicalFields,
+                                                   Map<String, FieldDef> reachableFields,
+                                                   String nestedName) {
+        rejectCanonicalFieldPropertiesOnOccurrence(occurrenceRes);
+
+        Statement fieldStmt = occurrenceRes.getProperty(IndexVocab.pField);
+        if (fieldStmt == null || !fieldStmt.getObject().isResource()) {
+            throw new TextIndexException("Field occurrence " + occurrenceRes + " is missing idx:field");
+        }
+
+        FieldDef field = resolveCanonicalField(a, fieldStmt.getObject().asResource(), canonicalFields);
+        reachableFields.putIfAbsent(field.getFieldIRI().getURI(), field);
+
+        Path path = extractOccurrencePath(occurrenceRes);
+        if (path == null) {
+            throw new TextIndexException("Field occurrence " + occurrenceRes + " is missing sh:path");
+        }
+
+        Node requiredClass = getOptionalResourceNode(occurrenceRes, shClass);
+        NodeKindConstraint nodeKindConstraint = getOptionalNodeKindConstraint(occurrenceRes);
+        Node datatype = getOptionalResourceNode(occurrenceRes, shDatatype);
+
+        List<List<JoinStep>> pathVariants = extractPathVariants(path);
+        Set<Node> predicates = extractLeafPredicates(path);
+
+        return new FieldOccurrence(field, path, pathVariants, predicates,
+            requiredClass, nodeKindConstraint, datatype, nestedName);
+    }
+
+    private static void rejectCanonicalFieldPropertiesOnOccurrence(Resource occurrenceRes) {
+        List<Property> forbidden = List.of(
+            IndexVocab.pFieldName,
+            IndexVocab.pFieldType,
+            IndexVocab.pAnalyzer,
+            IndexVocab.pQueryAnalyzer,
+            IndexVocab.pStored,
+            IndexVocab.pIndexed,
+            IndexVocab.pFacetable,
+            IndexVocab.pSortable,
+            IndexVocab.pMultiValued,
+            IndexVocab.pDefaultSearch,
+            IndexVocab.pStoreLiteralMetadata,
+            IndexVocab.pJoinPath,
+            IndexVocab.pNested,
+            IndexVocab.pPath
+        );
+        for (Property property : forbidden) {
+            if (occurrenceRes.hasProperty(property)) {
+                throw new TextIndexException(
+                    "Field occurrence " + occurrenceRes + " mixes occurrence data with canonical field metadata via " + property);
+            }
+        }
+    }
+
+    private static FieldDef resolveCanonicalField(Assembler a, Resource fieldRes,
+                                                  Map<String, FieldDef> canonicalFields) {
+        String directKey = fieldRes.isURIResource() ? fieldRes.getURI() : null;
+        if (directKey != null) {
+            FieldDef existing = canonicalFields.get(directKey);
+            if (existing != null) {
+                return existing;
+            }
+        }
+
+        FieldDef parsed = parseCanonicalField(a, fieldRes);
         String iri = parsed.getFieldIRI().getURI();
-        FieldDef existing = fieldsByIRI.get(iri);
+        FieldDef existing = canonicalFields.get(iri);
         if (existing == null) {
-            fieldsByIRI.put(iri, parsed);
+            canonicalFields.put(iri, parsed);
             return parsed;
         }
-        if (existing.isNestedScoped()) {
-            throw new TextIndexException(
-                "Field " + iri + " cannot be used both as a root field and as an idx:nested property. "
-                + "Define separate field IRIs for parent and nested scopes.");
-        }
+        validateSameCanonicalField(existing, parsed);
         return existing;
     }
 
-    private static FieldDef resolveNestedFieldDef(Assembler a, Resource fieldRes,
-            Map<String, FieldDef> fieldsByIRI, String nestedName) {
-        FieldDef parsed = parseFieldDef(a, fieldRes).withNestedName(nestedName);
-        String iri = parsed.getFieldIRI().getURI();
-        FieldDef existing = fieldsByIRI.get(iri);
-        if (existing == null) {
-            fieldsByIRI.put(iri, parsed);
-            return parsed;
-        }
-        if (existing.isRootScoped()) {
+    private static void validateSameCanonicalField(FieldDef existing, FieldDef parsed) {
+        if (!Objects.equals(existing.getFieldName(), parsed.getFieldName())
+                || existing.getFieldType() != parsed.getFieldType()
+                || existing.isStored() != parsed.isStored()
+                || existing.isIndexed() != parsed.isIndexed()
+                || existing.isFacetable() != parsed.isFacetable()
+                || existing.isSortable() != parsed.isSortable()
+                || existing.isMultiValued() != parsed.isMultiValued()
+                || existing.isDefaultSearch() != parsed.isDefaultSearch()
+                || existing.isStoreLiteralMetadata() != parsed.isStoreLiteralMetadata()) {
             throw new TextIndexException(
-                "Field " + iri + " cannot be used both as a root field and as an idx:nested property. "
-                + "Define separate field IRIs for parent and nested scopes.");
+                "Canonical field " + existing.getFieldIRI().getURI() + " is defined inconsistently across occurrences");
         }
-        if (!nestedName.equals(existing.getNestedName())) {
+    }
+
+    private static FieldDef parseCanonicalField(Assembler a, Resource fieldRes) {
+        rejectOccurrencePropertiesOnCanonicalField(fieldRes);
+
+        String fieldName = getRequiredString(fieldRes, IndexVocab.pFieldName,
+            "Canonical field " + fieldRes + " is missing idx:fieldName");
+
+        FieldType fieldType = FieldType.TEXT;
+        Statement ftStmt = fieldRes.getProperty(IndexVocab.pFieldType);
+        if (ftStmt != null) {
+            fieldType = parseFieldType(ftStmt.getObject());
+        }
+
+        Analyzer analyzer = null;
+        Statement analyzerStmt = fieldRes.getProperty(IndexVocab.pAnalyzer);
+        if (analyzerStmt != null && analyzerStmt.getObject().isResource()) {
+            analyzer = (Analyzer) a.open(analyzerStmt.getObject().asResource());
+        }
+
+        Analyzer queryAnalyzer = null;
+        Statement queryAnalyzerStmt = fieldRes.getProperty(IndexVocab.pQueryAnalyzer);
+        if (queryAnalyzerStmt != null && queryAnalyzerStmt.getObject().isResource()) {
+            queryAnalyzer = (Analyzer) a.open(queryAnalyzerStmt.getObject().asResource());
+        }
+
+        boolean stored = getOptionalBoolean(fieldRes, IndexVocab.pStored, true);
+        boolean indexed = getOptionalBoolean(fieldRes, IndexVocab.pIndexed, true);
+        boolean facetable = getOptionalBoolean(fieldRes, IndexVocab.pFacetable, false);
+        boolean sortable = getOptionalBoolean(fieldRes, IndexVocab.pSortable, false);
+        boolean multiValued = getOptionalBoolean(fieldRes, IndexVocab.pMultiValued, false);
+        boolean defaultSearch = getOptionalBoolean(fieldRes, IndexVocab.pDefaultSearch, false);
+        boolean storeLiteralMetadata = getOptionalBoolean(fieldRes, IndexVocab.pStoreLiteralMetadata, false);
+
+        Node fieldIRI = fieldRes.isURIResource() ? fieldRes.asNode() : null;
+        FieldDef fieldDef = new FieldDef(fieldName, fieldType, analyzer, queryAnalyzer,
+            stored, indexed, facetable, sortable, multiValued, defaultSearch,
+            storeLiteralMetadata, fieldIRI);
+        log.debug("Parsed canonical field: {} type={} facetable={}", fieldDef.getFieldName(),
+            fieldDef.getFieldType(), fieldDef.isFacetable());
+        return fieldDef;
+    }
+
+    private static void rejectOccurrencePropertiesOnCanonicalField(Resource fieldRes) {
+        if (fieldRes.hasProperty(shPath)
+                || fieldRes.hasProperty(IndexVocab.pPath)
+                || fieldRes.hasProperty(shClass)
+                || fieldRes.hasProperty(shNodeKind)
+                || fieldRes.hasProperty(shDatatype)
+                || fieldRes.hasProperty(IndexVocab.pField)) {
             throw new TextIndexException(
-                "Field " + iri + " cannot be reused across multiple idx:nested scopes. "
-                + "Define a separate field IRI for each nested collection.");
+                "Canonical field " + fieldRes + " must not carry occurrence properties such as sh:path or idx:field");
         }
-        return existing;
     }
 
     private static String deriveNestedName(Path joinPath) {
@@ -301,8 +389,7 @@ public class ShaclIndexAssembler {
         List<JoinStep> steps = new ArrayList<>();
         collectJoinSteps(joinPath, steps);
         if (steps.isEmpty()) {
-            throw new TextIndexException(
-                "idx:joinPath must contain at least one predicate step: " + joinPath);
+            throw new TextIndexException("idx:joinPath must contain at least one predicate step: " + joinPath);
         }
         return Collections.unmodifiableList(steps);
     }
@@ -331,108 +418,99 @@ public class ShaclIndexAssembler {
             + "and sequences composed from them: " + joinPath);
     }
 
+    public static List<List<JoinStep>> extractPathVariants(Path path) {
+        List<List<JoinStep>> variants = collectPathVariants(path);
+        if (variants.isEmpty()) {
+            throw new TextIndexException("sh:path must contain at least one predicate step: " + path);
+        }
+        return Collections.unmodifiableList(variants);
+    }
+
+    private static List<List<JoinStep>> collectPathVariants(Path path) {
+        if (path instanceof P_Link link) {
+            return List.of(List.of(new JoinStep(link.getNode(), false)));
+        }
+        if (path instanceof P_Inverse inverse) {
+            return invertVariants(collectPathVariants(inverse.getSubPath()));
+        }
+        if (path instanceof P_Seq seq) {
+            return combineVariants(collectPathVariants(seq.getLeft()), collectPathVariants(seq.getRight()));
+        }
+        if (path instanceof P_Alt alt) {
+            List<List<JoinStep>> variants = new ArrayList<>();
+            variants.addAll(collectPathVariants(alt.getLeft()));
+            variants.addAll(collectPathVariants(alt.getRight()));
+            return variants;
+        }
+        throw new TextIndexException(
+            "sh:path supports only simple predicate steps, inverse predicate steps, "
+            + "sequences, and alternatives composed from them: " + path);
+    }
+
+    private static List<List<JoinStep>> invertVariants(List<List<JoinStep>> variants) {
+        List<List<JoinStep>> inverted = new ArrayList<>();
+        for (List<JoinStep> variant : variants) {
+            List<JoinStep> copy = new ArrayList<>(variant.size());
+            for (int i = variant.size() - 1; i >= 0; i--) {
+                JoinStep step = variant.get(i);
+                copy.add(new JoinStep(step.getPredicate(), !step.isInverse()));
+            }
+            inverted.add(Collections.unmodifiableList(copy));
+        }
+        return Collections.unmodifiableList(inverted);
+    }
+
+    private static List<List<JoinStep>> combineVariants(List<List<JoinStep>> left, List<List<JoinStep>> right) {
+        List<List<JoinStep>> combined = new ArrayList<>();
+        for (List<JoinStep> lhs : left) {
+            for (List<JoinStep> rhs : right) {
+                List<JoinStep> seq = new ArrayList<>(lhs.size() + rhs.size());
+                seq.addAll(lhs);
+                seq.addAll(rhs);
+                combined.add(Collections.unmodifiableList(seq));
+            }
+        }
+        return Collections.unmodifiableList(combined);
+    }
+
     private static Set<Node> extractJoinPredicates(List<JoinStep> joinSteps) {
         Set<Node> predicates = new LinkedHashSet<>();
-        for (JoinStep joinStep : joinSteps) {
-            predicates.add(joinStep.getPredicate());
+        for (JoinStep step : joinSteps) {
+            predicates.add(step.getPredicate());
         }
         return Collections.unmodifiableSet(predicates);
     }
 
     private static FieldDef findFieldByIRI(List<FieldDef> fields, String iri) {
-        for (FieldDef fd : fields) {
-            if (fd.getFieldIRI().getURI().equals(iri)) {
-                return fd;
+        for (FieldDef field : fields) {
+            if (field.getFieldIRI().getURI().equals(iri)) {
+                return field;
             }
         }
         return null;
     }
 
-    private static FieldDef parseFieldDef(Assembler a, Resource fieldRes) {
-        // idx:fieldName (required)
-        String fieldName = getRequiredString(fieldRes, IndexVocab.pFieldName,
-            "Field " + fieldRes + " missing idx:fieldName");
-
-        // idx:fieldType (optional, default TEXT)
-        FieldType fieldType = FieldType.TEXT;
-        Statement ftStmt = fieldRes.getProperty(IndexVocab.pFieldType);
-        if (ftStmt != null) {
-            fieldType = parseFieldType(ftStmt.getObject());
+    private static List<FieldDef> distinctFields(List<FieldOccurrence> occurrences) {
+        Map<String, FieldDef> fieldsByIri = new LinkedHashMap<>();
+        for (FieldOccurrence occurrence : occurrences) {
+            FieldDef field = occurrence.getField();
+            fieldsByIri.putIfAbsent(field.getFieldIRI().getURI(), field);
         }
-
-        // idx:analyzer (optional — used for indexing; also used for querying if idx:queryAnalyzer is not set)
-        Analyzer analyzer = null;
-        Statement analyzerStmt = fieldRes.getProperty(IndexVocab.pAnalyzer);
-        if (analyzerStmt != null && analyzerStmt.getObject().isResource()) {
-            analyzer = (Analyzer) a.open(analyzerStmt.getObject().asResource());
-        }
-
-        // idx:queryAnalyzer (optional — overrides idx:analyzer at query time)
-        Analyzer queryAnalyzer = null;
-        Statement queryAnalyzerStmt = fieldRes.getProperty(IndexVocab.pQueryAnalyzer);
-        if (queryAnalyzerStmt != null && queryAnalyzerStmt.getObject().isResource()) {
-            queryAnalyzer = (Analyzer) a.open(queryAnalyzerStmt.getObject().asResource());
-        }
-
-        // Boolean flags with defaults
-        boolean stored = getOptionalBoolean(fieldRes, IndexVocab.pStored, true);
-        boolean indexed = getOptionalBoolean(fieldRes, IndexVocab.pIndexed, true);
-        boolean facetable = getOptionalBoolean(fieldRes, IndexVocab.pFacetable, false);
-        boolean sortable = getOptionalBoolean(fieldRes, IndexVocab.pSortable, false);
-        boolean multiValued = getOptionalBoolean(fieldRes, IndexVocab.pMultiValued, false);
-        boolean defaultSearch = getOptionalBoolean(fieldRes, IndexVocab.pDefaultSearch, false);
-        boolean storeLiteralMetadata = getOptionalBoolean(fieldRes, IndexVocab.pStoreLiteralMetadata, false);
-
-        // Parse path: from sh:path or idx:path
-        Path path = extractPath(fieldRes);
-        if (path == null) {
-            throw new TextIndexException("Field " + fieldRes + " (" + fieldName + ") has no path/predicate");
-        }
-
-        // Extract leaf predicates for change listener compatibility
-        Set<Node> predicates = extractLeafPredicates(path);
-
-        // Use the field resource's URI as the field IRI if it's a named resource
-        Node fieldIRI = fieldRes.isURIResource() ? fieldRes.asNode() : null;
-
-        log.debug("Parsed field: {} type={} path={} facetable={}", fieldName, fieldType, path, facetable);
-        return new FieldDef(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed,
-                           facetable, sortable, multiValued, defaultSearch, storeLiteralMetadata,
-                           predicates, path, fieldIRI);
+        return new ArrayList<>(fieldsByIri.values());
     }
 
-    /**
-     * Extract a {@link Path} from sh:path or idx:path on a field/property-shape resource.
-     * <p>
-     * Supports the SHACL property path subset:
-     * <ul>
-     *   <li>{@code sh:path <uri>} — predicate path</li>
-     *   <li>{@code sh:path [ sh:alternativePath (<uri1> <uri2> ...) ]} — alternative path</li>
-     *   <li>{@code sh:path [ sh:inversePath <uri> ]} — inverse path</li>
-     *   <li>{@code sh:path ( <uri1> <uri2> )} — sequence path</li>
-     *   <li>Nesting of the above types</li>
-     *   <li>{@code idx:path <uri>} — single predicate (convenience)</li>
-     * </ul>
-     */
-    static Path extractPath(Resource fieldRes) {
-        // Try sh:path first
-        Statement pathStmt = fieldRes.getProperty(shPath);
-        if (pathStmt != null) {
-            Node pathNode = pathStmt.getObject().asNode();
-            Graph graph = fieldRes.getModel().getGraph();
-            return parseShaclPath(graph, pathNode);
-        }
-
-        // Also try idx:path as a convenience (single predicate only)
-        Statement idxPathStmt = fieldRes.getProperty(IndexVocab.pPath);
-        if (idxPathStmt != null) {
-            RDFNode pathNode = idxPathStmt.getObject();
-            if (pathNode.isURIResource()) {
-                return PathFactory.pathLink(pathNode.asNode());
+    static Path extractOccurrencePath(Resource occurrenceRes) {
+        Statement pathStmt = occurrenceRes.getProperty(shPath);
+        if (pathStmt == null) {
+            if (occurrenceRes.hasProperty(IndexVocab.pPath)) {
+                throw new TextIndexException(
+                    "Field occurrence " + occurrenceRes + " uses legacy idx:path. Use sh:path instead.");
             }
+            return null;
         }
-
-        return null;
+        Node pathNode = pathStmt.getObject().asNode();
+        Graph graph = occurrenceRes.getModel().getGraph();
+        return parseShaclPath(graph, pathNode);
     }
 
     static Path extractJoinPath(Resource nestedRes) {
@@ -445,21 +523,11 @@ public class ShaclIndexAssembler {
         return parseShaclPath(graph, pathNode);
     }
 
-    /**
-     * Parse a SHACL property path from an RDF graph into a jena-arq {@link Path} object.
-     * Supports predicate, alternative, inverse, and sequence paths (and nesting of these).
-     * Does not support zeroOrMore, oneOrMore, or zeroOrOne paths.
-     * <p>
-     * Logic adapted from {@code org.apache.jena.shacl.engine.ShaclPaths.path()} to avoid
-     * a jena-shacl dependency.
-     */
     static Path parseShaclPath(Graph graph, Node node) {
-        // Predicate path: a URI node
         if (node.isURI() && !RDF_NIL.equals(node)) {
             return PathFactory.pathLink(node);
         }
 
-        // Sequence path: an RDF list ( p1 p2 ... )
         if (isList(graph, node)) {
             List<Node> nodes = G.rdfList(graph, node);
             if (nodes.isEmpty()) {
@@ -467,37 +535,25 @@ public class ShaclIndexAssembler {
             }
             Path path = null;
             for (Node n : nodes) {
-                Path p = parseShaclPath(graph, n);
-                if (path == null) {
-                    path = p;
-                } else {
-                    path = PathFactory.pathSeq(path, p);
-                }
+                Path next = parseShaclPath(graph, n);
+                path = path == null ? next : PathFactory.pathSeq(path, next);
             }
             return path;
         }
 
-        // Blank node: inverse or alternative path
         if (node.isBlank()) {
-            // sh:inversePath
             if (G.hasProperty(graph, node, SH_INVERSE_PATH)) {
-                Node x = G.getOneSP(graph, node, SH_INVERSE_PATH);
-                Path p = parseShaclPath(graph, x);
-                return PathFactory.pathInverse(p);
+                Node subPath = G.getOneSP(graph, node, SH_INVERSE_PATH);
+                return PathFactory.pathInverse(parseShaclPath(graph, subPath));
             }
 
-            // sh:alternativePath
             if (G.hasProperty(graph, node, SH_ALTERNATIVE_PATH)) {
-                Node x = G.getOneSP(graph, node, SH_ALTERNATIVE_PATH);
-                List<Node> nodes = G.rdfList(graph, x);
+                Node pathList = G.getOneSP(graph, node, SH_ALTERNATIVE_PATH);
+                List<Node> nodes = G.rdfList(graph, pathList);
                 Path path = null;
                 for (Node n : nodes) {
-                    Path p = parseShaclPath(graph, n);
-                    if (path == null) {
-                        path = p;
-                    } else {
-                        path = PathFactory.pathAlt(path, p);
-                    }
+                    Path next = parseShaclPath(graph, n);
+                    path = path == null ? next : PathFactory.pathAlt(path, next);
                 }
                 return path;
             }
@@ -507,45 +563,34 @@ public class ShaclIndexAssembler {
             + ". Only predicate, alternative, inverse, and sequence paths are supported.");
     }
 
-    /** Check if a node is the head of an RDF list. */
     private static boolean isList(Graph graph, Node node) {
         return RDF_NIL.equals(node) || G.contains(graph, node, RDF_FIRST, null);
     }
 
-    /**
-     * Extract all leaf predicate URIs from a {@link Path} for change listener compatibility.
-     * For simple paths, returns the single predicate. For complex paths, collects all
-     * predicate URIs that appear anywhere in the path structure.
-     */
     static Set<Node> extractLeafPredicates(Path path) {
         Set<Node> predicates = new LinkedHashSet<>();
         collectPredicates(path, predicates);
-        return predicates;
+        return Collections.unmodifiableSet(predicates);
     }
 
     private static void collectPredicates(Path path, Set<Node> predicates) {
-        if (path instanceof P_Link pLink) {
-            predicates.add(pLink.getNode());
-        } else if (path instanceof P_Inverse pInv) {
-            collectPredicates(pInv.getSubPath(), predicates);
-        } else if (path instanceof P_Seq pSeq) {
-            collectPredicates(pSeq.getLeft(), predicates);
-            collectPredicates(pSeq.getRight(), predicates);
-        } else if (path instanceof P_Alt pAlt) {
-            collectPredicates(pAlt.getLeft(), predicates);
-            collectPredicates(pAlt.getRight(), predicates);
+        if (path instanceof P_Link link) {
+            predicates.add(link.getNode());
+        } else if (path instanceof P_Inverse inverse) {
+            collectPredicates(inverse.getSubPath(), predicates);
+        } else if (path instanceof P_Seq seq) {
+            collectPredicates(seq.getLeft(), predicates);
+            collectPredicates(seq.getRight(), predicates);
+        } else if (path instanceof P_Alt alt) {
+            collectPredicates(alt.getLeft(), predicates);
+            collectPredicates(alt.getRight(), predicates);
         }
     }
 
-    /**
-     * Build an {@link EntityDefinition} from a {@link ShaclIndexMapping} for backward
-     * compatibility with existing query methods ({@code text:query}, {@code text:facet}).
-     */
     public static EntityDefinition deriveEntityDefinition(ShaclIndexMapping mapping) {
         IndexProfile firstProfile = mapping.getProfiles().get(0);
         String entityField = firstProfile.getDocIdField();
 
-        // Find the first defaultSearch field
         String primaryField = null;
         for (IndexProfile profile : mapping.getProfiles()) {
             for (FieldDef field : profile.getFields()) {
@@ -554,9 +599,10 @@ public class ShaclIndexAssembler {
                     break;
                 }
             }
-            if (primaryField != null) break;
+            if (primaryField != null) {
+                break;
+            }
         }
-        // Fallback: use first TEXT field
         if (primaryField == null) {
             for (FieldDef field : firstProfile.getFields()) {
                 if (field.getFieldType() == FieldType.TEXT) {
@@ -565,7 +611,6 @@ public class ShaclIndexAssembler {
                 }
             }
         }
-        // Last resort: first field
         if (primaryField == null) {
             primaryField = firstProfile.getFields().get(0).getFieldName();
         }
@@ -574,12 +619,16 @@ public class ShaclIndexAssembler {
         defn.setLangField("lang");
         defn.setUidField("uid");
 
-        // Register all fields and their predicates
         for (IndexProfile profile : mapping.getProfiles()) {
-            for (FieldDef field : profile.getFields()) {
-                for (Node pred : field.getPredicates()) {
-                    defn.set(field.getFieldName(), pred);
+            for (FieldOccurrence occurrence : profile.getRootOccurrences()) {
+                registerOccurrence(defn, occurrence);
+            }
+            for (NestedDef nestedDef : profile.getNestedDefs()) {
+                for (FieldOccurrence occurrence : nestedDef.getOccurrences()) {
+                    registerOccurrence(defn, occurrence);
                 }
+            }
+            for (FieldDef field : profile.getFields()) {
                 if (field.getAnalyzer() != null) {
                     defn.setAnalyzer(field.getFieldName(), field.getAnalyzer());
                 }
@@ -590,6 +639,12 @@ public class ShaclIndexAssembler {
         }
 
         return defn;
+    }
+
+    private static void registerOccurrence(EntityDefinition defn, FieldOccurrence occurrence) {
+        for (Node predicate : occurrence.getPredicates()) {
+            defn.set(occurrence.getField().getFieldName(), predicate);
+        }
     }
 
     private static FieldType parseFieldType(RDFNode node) {
@@ -608,21 +663,53 @@ public class ShaclIndexAssembler {
         throw new TextIndexException("Unknown idx:fieldType: " + uri);
     }
 
-    private static String getRequiredString(Resource r, Property p, String errorMsg) {
-        Statement s = r.getProperty(p);
-        if (s == null) throw new TextIndexException(errorMsg);
-        return s.getObject().asLiteral().getString();
+    private static String getRequiredString(Resource resource, Property property, String errorMsg) {
+        Statement stmt = resource.getProperty(property);
+        if (stmt == null) {
+            throw new TextIndexException(errorMsg);
+        }
+        return stmt.getObject().asLiteral().getString();
     }
 
-    private static String getOptionalString(Resource r, Property p) {
-        Statement s = r.getProperty(p);
-        if (s == null) return null;
-        return s.getObject().asLiteral().getString();
+    private static String getOptionalString(Resource resource, Property property) {
+        Statement stmt = resource.getProperty(property);
+        if (stmt == null) {
+            return null;
+        }
+        return stmt.getObject().asLiteral().getString();
     }
 
-    private static boolean getOptionalBoolean(Resource r, Property p, boolean defaultValue) {
-        Statement s = r.getProperty(p);
-        if (s == null) return defaultValue;
-        return s.getObject().asLiteral().getBoolean();
+    private static boolean getOptionalBoolean(Resource resource, Property property, boolean defaultValue) {
+        Statement stmt = resource.getProperty(property);
+        if (stmt == null) {
+            return defaultValue;
+        }
+        return stmt.getObject().asLiteral().getBoolean();
+    }
+
+    private static Node getOptionalResourceNode(Resource resource, Property property) {
+        Statement stmt = resource.getProperty(property);
+        if (stmt == null) {
+            return null;
+        }
+        if (!stmt.getObject().isResource()) {
+            throw new TextIndexException(property + " on " + resource + " must be a resource");
+        }
+        return stmt.getObject().asNode();
+    }
+
+    private static NodeKindConstraint getOptionalNodeKindConstraint(Resource occurrenceRes) {
+        Node nodeKind = getOptionalResourceNode(occurrenceRes, shNodeKind);
+        if (nodeKind == null) {
+            return null;
+        }
+        String uri = nodeKind.getURI();
+        if (SH_BLANK_NODE.equals(uri)) return NodeKindConstraint.BLANK_NODE;
+        if (SH_IRI.equals(uri)) return NodeKindConstraint.IRI;
+        if (SH_LITERAL.equals(uri)) return NodeKindConstraint.LITERAL;
+        if (SH_BLANK_NODE_OR_IRI.equals(uri)) return NodeKindConstraint.BLANK_NODE_OR_IRI;
+        if (SH_BLANK_NODE_OR_LITERAL.equals(uri)) return NodeKindConstraint.BLANK_NODE_OR_LITERAL;
+        if (SH_IRI_OR_LITERAL.equals(uri)) return NodeKindConstraint.IRI_OR_LITERAL;
+        throw new TextIndexException("Unsupported sh:nodeKind on " + occurrenceRes + ": " + nodeKind);
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
@@ -65,9 +65,11 @@ public class ShaclIndexAssembler {
 
     private ShaclIndexAssembler() {}
 
+    private record CanonicalFieldSpec(FieldDef field, Node analyzerNode, Node queryAnalyzerNode) {}
+
     public static ShaclIndexMapping parseShapes(Assembler a, Resource shapesList) {
         List<IndexProfile> profiles = new ArrayList<>();
-        Map<String, FieldDef> canonicalFields = new LinkedHashMap<>();
+        Map<String, CanonicalFieldSpec> canonicalFields = new LinkedHashMap<>();
 
         RDFList rdfList = shapesList.as(RDFList.class);
         for (RDFNode item : rdfList.asJavaList()) {
@@ -85,7 +87,7 @@ public class ShaclIndexAssembler {
     }
 
     private static IndexProfile parseProfile(Assembler a, Resource shape,
-                                             Map<String, FieldDef> canonicalFields) {
+                                             Map<String, CanonicalFieldSpec> canonicalFields) {
         Node shapeNode = shape.asNode();
         rejectLegacyShapeFieldList(shape);
 
@@ -107,13 +109,14 @@ public class ShaclIndexAssembler {
         Map<String, FieldDef> reachableFields = new LinkedHashMap<>();
         List<FieldOccurrence> rootOccurrences = parseRootOccurrences(a, shape, canonicalFields, reachableFields);
         List<NestedDef> nestedDefs = parseNestedDefs(a, shape, canonicalFields, reachableFields);
+        List<FieldDef> rootFields = distinctFields(rootOccurrences);
         List<FieldDef> fields = new ArrayList<>(reachableFields.values());
 
         if (rootOccurrences.isEmpty() && nestedDefs.isEmpty()) {
             throw new TextIndexException("Shape " + shape + " has no field occurrences");
         }
 
-        List<HierarchyDef> hierarchies = parseHierarchies(shape, fields);
+        List<HierarchyDef> hierarchies = parseHierarchies(shape, rootFields);
         return new IndexProfile(shapeNode, targetClasses, docIdField, discriminatorField,
             fields, rootOccurrences, hierarchies, nestedDefs);
     }
@@ -126,7 +129,7 @@ public class ShaclIndexAssembler {
     }
 
     private static List<FieldOccurrence> parseRootOccurrences(Assembler a, Resource shape,
-                                                              Map<String, FieldDef> canonicalFields,
+                                                              Map<String, CanonicalFieldSpec> canonicalFields,
                                                               Map<String, FieldDef> reachableFields) {
         List<FieldOccurrence> occurrences = new ArrayList<>();
         StmtIterator propIter = shape.listProperties(shProperty);
@@ -141,7 +144,7 @@ public class ShaclIndexAssembler {
     }
 
     private static List<NestedDef> parseNestedDefs(Assembler a, Resource shape,
-                                                   Map<String, FieldDef> canonicalFields,
+                                                   Map<String, CanonicalFieldSpec> canonicalFields,
                                                    Map<String, FieldDef> reachableFields) {
         List<NestedDef> nestedDefs = new ArrayList<>();
 
@@ -238,7 +241,7 @@ public class ShaclIndexAssembler {
     }
 
     private static FieldOccurrence parseOccurrence(Assembler a, Resource occurrenceRes,
-                                                   Map<String, FieldDef> canonicalFields,
+                                                   Map<String, CanonicalFieldSpec> canonicalFields,
                                                    Map<String, FieldDef> reachableFields,
                                                    String nestedName) {
         rejectCanonicalFieldPropertiesOnOccurrence(occurrenceRes);
@@ -293,42 +296,47 @@ public class ShaclIndexAssembler {
     }
 
     private static FieldDef resolveCanonicalField(Assembler a, Resource fieldRes,
-                                                  Map<String, FieldDef> canonicalFields) {
+                                                  Map<String, CanonicalFieldSpec> canonicalFields) {
         String directKey = fieldRes.isURIResource() ? fieldRes.getURI() : null;
         if (directKey != null) {
-            FieldDef existing = canonicalFields.get(directKey);
+            CanonicalFieldSpec existing = canonicalFields.get(directKey);
             if (existing != null) {
-                return existing;
+                return existing.field();
             }
         }
 
-        FieldDef parsed = parseCanonicalField(a, fieldRes);
-        String iri = parsed.getFieldIRI().getURI();
-        FieldDef existing = canonicalFields.get(iri);
+        CanonicalFieldSpec parsed = parseCanonicalField(a, fieldRes);
+        String iri = parsed.field().getFieldIRI().getURI();
+        CanonicalFieldSpec existing = canonicalFields.get(iri);
         if (existing == null) {
             canonicalFields.put(iri, parsed);
-            return parsed;
+            return parsed.field();
         }
         validateSameCanonicalField(existing, parsed);
-        return existing;
+        return existing.field();
     }
 
-    private static void validateSameCanonicalField(FieldDef existing, FieldDef parsed) {
-        if (!Objects.equals(existing.getFieldName(), parsed.getFieldName())
-                || existing.getFieldType() != parsed.getFieldType()
-                || existing.isStored() != parsed.isStored()
-                || existing.isIndexed() != parsed.isIndexed()
-                || existing.isFacetable() != parsed.isFacetable()
-                || existing.isSortable() != parsed.isSortable()
-                || existing.isMultiValued() != parsed.isMultiValued()
-                || existing.isDefaultSearch() != parsed.isDefaultSearch()
-                || existing.isStoreLiteralMetadata() != parsed.isStoreLiteralMetadata()) {
+    private static void validateSameCanonicalField(CanonicalFieldSpec existing, CanonicalFieldSpec parsed) {
+        FieldDef existingField = existing.field();
+        FieldDef parsedField = parsed.field();
+        if (!Objects.equals(existingField.getFieldName(), parsedField.getFieldName())
+                || existingField.getFieldType() != parsedField.getFieldType()
+                || existingField.isStored() != parsedField.isStored()
+                || existingField.isIndexed() != parsedField.isIndexed()
+                || existingField.isFacetable() != parsedField.isFacetable()
+                || existingField.isSortable() != parsedField.isSortable()
+                || existingField.isMultiValued() != parsedField.isMultiValued()
+                || existingField.isDefaultSearch() != parsedField.isDefaultSearch()
+                || existingField.isStoreLiteralMetadata() != parsedField.isStoreLiteralMetadata()
+                || !Objects.equals(existing.analyzerNode(), parsed.analyzerNode())
+                || !Objects.equals(existing.queryAnalyzerNode(), parsed.queryAnalyzerNode())) {
             throw new TextIndexException(
-                "Canonical field " + existing.getFieldIRI().getURI() + " is defined inconsistently across occurrences");
+                "Canonical field " + existingField.getFieldIRI().getURI()
+                + " is defined inconsistently across occurrences");
         }
     }
 
-    private static FieldDef parseCanonicalField(Assembler a, Resource fieldRes) {
+    private static CanonicalFieldSpec parseCanonicalField(Assembler a, Resource fieldRes) {
         rejectOccurrencePropertiesOnCanonicalField(fieldRes);
 
         String fieldName = getRequiredString(fieldRes, IndexVocab.pFieldName,
@@ -345,12 +353,18 @@ public class ShaclIndexAssembler {
         if (analyzerStmt != null && analyzerStmt.getObject().isResource()) {
             analyzer = (Analyzer) a.open(analyzerStmt.getObject().asResource());
         }
+        Node analyzerNode = analyzerStmt != null && analyzerStmt.getObject().isResource()
+            ? analyzerStmt.getObject().asNode()
+            : null;
 
         Analyzer queryAnalyzer = null;
         Statement queryAnalyzerStmt = fieldRes.getProperty(IndexVocab.pQueryAnalyzer);
         if (queryAnalyzerStmt != null && queryAnalyzerStmt.getObject().isResource()) {
             queryAnalyzer = (Analyzer) a.open(queryAnalyzerStmt.getObject().asResource());
         }
+        Node queryAnalyzerNode = queryAnalyzerStmt != null && queryAnalyzerStmt.getObject().isResource()
+            ? queryAnalyzerStmt.getObject().asNode()
+            : null;
 
         boolean stored = getOptionalBoolean(fieldRes, IndexVocab.pStored, true);
         boolean indexed = getOptionalBoolean(fieldRes, IndexVocab.pIndexed, true);
@@ -366,7 +380,7 @@ public class ShaclIndexAssembler {
             storeLiteralMetadata, fieldIRI);
         log.debug("Parsed canonical field: {} type={} facetable={}", fieldDef.getFieldName(),
             fieldDef.getFieldType(), fieldDef.isFacetable());
-        return fieldDef;
+        return new CanonicalFieldSpec(fieldDef, analyzerNode, queryAnalyzerNode);
     }
 
     private static void rejectOccurrencePropertiesOnCanonicalField(Resource fieldRes) {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -108,6 +108,9 @@ import org.junit.runners.Suite.SuiteClasses;
     // luc:match property function
     , TestTextMatchPF.class
 
+    // Shared field occurrences / fan-in
+    , TestSharedFieldOccurrences.class
+
     // Hierarchical facets
     , TestHierarchicalFacets.class
     , TestHierarchicalFacetsSparql.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java
@@ -31,9 +31,12 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.query.text.cql.CqlExpression;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
@@ -69,11 +72,20 @@ public class TestDateLiteralRoundTrip {
         FieldDef noteField = new FieldDef("note", FieldType.TEXT, null, null,
             true, true, false, false, false, false, true, Collections.singleton(NOTE_PRED), null, null);
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(labelField, PathFactory.pathLink(LABEL_PRED), Collections.singleton(LABEL_PRED)),
+            occurrence(dateField, PathFactory.pathLink(EVENT_DATE_PRED), Collections.singleton(EVENT_DATE_PRED)),
+            occurrence(tsField, PathFactory.pathLink(EVENT_TS_PRED), Collections.singleton(EVENT_TS_PRED)),
+            occurrence(noteField, PathFactory.pathLink(NOTE_PRED), Collections.singleton(NOTE_PRED)));
+
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI(NS + "EventShape"),
             Collections.singleton(EVENT_CLASS),
             "uri", "docType",
-            Arrays.asList(labelField, dateField, tsField, noteField));
+            Arrays.asList(labelField, dateField, tsField, noteField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -97,6 +109,15 @@ public class TestDateLiteralRoundTrip {
         } finally {
             dataset.end();
         }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java
@@ -64,13 +64,13 @@ public class TestDateLiteralRoundTrip {
     @Before
     public void setUp() {
         FieldDef labelField = new FieldDef("label", FieldType.TEXT, null,
-            true, true, false, false, false, true, Collections.singleton(LABEL_PRED));
+            true, true, false, false, false, true);
         FieldDef dateField = new FieldDef("eventDate", FieldType.DATE, null, null,
-            true, true, false, true, false, false, true, Collections.singleton(EVENT_DATE_PRED), null, null);
+            true, true, false, true, false, false, true);
         FieldDef tsField = new FieldDef("eventTimestamp", FieldType.DATETIME, null, null,
-            true, true, false, true, false, false, true, Collections.singleton(EVENT_TS_PRED), null, null);
+            true, true, false, true, false, false, true);
         FieldDef noteField = new FieldDef("note", FieldType.TEXT, null, null,
-            true, true, false, false, false, false, true, Collections.singleton(NOTE_PRED), null, null);
+            true, true, false, false, false, false, true);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(labelField, PathFactory.pathLink(LABEL_PRED), Collections.singleton(LABEL_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
@@ -29,6 +29,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
@@ -131,23 +132,56 @@ public class TestDemoMiningScenarios {
             PathFactory.pathLink(DEPTH));
 
         // --- Profiles (shapes) ---
+        List<FieldOccurrence> reportOccurrences = Arrays.asList(
+            occurrence(entityType, PathFactory.pathLink(RDF.type.asNode()), Collections.singleton(RDF.type.asNode())),
+            occurrence(title, PathFactory.pathLink(LABEL), Collections.singleton(LABEL)),
+            occurrence(commodity, PathFactory.pathLink(COMMODITY), Collections.singleton(COMMODITY)),
+            occurrence(state, PathFactory.pathLink(STATE), Collections.singleton(STATE)),
+            occurrence(operator, PathFactory.pathLink(OPERATOR), Collections.singleton(OPERATOR)),
+            occurrence(status, PathFactory.pathLink(STATUS), Collections.singleton(STATUS)),
+            occurrence(authorName, authorNamePath, authorNamePreds),
+            occurrence(authoredByUri, authoredByUriPath, Collections.singleton(AUTHORED)));
+
         IndexProfile reportProfile = new IndexProfile(
             NodeFactory.createURI(EX + "MiningReportShape"),
             Collections.singleton(REPORT_CLASS),
             "uri", "docType",
-            Arrays.asList(entityType, title, commodity, state, operator, status, authorName, authoredByUri));
+            Arrays.asList(entityType, title, commodity, state, operator, status, authorName, authoredByUri),
+            reportOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        List<FieldOccurrence> boreholeOccurrences = Arrays.asList(
+            occurrence(entityType, PathFactory.pathLink(RDF.type.asNode()), Collections.singleton(RDF.type.asNode())),
+            occurrence(title, PathFactory.pathLink(LABEL), Collections.singleton(LABEL)),
+            occurrence(commodity, PathFactory.pathLink(COMMODITY), Collections.singleton(COMMODITY)),
+            occurrence(state, PathFactory.pathLink(STATE), Collections.singleton(STATE)),
+            occurrence(depth, PathFactory.pathLink(DEPTH), Collections.singleton(DEPTH)));
 
         IndexProfile boreholeProfile = new IndexProfile(
             NodeFactory.createURI(EX + "BoreholeShape"),
             Collections.singleton(BOREHOLE_CLASS),
             "uri", "docType",
-            Arrays.asList(entityType, title, commodity, state, depth));
+            Arrays.asList(entityType, title, commodity, state, depth),
+            boreholeOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        List<FieldOccurrence> siteOccurrences = Arrays.asList(
+            occurrence(entityType, PathFactory.pathLink(RDF.type.asNode()), Collections.singleton(RDF.type.asNode())),
+            occurrence(title, PathFactory.pathLink(LABEL), Collections.singleton(LABEL)),
+            occurrence(commodity, PathFactory.pathLink(COMMODITY), Collections.singleton(COMMODITY)),
+            occurrence(state, PathFactory.pathLink(STATE), Collections.singleton(STATE)),
+            occurrence(status, PathFactory.pathLink(STATUS), Collections.singleton(STATUS)));
 
         IndexProfile siteProfile = new IndexProfile(
             NodeFactory.createURI(EX + "SiteShape"),
             Collections.singleton(SITE_CLASS),
             "uri", "docType",
-            Arrays.asList(entityType, title, commodity, state, status));
+            Arrays.asList(entityType, title, commodity, state, status),
+            siteOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(
             Arrays.asList(reportProfile, boreholeProfile, siteProfile));
@@ -318,6 +352,15 @@ public class TestDemoMiningScenarios {
             ResourceFactory.createResource(EX + statusId));
         m.add(report, ResourceFactory.createProperty(EX + "authoredBy"),
             ResourceFactory.createResource(EX + authorId));
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
@@ -80,34 +80,22 @@ public class TestDemoMiningScenarios {
 
         // --- Field definitions ---
         FieldDef entityType = new FieldDef("entityType", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(RDF.type.asNode()),
-            PathFactory.pathLink(RDF.type.asNode()));
+            true, true, true, false, false, false);
 
         FieldDef title = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(LABEL),
-            PathFactory.pathLink(LABEL));
+            true, true, false, false, false, true);
 
         FieldDef commodity = new FieldDef("commodity", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(COMMODITY),
-            PathFactory.pathLink(COMMODITY));
+            true, true, true, false, true, false);
 
         FieldDef state = new FieldDef("state", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(STATE),
-            PathFactory.pathLink(STATE));
+            true, true, true, false, false, false);
 
         FieldDef operator = new FieldDef("operator", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(OPERATOR),
-            PathFactory.pathLink(OPERATOR));
+            true, true, true, false, false, false);
 
         FieldDef status = new FieldDef("status", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(STATUS),
-            PathFactory.pathLink(STATUS));
+            true, true, true, false, false, false);
 
         // Sequence path: (ex:authoredBy / ex:name)
         Path authorNamePath = PathFactory.pathSeq(
@@ -117,19 +105,15 @@ public class TestDemoMiningScenarios {
         authorNamePreds.add(AUTHORED_BY);
         authorNamePreds.add(NAME);
         FieldDef authorName = new FieldDef("authorName", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            authorNamePreds, authorNamePath);
+            true, true, true, false, false, false);
 
         // Inverse path: ^ex:authored
         Path authoredByUriPath = PathFactory.pathInverse(PathFactory.pathLink(AUTHORED));
         FieldDef authoredByUri = new FieldDef("authoredByUri", FieldType.KEYWORD, null,
-            true, true, false, false, true, false,
-            Collections.singleton(AUTHORED), authoredByUriPath);
+            true, true, false, false, true, false);
 
         FieldDef depth = new FieldDef("depth", FieldType.INT, null,
-            true, true, false, true, false, false,
-            Collections.singleton(DEPTH),
-            PathFactory.pathLink(DEPTH));
+            true, true, false, true, false, false);
 
         // --- Profiles (shapes) ---
         List<FieldOccurrence> reportOccurrences = Arrays.asList(

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacets.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacets.java
@@ -32,6 +32,8 @@ import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.text.ShaclIndexMapping.*;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.query.text.cql.CqlExpression;
 import org.apache.jena.query.text.cql.CqlParser;
 import org.apache.jena.rdf.model.Model;
@@ -86,12 +88,20 @@ public class TestHierarchicalFacets {
         HierarchyDef typeHierarchy = new HierarchyDef("type_subtype",
             Arrays.asList(typeField, subtypeField));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(nameField, PathFactory.pathLink(NAME_PRED), Collections.singleton(NAME_PRED)),
+            occurrence(typeField, PathFactory.pathLink(TYPE_PRED), Collections.singleton(TYPE_PRED)),
+            occurrence(subtypeField, PathFactory.pathLink(SUBTYPE_PRED), Collections.singleton(SUBTYPE_PRED)),
+            occurrence(stateField, PathFactory.pathLink(STATE_PRED), Collections.singleton(STATE_PRED)));
+
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI(NS + "BoreholeShape"),
             Collections.singleton(BOREHOLE_CLASS),
             "uri", "docType",
             Arrays.asList(nameField, typeField, subtypeField, stateField),
-            Collections.singletonList(typeHierarchy));
+            rootOccurrences,
+            Collections.singletonList(typeHierarchy),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -291,6 +301,15 @@ public class TestHierarchicalFacets {
             uris.add(hit.getNode().getURI());
         }
         assertEquals(Set.of(NS + "bh4", NS + "bh5"), uris);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     private static Map<String, Long> toMap(List<FacetValue> facets) {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacets.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacets.java
@@ -69,20 +69,16 @@ public class TestHierarchicalFacets {
         Node stateIRI = NodeFactory.createURI(FIELD_NS + "state");
 
         FieldDef nameField = new FieldDef("name", FieldType.TEXT, null, null,
-            true, true, false, false, false, true,
-            Collections.singleton(NAME_PRED), null, nameIRI);
+            true, true, false, false, false, true, nameIRI);
 
         FieldDef typeField = new FieldDef("type", FieldType.KEYWORD, null, null,
-            true, true, true, false, false, false,
-            Collections.singleton(TYPE_PRED), null, typeIRI);
+            true, true, true, false, false, false, typeIRI);
 
         FieldDef subtypeField = new FieldDef("subtype", FieldType.KEYWORD, null, null,
-            true, true, true, false, false, false,
-            Collections.singleton(SUBTYPE_PRED), null, subtypeIRI);
+            true, true, true, false, false, false, subtypeIRI);
 
         FieldDef stateField = new FieldDef("state", FieldType.KEYWORD, null, null,
-            true, true, true, false, false, false,
-            Collections.singleton(STATE_PRED), null, stateIRI);
+            true, true, true, false, false, false, stateIRI);
 
         // Hierarchy: type → subtype
         HierarchyDef typeHierarchy = new HierarchyDef("type_subtype",
@@ -218,6 +214,32 @@ public class TestHierarchicalFacets {
         Map<String, Long> facetMap = toMap(facets);
         assertEquals("Gold count under Mineral", Long.valueOf(2), facetMap.get("Gold"));
         assertEquals("Iron count under Mineral", Long.valueOf(1), facetMap.get("Iron"));
+    }
+
+    @Test
+    public void testBlankHierarchyComponentIsTreatedAsMissing() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            addBorehole(dataset.getDefaultModel(), "bhBlank", "Blank Subtype Well", "Water", "   ", "WA");
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+
+        Map<String, List<FacetValue>> topLevelCounts = textIndex.getFacetCounts(
+            null, null, Collections.singletonList("type_subtype"), 10, 0);
+        Map<String, Long> topLevelFacetMap = toMap(topLevelCounts.get("type_subtype"));
+        assertEquals("Water count should include partial path with blank child", Long.valueOf(4), topLevelFacetMap.get("Water"));
+
+        Map<String, String[]> drillDown = new HashMap<>();
+        drillDown.put("type_subtype", new String[]{"Water"});
+        Map<String, List<FacetValue>> drillDownCounts = textIndex.getFacetCounts(
+            null, null, Collections.singletonList("type_subtype"), 10, 0, drillDown);
+        Map<String, Long> drillDownFacetMap = toMap(drillDownCounts.get("type_subtype"));
+        assertEquals("Shallow count under Water", Long.valueOf(2), drillDownFacetMap.get("Shallow"));
+        assertEquals("Deep count under Water", Long.valueOf(1), drillDownFacetMap.get("Deep"));
+        assertFalse("Blank subtype should not become a facet label", drillDownFacetMap.containsKey(""));
+        assertFalse("Whitespace subtype should not become a facet label", drillDownFacetMap.containsKey("   "));
     }
 
     @Test

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java
@@ -30,6 +30,8 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.*;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -76,12 +78,19 @@ public class TestHierarchicalFacetsSparql {
         HierarchyDef typeHierarchy = new HierarchyDef("type_subtype",
             Arrays.asList(typeField, subtypeField));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(nameField, PathFactory.pathLink(NAME_PRED), Collections.singleton(NAME_PRED)),
+            occurrence(typeField, PathFactory.pathLink(TYPE_PRED), Collections.singleton(TYPE_PRED)),
+            occurrence(subtypeField, PathFactory.pathLink(SUBTYPE_PRED), Collections.singleton(SUBTYPE_PRED)));
+
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI(NS + "BoreholeShape"),
             Collections.singleton(BOREHOLE_CLASS),
             "uri", "docType",
             Arrays.asList(nameField, typeField, subtypeField),
-            Collections.singletonList(typeHierarchy));
+            rootOccurrences,
+            Collections.singletonList(typeHierarchy),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -134,6 +143,15 @@ public class TestHierarchicalFacetsSparql {
             ResourceFactory.createPlainLiteral(type));
         model.add(bh, ResourceFactory.createProperty(NS + "subtype"),
             ResourceFactory.createPlainLiteral(subtype));
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java
@@ -64,16 +64,13 @@ public class TestHierarchicalFacetsSparql {
         Node subtypeIRI = NodeFactory.createURI(FIELD_NS + "subtype");
 
         FieldDef nameField = new FieldDef("name", FieldType.TEXT, null, null,
-            true, true, false, false, false, true,
-            Collections.singleton(NAME_PRED), null, nameIRI);
+            true, true, false, false, false, true, nameIRI);
 
         FieldDef typeField = new FieldDef("type", FieldType.KEYWORD, null, null,
-            true, true, true, false, false, false,
-            Collections.singleton(TYPE_PRED), null, typeIRI);
+            true, true, true, false, false, false, typeIRI);
 
         FieldDef subtypeField = new FieldDef("subtype", FieldType.KEYWORD, null, null,
-            true, true, true, false, false, false,
-            Collections.singleton(SUBTYPE_PRED), null, subtypeIRI);
+            true, true, true, false, false, false, subtypeIRI);
 
         HierarchyDef typeHierarchy = new HierarchyDef("type_subtype",
             Arrays.asList(typeField, subtypeField));

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNativeFacetCounts.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNativeFacetCounts.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -34,9 +35,12 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -74,11 +78,19 @@ public class TestNativeFacetCounts {
             true, true, true, false, false, false,
             Collections.singleton(AUTHOR_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(categoryField, PathFactory.pathLink(CATEGORY_PRED), Collections.singleton(CATEGORY_PRED)),
+            occurrence(authorField, PathFactory.pathLink(AUTHOR_PRED), Collections.singleton(AUTHOR_PRED)));
+
         IndexProfile docProfile = new IndexProfile(
             NodeFactory.createURI(NS + "DocShape"),
             Collections.singleton(DOC_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, authorField));
+            Arrays.asList(titleField, categoryField, authorField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(docProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -268,6 +280,15 @@ public class TestNativeFacetCounts {
         List<FacetValue> authorFacets = facets.get("author");
         assertNotNull(authorFacets);
         assertEquals("maxValues=0 should return all authors", 6, authorFacets.size());
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @Test

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNativeFacetCounts.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNativeFacetCounts.java
@@ -67,16 +67,13 @@ public class TestNativeFacetCounts {
     @Before
     public void setUp() {
         FieldDef titleField = new FieldDef("text", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, false, true, false);
 
         FieldDef authorField = new FieldDef("author", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(AUTHOR_PRED));
+            true, true, true, false, false, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNestedHierarchicalFacets.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNestedHierarchicalFacets.java
@@ -31,9 +31,11 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.HierarchyDef;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
 import org.apache.jena.query.text.ShaclIndexMapping.NestedDef;
 import org.apache.jena.query.text.analyzer.EdgeNGramAnalyzer;
 import org.apache.jena.query.text.analyzer.LowerCaseKeywordAnalyzer;
@@ -86,35 +88,23 @@ public class TestNestedHierarchicalFacets {
         Node valueTextIRI = NodeFactory.createURI(FIELD_NS + "identifierValueText");
 
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null, null,
-            true, true, false, false, false, true,
-            Collections.singleton(LABEL_PRED), PathFactory.pathLink(LABEL_PRED), titleIRI);
+            true, true, false, false, false, true, false, titleIRI);
 
         FieldDef stateField = new FieldDef("state", FieldType.KEYWORD, null, null,
-            true, true, true, false, false, false,
-            Collections.singleton(STATE_PRED), PathFactory.pathLink(STATE_PRED), stateIRI);
+            true, true, true, false, false, false, false, stateIRI);
 
         FieldDef commodityField = new FieldDef("commodity", FieldType.KEYWORD, null, null,
-            true, true, true, false, true, false,
-            Collections.singleton(COMMODITY_PRED), PathFactory.pathLink(COMMODITY_PRED), commodityIRI);
+            true, true, true, false, true, false, false, commodityIRI);
 
         FieldDef typeField = new FieldDef("identifierType", FieldType.KEYWORD, null, null,
-            true, true, true, false, true, false,
-            Collections.singleton(IDENTIFIER_TYPE_PRED),
-            PathFactory.pathLink(IDENTIFIER_TYPE_PRED), typeIRI)
-            .withNestedName(IDENTIFIER_SCOPE);
+            true, true, true, false, true, false, false, typeIRI);
 
         FieldDef valueExactField = new FieldDef("identifierValueExact", FieldType.KEYWORD, null, null,
-            true, true, true, false, true, false,
-            Collections.singleton(IDENTIFIER_VALUE_PRED),
-            PathFactory.pathLink(IDENTIFIER_VALUE_PRED), valueExactIRI)
-            .withNestedName(IDENTIFIER_SCOPE);
+            true, true, true, false, true, false, false, valueExactIRI);
 
         FieldDef valueTextField = new FieldDef("identifierValueText", FieldType.TEXT,
             new EdgeNGramAnalyzer(1, 20), new LowerCaseKeywordAnalyzer(),
-            true, true, false, false, true, false,
-            Collections.singleton(IDENTIFIER_VALUE_PRED),
-            PathFactory.pathLink(IDENTIFIER_VALUE_PRED), valueTextIRI)
-            .withNestedName(IDENTIFIER_SCOPE);
+            true, true, false, false, true, false, false, valueTextIRI);
 
         HierarchyDef stateCommodityHierarchy = new HierarchyDef(STATE_COMMODITY_DIM,
             Arrays.asList(stateField, commodityField));
@@ -122,11 +112,22 @@ public class TestNestedHierarchicalFacets {
         HierarchyDef identifierHierarchy = new HierarchyDef(IDENTIFIER_DIM,
             Arrays.asList(typeField, valueExactField));
 
+        List<FieldOccurrence> rootOccurrences = List.of(
+            rootOccurrence(titleField, LABEL_PRED),
+            rootOccurrence(stateField, STATE_PRED),
+            rootOccurrence(commodityField, COMMODITY_PRED));
+
+        List<FieldOccurrence> identifierOccurrences = List.of(
+            nestedOccurrence(typeField, IDENTIFIER_TYPE_PRED, IDENTIFIER_SCOPE),
+            nestedOccurrence(valueExactField, IDENTIFIER_VALUE_PRED, IDENTIFIER_SCOPE),
+            nestedOccurrence(valueTextField, IDENTIFIER_VALUE_PRED, IDENTIFIER_SCOPE));
+
         NestedDef identifiers = new NestedDef(
             IDENTIFIER_SCOPE,
             PathFactory.pathLink(IDENTIFIER_PRED),
+            List.of(new JoinStep(IDENTIFIER_PRED, false)),
             Collections.singleton(IDENTIFIER_PRED),
-            Arrays.asList(typeField, valueExactField, valueTextField),
+            identifierOccurrences,
             Collections.singletonList(identifierHierarchy));
 
         IndexProfile profile = new IndexProfile(
@@ -134,6 +135,7 @@ public class TestNestedHierarchicalFacets {
             Collections.singleton(BOREHOLE_CLASS),
             "uri", "docType",
             Arrays.asList(titleField, stateField, commodityField, typeField, valueExactField, valueTextField),
+            rootOccurrences,
             Collections.singletonList(stateCommodityHierarchy),
             Collections.singletonList(identifiers));
 
@@ -203,6 +205,26 @@ public class TestNestedHierarchicalFacets {
             model.add(identifier, ResourceFactory.createProperty(SCHEMA + "propertyID"), identifiers[i][0]);
             model.add(identifier, ResourceFactory.createProperty(SCHEMA + "value"), identifiers[i][1]);
         }
+    }
+
+    private static FieldOccurrence rootOccurrence(FieldDef field, Node predicate) {
+        return occurrence(field, predicate, null);
+    }
+
+    private static FieldOccurrence nestedOccurrence(FieldDef field, Node predicate, String nestedName) {
+        return occurrence(field, predicate, nestedName);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Node predicate, String nestedName) {
+        return new FieldOccurrence(
+            field,
+            PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null,
+            null,
+            null,
+            nestedName);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNestedHierarchicalFacets.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNestedHierarchicalFacets.java
@@ -261,6 +261,39 @@ public class TestNestedHierarchicalFacets {
     }
 
     @Test
+    public void testBlankNestedHierarchyComponentIsTreatedAsMissing() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            addBorehole(dataset.getDefaultModel(), "bhBlank", "Delta Bore",
+                "WA", new String[] {"Gold"},
+                new String[][] {
+                    {"Company", "   "},
+                    {"HoleNumber", "4444"}
+                });
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+
+        Map<String, List<FacetValue>> topLevelCounts = textIndex.getFacetCounts(
+            null, null, Collections.singletonList(IDENTIFIER_DIM), 10, 0);
+        Map<String, Long> topLevelValues = toFacetMap(topLevelCounts.get(IDENTIFIER_DIM));
+        assertEquals(Long.valueOf(4), topLevelValues.get("Company"));
+        assertEquals(Long.valueOf(4), topLevelValues.get("HoleNumber"));
+
+        Map<String, String[]> drillDown = new HashMap<>();
+        drillDown.put(IDENTIFIER_DIM, new String[] {"Company"});
+        Map<String, List<FacetValue>> drillDownCounts = textIndex.getFacetCounts(
+            null, null, Collections.singletonList(IDENTIFIER_DIM), 10, 0, drillDown);
+        Map<String, Long> drillDownValues = toFacetMap(drillDownCounts.get(IDENTIFIER_DIM));
+        assertEquals(Long.valueOf(1), drillDownValues.get("Acme"));
+        assertEquals(Long.valueOf(1), drillDownValues.get("8412"));
+        assertEquals(Long.valueOf(1), drillDownValues.get("Rio"));
+        assertFalse(drillDownValues.containsKey(""));
+        assertFalse(drillDownValues.containsKey("   "));
+    }
+
+    @Test
     public void testExactHierarchyFiltersUseCorrelatedPathQuery() {
         CqlExpression cql = CqlParser.parse("""
             {"op":"and","args":[

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNestedJoinPathSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNestedJoinPathSupport.java
@@ -35,6 +35,7 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.HierarchyDef;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
@@ -219,20 +220,20 @@ public class TestNestedJoinPathSupport {
         Node valueExactIRI = NodeFactory.createURI(FIELD_NS + "identifierValueExact");
 
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null, null,
-            true, true, false, false, false, true,
-            Collections.singleton(LABEL_PRED), PathFactory.pathLink(LABEL_PRED), titleIRI);
+            true, true, false, false, false, true, false, titleIRI);
 
         FieldDef typeField = new FieldDef("identifierType", FieldType.KEYWORD, null, null,
-            true, true, true, false, true, false,
-            Collections.singleton(IDENTIFIER_TYPE_PRED),
-            PathFactory.pathLink(IDENTIFIER_TYPE_PRED), typeIRI)
-            .withNestedName(joinPath.toString());
+            true, true, true, false, true, false, false, typeIRI);
 
         FieldDef valueExactField = new FieldDef("identifierValueExact", FieldType.KEYWORD, null, null,
-            true, true, true, false, true, false,
-            Collections.singleton(IDENTIFIER_VALUE_PRED),
-            PathFactory.pathLink(IDENTIFIER_VALUE_PRED), valueExactIRI)
-            .withNestedName(joinPath.toString());
+            true, true, true, false, true, false, false, valueExactIRI);
+
+        List<FieldOccurrence> rootOccurrences = Collections.singletonList(
+            occurrence(titleField, LABEL_PRED, null));
+
+        List<FieldOccurrence> nestedOccurrences = Arrays.asList(
+            occurrence(typeField, IDENTIFIER_TYPE_PRED, joinPath.toString()),
+            occurrence(valueExactField, IDENTIFIER_VALUE_PRED, joinPath.toString()));
 
         HierarchyDef identifierHierarchy = new HierarchyDef(IDENTIFIER_DIM, Arrays.asList(typeField, valueExactField));
         NestedDef nestedDef = new NestedDef(
@@ -240,7 +241,7 @@ public class TestNestedJoinPathSupport {
             joinPath,
             joinSteps,
             collectJoinPredicates(joinSteps),
-            Arrays.asList(typeField, valueExactField),
+            nestedOccurrences,
             Collections.singletonList(identifierHierarchy));
 
         IndexProfile profile = new IndexProfile(
@@ -248,6 +249,7 @@ public class TestNestedJoinPathSupport {
             Collections.singleton(BOREHOLE_CLASS),
             "uri", "docType",
             Arrays.asList(titleField, typeField, valueExactField),
+            rootOccurrences,
             Collections.emptyList(),
             Collections.singletonList(nestedDef));
 
@@ -288,6 +290,18 @@ public class TestNestedJoinPathSupport {
             predicates.add(joinStep.getPredicate());
         }
         return predicates;
+    }
+
+    private FieldOccurrence occurrence(FieldDef field, Node predicate, String nestedName) {
+        return new FieldOccurrence(
+            field,
+            PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null,
+            null,
+            null,
+            nestedName);
     }
 
     private static final class Harness implements AutoCloseable {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
@@ -29,9 +29,12 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -96,11 +99,18 @@ public class TestPerFieldQueryAnalyzer {
             true, true, false, false, false, false,
             Collections.singleton(LABEL_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(identifierField, PathFactory.pathLink(IDENTIFIER_PRED), Collections.singleton(IDENTIFIER_PRED)),
+            occurrence(labelField, PathFactory.pathLink(LABEL_PRED), Collections.singleton(LABEL_PRED)));
+
         IndexProfile specimenProfile = new IndexProfile(
             NodeFactory.createURI(NS + "SpecimenShape"),
             Collections.singleton(SPECIMEN_CLASS),
             "uri", "docType",
-            Arrays.asList(identifierField, labelField));
+            Arrays.asList(identifierField, labelField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(specimenProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -140,6 +150,15 @@ public class TestPerFieldQueryAnalyzer {
         model.add(specimen, RDF.type, ResourceFactory.createResource(NS + "Specimen"));
         model.add(specimen, ResourceFactory.createProperty(NS + "identifier"), identifier);
         model.add(specimen, ResourceFactory.createProperty(NS + "label"), label);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After
@@ -271,11 +290,17 @@ public class TestPerFieldQueryAnalyzer {
             true, true, false, false, false, true,
             Collections.singleton(IDENTIFIER_PRED), null, null);
 
+        List<FieldOccurrence> profileOccurrences = Collections.singletonList(
+            occurrence(idField, PathFactory.pathLink(IDENTIFIER_PRED), Collections.singleton(IDENTIFIER_PRED)));
+
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI(NS + "TestShape"),
             Collections.singleton(SPECIMEN_CLASS),
             "uri", "docType",
-            Collections.singletonList(idField));
+            Collections.singletonList(idField),
+            profileOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
@@ -92,12 +92,10 @@ public class TestPerFieldQueryAnalyzer {
     public void setUp() {
         FieldDef identifierField = new FieldDef("identifier", FieldType.TEXT,
             edgeNgramIndexAnalyzer(), lowercaseKeywordAnalyzer(),
-            true, true, false, false, false, true,
-            Collections.singleton(IDENTIFIER_PRED), null, null);
+            true, true, false, false, false, true);
 
         FieldDef labelField = new FieldDef("label", FieldType.TEXT, null,
-            true, true, false, false, false, false,
-            Collections.singleton(LABEL_PRED));
+            true, true, false, false, false, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(identifierField, PathFactory.pathLink(IDENTIFIER_PRED), Collections.singleton(IDENTIFIER_PRED)),
@@ -275,8 +273,7 @@ public class TestPerFieldQueryAnalyzer {
         // the system falls back to using the index analyzer for queries.
         FieldDef noOverride = new FieldDef("test", FieldType.TEXT,
             edgeNgramIndexAnalyzer(),
-            true, true, false, false, false, false,
-            Collections.singleton(LABEL_PRED));
+            true, true, false, false, false, false);
         assertNull("queryAnalyzer should be null when not set", noOverride.getQueryAnalyzer());
         assertNotNull("index analyzer should be present", noOverride.getAnalyzer());
     }
@@ -287,8 +284,7 @@ public class TestPerFieldQueryAnalyzer {
         // from FieldDef into EntityDefinition
         FieldDef idField = new FieldDef("identifier", FieldType.TEXT,
             edgeNgramIndexAnalyzer(), lowercaseKeywordAnalyzer(),
-            true, true, false, false, false, true,
-            Collections.singleton(IDENTIFIER_PRED), null, null);
+            true, true, false, false, false, true);
 
         List<FieldOccurrence> profileOccurrences = Collections.singletonList(
             occurrence(idField, PathFactory.pathLink(IDENTIFIER_PRED), Collections.singleton(IDENTIFIER_PRED)));

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -34,9 +35,12 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -57,24 +61,38 @@ public class TestRangeFacetCounts {
     public void setUp() {
         TextQuery.init();
 
+        Node titlePred = NodeFactory.createURI(NS + "title");
+        Node yearPred = NodeFactory.createURI(NS + "year");
+        Node eventTimePred = NodeFactory.createURI(NS + "eventTime");
+        Node scorePred = NodeFactory.createURI(NS + "score");
+
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
             true, true, false, false, false, true,
-            Collections.singleton(NodeFactory.createURI(NS + "title")));
+            Collections.singleton(titlePred));
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
             true, true, true, true, true, false,
-            Collections.singleton(NodeFactory.createURI(NS + "year")));
+            Collections.singleton(yearPred));
         FieldDef eventTimeField = new FieldDef("eventTime", FieldType.LONG, null,
             true, true, true, true, false, false,
-            Collections.singleton(NodeFactory.createURI(NS + "eventTime")));
+            Collections.singleton(eventTimePred));
         FieldDef scoreField = new FieldDef("score", FieldType.DOUBLE, null,
             true, true, true, true, false, false,
-            Collections.singleton(NodeFactory.createURI(NS + "score")));
+            Collections.singleton(scorePred));
+
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(titlePred), Collections.singleton(titlePred)),
+            occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred)),
+            occurrence(eventTimeField, PathFactory.pathLink(eventTimePred), Collections.singleton(eventTimePred)),
+            occurrence(scoreField, PathFactory.pathLink(scorePred), Collections.singleton(scorePred)));
 
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI(NS + "ThingShape"),
             Collections.singleton(NodeFactory.createURI(NS + "Thing")),
             "uri", "docType",
-            Arrays.asList(titleField, yearField, eventTimeField, scoreField));
+            Arrays.asList(titleField, yearField, eventTimeField, scoreField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -116,6 +134,15 @@ public class TestRangeFacetCounts {
         }
         model.add(thing, ResourceFactory.createProperty(NS + "eventTime"), ResourceFactory.createTypedLiteral(eventTime));
         model.add(thing, ResourceFactory.createProperty(NS + "score"), ResourceFactory.createTypedLiteral(score));
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java
@@ -67,17 +67,13 @@ public class TestRangeFacetCounts {
         Node scorePred = NodeFactory.createURI(NS + "score");
 
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(titlePred));
+            true, true, false, false, false, true);
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, true, true, true, false,
-            Collections.singleton(yearPred));
+            true, true, true, true, true, false);
         FieldDef eventTimeField = new FieldDef("eventTime", FieldType.LONG, null,
-            true, true, true, true, false, false,
-            Collections.singleton(eventTimePred));
+            true, true, true, true, false, false);
         FieldDef scoreField = new FieldDef("score", FieldType.DOUBLE, null,
-            true, true, true, true, false, false,
-            Collections.singleton(scorePred));
+            true, true, true, true, false, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(titlePred), Collections.singleton(titlePred)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclBulkIndexer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclBulkIndexer.java
@@ -69,16 +69,13 @@ public class TestShaclBulkIndexer {
     public void setUp() {
         // Book profile
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, false, true, false);
 
         FieldDef authorField = new FieldDef("author", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(AUTHOR_PRED));
+            true, true, true, false, false, false);
 
         List<FieldOccurrence> bookOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
@@ -96,12 +93,10 @@ public class TestShaclBulkIndexer {
 
         // Article profile (different shape, shared title field)
         FieldDef articleTitleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef topicField = new FieldDef("topic", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(TOPIC_PRED));
+            true, true, true, false, false, false);
 
         List<FieldOccurrence> articleOccurrences = Arrays.asList(
             occurrence(articleTitleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclBulkIndexer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclBulkIndexer.java
@@ -29,9 +29,12 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -77,11 +80,19 @@ public class TestShaclBulkIndexer {
             true, true, true, false, false, false,
             Collections.singleton(AUTHOR_PRED));
 
+        List<FieldOccurrence> bookOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(categoryField, PathFactory.pathLink(CATEGORY_PRED), Collections.singleton(CATEGORY_PRED)),
+            occurrence(authorField, PathFactory.pathLink(AUTHOR_PRED), Collections.singleton(AUTHOR_PRED)));
+
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, authorField));
+            Arrays.asList(titleField, categoryField, authorField),
+            bookOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         // Article profile (different shape, shared title field)
         FieldDef articleTitleField = new FieldDef("title", FieldType.TEXT, null,
@@ -92,11 +103,18 @@ public class TestShaclBulkIndexer {
             true, true, true, false, false, false,
             Collections.singleton(TOPIC_PRED));
 
+        List<FieldOccurrence> articleOccurrences = Arrays.asList(
+            occurrence(articleTitleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(topicField, PathFactory.pathLink(TOPIC_PRED), Collections.singleton(TOPIC_PRED)));
+
         IndexProfile articleProfile = new IndexProfile(
             NodeFactory.createURI(NS + "ArticleShape"),
             Collections.singleton(ARTICLE_CLASS),
             "uri", "docType",
-            Arrays.asList(articleTitleField, topicField));
+            Arrays.asList(articleTitleField, topicField),
+            articleOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         mapping = new ShaclIndexMapping(Arrays.asList(bookProfile, articleProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -111,6 +129,15 @@ public class TestShaclBulkIndexer {
 
         // Create a plain dataset — NO text wrapper, simulating bulk load
         baseDataset = DatasetFactory.create();
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclDocumentBuilding.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclDocumentBuilding.java
@@ -28,8 +28,12 @@ import java.util.*;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.store.ByteBuffersDirectory;
@@ -76,11 +80,21 @@ public class TestShaclDocumentBuilding {
             true, true, false, true, false, false,
             Collections.singleton(RATING_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(categoryField, PathFactory.pathLink(CATEGORY_PRED), Collections.singleton(CATEGORY_PRED)),
+            occurrence(yearField, PathFactory.pathLink(YEAR_PRED), Collections.singleton(YEAR_PRED)),
+            occurrence(pagesField, PathFactory.pathLink(PAGES_PRED), Collections.singleton(PAGES_PRED)),
+            occurrence(ratingField, PathFactory.pathLink(RATING_PRED), Collections.singleton(RATING_PRED)));
+
         testProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, yearField, pagesField, ratingField));
+            Arrays.asList(titleField, categoryField, yearField, pagesField, ratingField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(testProfile));
 
@@ -95,6 +109,15 @@ public class TestShaclDocumentBuilding {
         config.setFacetFields(Collections.singletonList("category"));
 
         textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After
@@ -208,11 +231,16 @@ public class TestShaclDocumentBuilding {
         FieldDef multiTitleField = new FieldDef("title", FieldType.TEXT, null,
             true, true, false, false, true, true,
             Collections.singleton(TITLE_PRED));
+        List<FieldOccurrence> multiRootOccurrences = Collections.singletonList(
+            occurrence(multiTitleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)));
         IndexProfile multiValueProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShapeMulti"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Collections.singletonList(multiTitleField));
+            Collections.singletonList(multiTitleField),
+            multiRootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         Entity entity = new Entity("http://example.org/book1", null);
         entity.addValue("title", "First Title");

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclDocumentBuilding.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclDocumentBuilding.java
@@ -61,24 +61,19 @@ public class TestShaclDocumentBuilding {
     @Before
     public void setUp() {
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, true, false, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, true, false, false);
 
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, false, true, false, false,
-            Collections.singleton(YEAR_PRED));
+            true, true, false, true, false, false);
 
         FieldDef pagesField = new FieldDef("pages", FieldType.LONG, null,
-            true, true, false, false, false, false,
-            Collections.singleton(PAGES_PRED));
+            true, true, false, false, false, false);
 
         FieldDef ratingField = new FieldDef("rating", FieldType.DOUBLE, null,
-            true, true, false, true, false, false,
-            Collections.singleton(RATING_PRED));
+            true, true, false, true, false, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
@@ -229,8 +224,7 @@ public class TestShaclDocumentBuilding {
     @Test
     public void testMultiValuedField() {
         FieldDef multiTitleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, true, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, true, true);
         List<FieldOccurrence> multiRootOccurrences = Collections.singletonList(
             occurrence(multiTitleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)));
         IndexProfile multiValueProfile = new IndexProfile(

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
@@ -29,12 +29,15 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.junit.After;
@@ -70,11 +73,19 @@ public class TestShaclEntityPerDocument {
             true, true, true, false, false, false,
             Collections.singleton(AUTHOR_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, TITLE_PRED),
+            occurrence(categoryField, CATEGORY_PRED),
+            occurrence(authorField, AUTHOR_PRED));
+
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, authorField));
+            Arrays.asList(titleField, categoryField, authorField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -119,6 +130,18 @@ public class TestShaclEntityPerDocument {
         model.add(book, ResourceFactory.createProperty(NS + "title"), title);
         model.add(book, ResourceFactory.createProperty(NS + "category"), category);
         model.add(book, ResourceFactory.createProperty(NS + "author"), author);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Node predicate) {
+        return new FieldOccurrence(
+            field,
+            PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null,
+            null,
+            null,
+            null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
@@ -62,16 +62,13 @@ public class TestShaclEntityPerDocument {
     @Before
     public void setUp() {
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, false, true, false);
 
         FieldDef authorField = new FieldDef("author", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(AUTHOR_PRED));
+            true, true, true, false, false, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, TITLE_PRED),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclIndexMapping.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclIndexMapping.java
@@ -148,7 +148,8 @@ public class TestShaclIndexMapping {
             NodeFactory.createURI(NS + "TestShape"),
             Collections.singleton(BOOK_CLASS),
             null, null,
-            Collections.singletonList(field));
+            Collections.singletonList(field),
+            Collections.singletonList(occurrence(field, TITLE_PRED)));
 
         assertEquals("uri", profile.getDocIdField());
         assertEquals("docType", profile.getDiscriminatorField());
@@ -215,6 +216,48 @@ public class TestShaclIndexMapping {
             Collections.emptyList());
 
         new ShaclIndexMapping(Arrays.asList(p1, p2));
+    }
+
+    @Test(expected = TextIndexException.class)
+    public void testRootHierarchyCannotReferenceNestedOnlyField() {
+        FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, false, true,
+            NodeFactory.createURI(NS + "titleField"));
+        FieldDef nestedOnlyField = new FieldDef("identifierType", FieldType.KEYWORD, null,
+            true, true, true, false, false, false,
+            NodeFactory.createURI(NS + "identifierTypeField"));
+
+        FieldOccurrence rootTitle = occurrence(titleField, TITLE_PRED);
+        FieldOccurrence nestedOccurrence = new FieldOccurrence(
+            nestedOnlyField,
+            PathFactory.pathLink(CATEGORY_PRED),
+            List.of(List.of(new JoinStep(CATEGORY_PRED, false))),
+            Collections.singleton(CATEGORY_PRED),
+            null,
+            null,
+            null,
+            "nested");
+        NestedDef nestedDef = new NestedDef(
+            "nested",
+            PathFactory.pathLink(LABEL_PRED),
+            List.of(new JoinStep(LABEL_PRED, false)),
+            Collections.singleton(LABEL_PRED),
+            Collections.singletonList(nestedOccurrence),
+            Collections.emptyList());
+        HierarchyDef invalidHierarchy = new HierarchyDef(
+            "title_identifierType",
+            Arrays.asList(titleField, nestedOnlyField));
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + "Shape"),
+            Collections.singleton(BOOK_CLASS),
+            "uri", "docType",
+            Arrays.asList(titleField, nestedOnlyField),
+            Collections.singletonList(rootTitle),
+            Collections.singletonList(invalidHierarchy),
+            Collections.singletonList(nestedDef));
+
+        new ShaclIndexMapping(Collections.singletonList(profile));
     }
 
     private static FieldOccurrence occurrence(FieldDef field, Node predicate) {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclIndexMapping.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclIndexMapping.java
@@ -28,10 +28,11 @@ import java.util.*;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.text.ShaclIndexMapping.*;
+import org.apache.jena.sparql.path.PathFactory;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link ShaclIndexMapping} — predicate/class lookups, field types.
+ * Unit tests for {@link ShaclIndexMapping}.
  */
 public class TestShaclIndexMapping {
 
@@ -46,33 +47,37 @@ public class TestShaclIndexMapping {
 
     private ShaclIndexMapping createTestMapping() {
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            new LinkedHashSet<>(Arrays.asList(TITLE_PRED, LABEL_PRED)));
-
+            true, true, false, false, false, true);
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
-
+            true, true, true, false, true, false);
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, false, true, false, false,
-            Collections.singleton(YEAR_PRED));
+            true, true, false, true, false, false);
 
+        List<FieldOccurrence> bookOccurrences = List.of(
+            occurrence(titleField, TITLE_PRED),
+            occurrence(titleField, LABEL_PRED),
+            occurrence(categoryField, CATEGORY_PRED),
+            occurrence(yearField, YEAR_PRED)
+        );
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, yearField));
+            Arrays.asList(titleField, categoryField, yearField),
+            bookOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
-        // Second profile — Article has title only
         FieldDef articleTitle = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
-
+            true, true, false, false, false, true);
         IndexProfile articleProfile = new IndexProfile(
             NodeFactory.createURI(NS + "ArticleShape"),
             Collections.singleton(ARTICLE_CLASS),
             "uri", "docType",
-            Collections.singletonList(articleTitle));
+            Collections.singletonList(articleTitle),
+            Collections.singletonList(occurrence(articleTitle, TITLE_PRED)),
+            Collections.emptyList(),
+            Collections.emptyList());
 
         return new ShaclIndexMapping(Arrays.asList(bookProfile, articleProfile));
     }
@@ -89,43 +94,35 @@ public class TestShaclIndexMapping {
     }
 
     @Test
-    public void testPredicateReturnsCorrectProfiles() {
+    public void testPredicateReturnsCorrectOccurrences() {
         ShaclIndexMapping mapping = createTestMapping();
 
-        // TITLE_PRED should match both Book and Article profiles
-        List<ProfileField> titleMatches = mapping.getProfilesForPredicate(TITLE_PRED);
+        List<ProfileOccurrence> titleMatches = mapping.getOccurrencesForPredicate(TITLE_PRED);
         assertEquals(2, titleMatches.size());
 
-        // LABEL_PRED should match only Book profile (via alternativePath)
-        List<ProfileField> labelMatches = mapping.getProfilesForPredicate(LABEL_PRED);
+        List<ProfileOccurrence> labelMatches = mapping.getOccurrencesForPredicate(LABEL_PRED);
         assertEquals(1, labelMatches.size());
-        assertEquals("title", labelMatches.get(0).getField().getFieldName());
+        assertEquals("title", labelMatches.get(0).getOccurrence().getField().getFieldName());
 
-        // CATEGORY_PRED should match only Book
-        List<ProfileField> catMatches = mapping.getProfilesForPredicate(CATEGORY_PRED);
+        List<ProfileOccurrence> catMatches = mapping.getOccurrencesForPredicate(CATEGORY_PRED);
         assertEquals(1, catMatches.size());
-        assertEquals("category", catMatches.get(0).getField().getFieldName());
+        assertEquals("category", catMatches.get(0).getOccurrence().getField().getFieldName());
     }
 
     @Test
     public void testClassLookup() {
         ShaclIndexMapping mapping = createTestMapping();
 
-        List<IndexProfile> bookProfiles = mapping.getProfilesForClass(BOOK_CLASS);
-        assertEquals(1, bookProfiles.size());
-
-        List<IndexProfile> articleProfiles = mapping.getProfilesForClass(ARTICLE_CLASS);
-        assertEquals(1, articleProfiles.size());
-
-        List<IndexProfile> unknownProfiles = mapping.getProfilesForClass(IRRELEVANT_PRED);
-        assertTrue(unknownProfiles.isEmpty());
+        assertEquals(1, mapping.getProfilesForClass(BOOK_CLASS).size());
+        assertEquals(1, mapping.getProfilesForClass(ARTICLE_CLASS).size());
+        assertTrue(mapping.getProfilesForClass(IRRELEVANT_PRED).isEmpty());
     }
 
     @Test
     public void testIrrelevantPredicateReturnsEmpty() {
         ShaclIndexMapping mapping = createTestMapping();
 
-        List<ProfileField> results = mapping.getProfilesForPredicate(IRRELEVANT_PRED);
+        List<ProfileOccurrence> results = mapping.getOccurrencesForPredicate(IRRELEVANT_PRED);
         assertNotNull(results);
         assertTrue(results.isEmpty());
     }
@@ -133,26 +130,20 @@ public class TestShaclIndexMapping {
     @Test
     public void testGetFacetFieldNames() {
         ShaclIndexMapping mapping = createTestMapping();
-
-        List<String> facetFields = mapping.getFacetFieldNames();
-        assertEquals(1, facetFields.size());
-        assertTrue(facetFields.contains("category"));
+        assertEquals(List.of("category"), mapping.getFacetFieldNames());
     }
 
     @Test
     public void testFieldDefDefaults() {
-        // Test default field type
         FieldDef field = new FieldDef("test", null, null,
-            true, true, false, false, false, false,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, false);
         assertEquals(FieldType.TEXT, field.getFieldType());
     }
 
     @Test
     public void testProfileDefaults() {
         FieldDef field = new FieldDef("test", FieldType.TEXT, null,
-            true, true, false, false, false, false,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, false);
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI(NS + "TestShape"),
             Collections.singleton(BOOK_CLASS),
@@ -165,21 +156,18 @@ public class TestShaclIndexMapping {
 
     @Test
     public void testProfileCount() {
-        ShaclIndexMapping mapping = createTestMapping();
-        assertEquals(2, mapping.getProfiles().size());
+        assertEquals(2, createTestMapping().getProfiles().size());
     }
 
     @Test
     public void testGetDefaultSearchFieldNames() {
-        ShaclIndexMapping mapping = createTestMapping();
-        List<String> defaults = mapping.getDefaultSearchFieldNames();
-        assertTrue("title should be a default search field", defaults.contains("title"));
+        List<String> defaults = createTestMapping().getDefaultSearchFieldNames();
+        assertTrue(defaults.contains("title"));
     }
 
     @Test
     public void testFieldIRIAutoGenerated() {
-        ShaclIndexMapping mapping = createTestMapping();
-        FieldDef titleField = mapping.findField("urn:jena:lucene:field#title");
+        FieldDef titleField = createTestMapping().findField("urn:jena:lucene:field#title");
         assertNotNull(titleField.getFieldIRI());
         assertTrue(titleField.getFieldIRI().isURI());
         assertEquals("urn:jena:lucene:field#title", titleField.getFieldIRI().getURI());
@@ -188,16 +176,14 @@ public class TestShaclIndexMapping {
     @Test
     public void testFieldIRIExplicit() {
         Node customIRI = NodeFactory.createURI(NS + "myCustomField");
-        FieldDef field = new FieldDef("test", FieldType.TEXT, null,
-            true, true, false, false, false, false,
-            Collections.singleton(TITLE_PRED), null, customIRI);
+        FieldDef field = new FieldDef("test", FieldType.TEXT, null, null,
+            true, true, false, false, false, false, false, customIRI);
         assertEquals(customIRI, field.getFieldIRI());
     }
 
     @Test
     public void testGetAllFieldNames() {
-        ShaclIndexMapping mapping = createTestMapping();
-        Set<String> all = mapping.getAllFieldNames();
+        Set<String> all = createTestMapping().getAllFieldNames();
         assertTrue(all.contains("title"));
         assertTrue(all.contains("category"));
         assertTrue(all.contains("year"));
@@ -205,25 +191,41 @@ public class TestShaclIndexMapping {
 
     @Test(expected = TextIndexException.class)
     public void testConflictingFieldTypes() {
-        // Same field name with different types should throw
         FieldDef textTitle = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
+        FieldDef keywordTitle = new FieldDef("title", FieldType.KEYWORD, null,
+            true, true, false, false, false, true);
+
         IndexProfile p1 = new IndexProfile(
             NodeFactory.createURI(NS + "Shape1"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Collections.singletonList(textTitle));
+            Collections.singletonList(textTitle),
+            Collections.singletonList(occurrence(textTitle, TITLE_PRED)),
+            Collections.emptyList(),
+            Collections.emptyList());
 
-        FieldDef keywordTitle = new FieldDef("title", FieldType.KEYWORD, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
         IndexProfile p2 = new IndexProfile(
             NodeFactory.createURI(NS + "Shape2"),
             Collections.singleton(ARTICLE_CLASS),
             "uri", "docType",
-            Collections.singletonList(keywordTitle));
+            Collections.singletonList(keywordTitle),
+            Collections.singletonList(occurrence(keywordTitle, TITLE_PRED)),
+            Collections.emptyList(),
+            Collections.emptyList());
 
         new ShaclIndexMapping(Arrays.asList(p1, p2));
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Node predicate) {
+        return new FieldOccurrence(
+            field,
+            PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null,
+            null,
+            null,
+            null);
     }
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -37,9 +39,12 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -66,11 +71,17 @@ public class TestShaclLucQueryRawValueOnMultiValuedField {
             true, true, false, false, true, false,
             Collections.singleton(IDENTIFIER_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(identifierField, PathFactory.pathLink(IDENTIFIER_PRED), Collections.singleton(IDENTIFIER_PRED)));
+
         IndexProfile recordProfile = new IndexProfile(
             NodeFactory.createURI(NS + "RecordShape"),
             Collections.singleton(RECORD_CLASS),
             "uri", "docType",
-            Arrays.asList(identifierField));
+            Arrays.asList(identifierField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(recordProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -101,6 +112,15 @@ public class TestShaclLucQueryRawValueOnMultiValuedField {
         } finally {
             dataset.end();
         }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
@@ -68,8 +68,7 @@ public class TestShaclLucQueryRawValueOnMultiValuedField {
         TextQuery.init();
 
         FieldDef identifierField = new FieldDef("identifier", FieldType.KEYWORD, null,
-            true, true, false, false, true, false,
-            Collections.singleton(IDENTIFIER_PRED));
+            true, true, false, false, true, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(identifierField, PathFactory.pathLink(IDENTIFIER_PRED), Collections.singleton(IDENTIFIER_PRED)));

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
@@ -29,8 +29,10 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
@@ -103,11 +105,20 @@ public class TestShaclPathSupport {
             true, true, false, false, true, false,
             wroteByPreds, wroteByPath);
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(LABEL_PRED), Collections.singleton(LABEL_PRED)),
+            occurrence(categoryField, PathFactory.pathLink(CATEGORY_PRED), Collections.singleton(CATEGORY_PRED)),
+            occurrence(authorNameField, authorNamePath, authorNamePreds),
+            occurrence(wroteByField, wroteByPath, wroteByPreds));
+
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, authorNameField, wroteByField));
+            Arrays.asList(titleField, categoryField, authorNameField, wroteByField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -180,6 +191,18 @@ public class TestShaclPathSupport {
         if (dataset != null) {
             dataset.close();
         }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null,
+            null,
+            null,
+            null);
     }
 
     // --- Sequence path tests ---

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
@@ -77,15 +77,11 @@ public class TestShaclPathSupport {
     public void setUp() {
         // title: direct predicate (rdfs:label)
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(LABEL_PRED),
-            PathFactory.pathLink(LABEL_PRED));
+            true, true, false, false, false, true);
 
         // category: direct predicate (keyword, facetable)
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(CATEGORY_PRED),
-            PathFactory.pathLink(CATEGORY_PRED));
+            true, true, true, false, false, false);
 
         // authorName: sequence path (ex:author / ex:name)
         Path authorNamePath = PathFactory.pathSeq(
@@ -95,15 +91,13 @@ public class TestShaclPathSupport {
         authorNamePreds.add(AUTHOR_PRED);
         authorNamePreds.add(NAME_PRED);
         FieldDef authorNameField = new FieldDef("authorName", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            authorNamePreds, authorNamePath);
+            true, true, true, false, false, false);
 
         // wroteBy: inverse path (^ex:wrote) — indexes who wrote this book
         Path wroteByPath = PathFactory.pathInverse(PathFactory.pathLink(WROTE_PRED));
         Set<Node> wroteByPreds = Collections.singleton(WROTE_PRED);
         FieldDef wroteByField = new FieldDef("wroteBy", FieldType.KEYWORD, null,
-            true, true, false, false, true, false,
-            wroteByPreds, wroteByPath);
+            true, true, false, false, true, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(LABEL_PRED), Collections.singleton(LABEL_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclTextDocProducer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclTextDocProducer.java
@@ -60,12 +60,10 @@ public class TestShaclTextDocProducer {
     @Before
     public void setUp() {
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, false, true, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, TITLE_PRED),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclTextDocProducer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclTextDocProducer.java
@@ -35,6 +35,7 @@ import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.junit.After;
@@ -66,11 +67,18 @@ public class TestShaclTextDocProducer {
             true, true, true, false, true, false,
             Collections.singleton(CATEGORY_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, TITLE_PRED),
+            occurrence(categoryField, CATEGORY_PRED));
+
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField));
+            Arrays.asList(titleField, categoryField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -95,6 +103,18 @@ public class TestShaclTextDocProducer {
         if (dataset != null) {
             dataset.close();
         }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Node predicate) {
+        return new FieldOccurrence(
+            field,
+            PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null,
+            null,
+            null,
+            null);
     }
 
     @Test

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSharedFieldOccurrences.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSharedFieldOccurrences.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.query.text.cql.CqlExpression;
+import org.apache.jena.query.text.cql.CqlParser;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.Test;
+
+public class TestSharedFieldOccurrences {
+
+    private static final String NS = "http://example.org/";
+    private static final String FIELD_NS = "urn:jena:lucene:field#";
+
+    private static final Node SURVEY_CLASS = NodeFactory.createURI(NS + "Survey");
+    private static final Node WELL_CLASS = NodeFactory.createURI(NS + "Well");
+    private static final Node SAMPLE_CLASS = NodeFactory.createURI(NS + "Sample");
+    private static final Node BOREHOLE_CLASS = NodeFactory.createURI(NS + "Borehole");
+
+    private static final Node ABOUT_PRED = NodeFactory.createURI(NS + "about");
+    private static final Node PARENT_PRED = NodeFactory.createURI(NS + "parent");
+    private static final Node VALUE_PRED = NodeFactory.createURI(NS + "value");
+
+    @Test
+    public void testSharedCanonicalFieldFansInAcrossProfiles() {
+        FieldDef hasParent = new FieldDef("hasParent", FieldType.KEYWORD, null, null,
+            true, true, false, false, true, false, false,
+            NodeFactory.createURI(FIELD_NS + "hasParent"));
+
+        IndexProfile surveyProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "SurveyShape"),
+            Collections.singleton(SURVEY_CLASS),
+            "uri", "docType",
+            Collections.singletonList(hasParent),
+            Collections.singletonList(occurrence(hasParent,
+                PathFactory.pathInverse(PathFactory.pathLink(ABOUT_PRED)),
+                Collections.singleton(ABOUT_PRED), null, null, null)),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        IndexProfile wellProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "WellShape"),
+            Collections.singleton(WELL_CLASS),
+            "uri", "docType",
+            Collections.singletonList(hasParent),
+            Collections.singletonList(occurrence(hasParent,
+                PathFactory.pathLink(PARENT_PRED),
+                Collections.singleton(PARENT_PRED), null, null, null)),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        try (Harness harness = createHarness(Arrays.asList(surveyProfile, wellProfile))) {
+            harness.dataset.begin(ReadWrite.WRITE);
+            try {
+                Model model = harness.dataset.getDefaultModel();
+                Resource survey = ResourceFactory.createResource(NS + "survey1");
+                Resource well = ResourceFactory.createResource(NS + "well1");
+                Resource borehole = ResourceFactory.createResource(NS + "bh1");
+
+                model.add(survey, RDF.type, ResourceFactory.createResource(SURVEY_CLASS.getURI()));
+                model.add(well, RDF.type, ResourceFactory.createResource(WELL_CLASS.getURI()));
+                model.add(borehole, ResourceFactory.createProperty(ABOUT_PRED.getURI()), survey);
+                model.add(well, ResourceFactory.createProperty(PARENT_PRED.getURI()), borehole);
+                harness.dataset.commit();
+            } finally {
+                harness.dataset.end();
+            }
+
+            assertEquals(Set.of(NS + "survey1", NS + "well1"),
+                queryByFieldValue(harness.textIndex, FIELD_NS + "hasParent", NS + "bh1"));
+        }
+    }
+
+    @Test
+    public void testClassConstraintFiltersReachedNodes() {
+        FieldDef hasParent = new FieldDef("hasParent", FieldType.KEYWORD, null, null,
+            true, true, false, false, true, false, false,
+            NodeFactory.createURI(FIELD_NS + "hasParent"));
+
+        IndexProfile surveyProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "SurveyShape"),
+            Collections.singleton(SURVEY_CLASS),
+            "uri", "docType",
+            Collections.singletonList(hasParent),
+            Collections.singletonList(occurrence(hasParent,
+                PathFactory.pathInverse(PathFactory.pathLink(ABOUT_PRED)),
+                Collections.singleton(ABOUT_PRED), BOREHOLE_CLASS, null, null)),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        try (Harness harness = createHarness(Collections.singletonList(surveyProfile))) {
+            harness.dataset.begin(ReadWrite.WRITE);
+            try {
+                Model model = harness.dataset.getDefaultModel();
+                Resource survey1 = ResourceFactory.createResource(NS + "survey1");
+                Resource survey2 = ResourceFactory.createResource(NS + "survey2");
+                Resource borehole = ResourceFactory.createResource(NS + "bh1");
+                Resource project = ResourceFactory.createResource(NS + "project1");
+
+                model.add(survey1, RDF.type, ResourceFactory.createResource(SURVEY_CLASS.getURI()));
+                model.add(survey2, RDF.type, ResourceFactory.createResource(SURVEY_CLASS.getURI()));
+                model.add(borehole, RDF.type, ResourceFactory.createResource(BOREHOLE_CLASS.getURI()));
+                model.add(borehole, ResourceFactory.createProperty(ABOUT_PRED.getURI()), survey1);
+                model.add(project, ResourceFactory.createProperty(ABOUT_PRED.getURI()), survey2);
+                harness.dataset.commit();
+            } finally {
+                harness.dataset.end();
+            }
+
+            assertEquals(Set.of(NS + "survey1"),
+                queryByFieldValue(harness.textIndex, FIELD_NS + "hasParent", NS + "bh1"));
+            assertEquals(Collections.emptySet(),
+                queryByFieldValue(harness.textIndex, FIELD_NS + "hasParent", NS + "project1"));
+        }
+    }
+
+    @Test
+    public void testNodeKindAndDatatypeConstraintsFilterValues() {
+        FieldDef valueField = new FieldDef("value", FieldType.KEYWORD, null, null,
+            true, true, false, false, true, false, false,
+            NodeFactory.createURI(FIELD_NS + "value"));
+
+        IndexProfile sampleProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "SampleShape"),
+            Collections.singleton(SAMPLE_CLASS),
+            "uri", "docType",
+            Collections.singletonList(valueField),
+            Collections.singletonList(occurrence(valueField,
+                PathFactory.pathLink(VALUE_PRED),
+                Collections.singleton(VALUE_PRED), null,
+                ShaclIndexMapping.NodeKindConstraint.LITERAL, XSDDatatype.XSDinteger.getURI())),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        try (Harness harness = createHarness(Collections.singletonList(sampleProfile))) {
+            harness.dataset.begin(ReadWrite.WRITE);
+            try {
+                Model model = harness.dataset.getDefaultModel();
+                Resource sample1 = ResourceFactory.createResource(NS + "sample1");
+                Resource sample2 = ResourceFactory.createResource(NS + "sample2");
+                Resource sample3 = ResourceFactory.createResource(NS + "sample3");
+
+                model.add(sample1, RDF.type, ResourceFactory.createResource(SAMPLE_CLASS.getURI()));
+                model.add(sample2, RDF.type, ResourceFactory.createResource(SAMPLE_CLASS.getURI()));
+                model.add(sample3, RDF.type, ResourceFactory.createResource(SAMPLE_CLASS.getURI()));
+                model.add(sample1, ResourceFactory.createProperty(VALUE_PRED.getURI()),
+                    model.createTypedLiteral("42", XSDDatatype.XSDinteger));
+                model.add(sample2, ResourceFactory.createProperty(VALUE_PRED.getURI()),
+                    model.createTypedLiteral("oops", XSDDatatype.XSDstring));
+                model.add(sample3, ResourceFactory.createProperty(VALUE_PRED.getURI()),
+                    ResourceFactory.createResource(NS + "objectValue"));
+                harness.dataset.commit();
+            } finally {
+                harness.dataset.end();
+            }
+
+            assertEquals(Set.of(NS + "sample1"),
+                queryByFieldValue(harness.textIndex, FIELD_NS + "value", "42"));
+            assertEquals(Collections.emptySet(),
+                queryByFieldValue(harness.textIndex, FIELD_NS + "value", "oops"));
+        }
+    }
+
+    @Test
+    public void testClassConstraintTypeChangesReindexParent() {
+        FieldDef hasParent = new FieldDef("hasParent", FieldType.KEYWORD, null, null,
+            true, true, false, false, true, false, false,
+            NodeFactory.createURI(FIELD_NS + "hasParent"));
+
+        IndexProfile surveyProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "SurveyShape"),
+            Collections.singleton(SURVEY_CLASS),
+            "uri", "docType",
+            Collections.singletonList(hasParent),
+            Collections.singletonList(occurrence(hasParent,
+                PathFactory.pathInverse(PathFactory.pathLink(ABOUT_PRED)),
+                Collections.singleton(ABOUT_PRED), BOREHOLE_CLASS, null, null)),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        try (Harness harness = createHarness(Collections.singletonList(surveyProfile))) {
+            harness.dataset.begin(ReadWrite.WRITE);
+            try {
+                Model model = harness.dataset.getDefaultModel();
+                Resource survey = ResourceFactory.createResource(NS + "survey1");
+                Resource candidateParent = ResourceFactory.createResource(NS + "bh1");
+
+                model.add(survey, RDF.type, ResourceFactory.createResource(SURVEY_CLASS.getURI()));
+                model.add(candidateParent, ResourceFactory.createProperty(ABOUT_PRED.getURI()), survey);
+                harness.dataset.commit();
+            } finally {
+                harness.dataset.end();
+            }
+
+            assertEquals(Collections.emptySet(),
+                queryByFieldValue(harness.textIndex, FIELD_NS + "hasParent", NS + "bh1"));
+
+            harness.dataset.begin(ReadWrite.WRITE);
+            try {
+                Model model = harness.dataset.getDefaultModel();
+                model.add(ResourceFactory.createResource(NS + "bh1"),
+                    RDF.type, ResourceFactory.createResource(BOREHOLE_CLASS.getURI()));
+                harness.dataset.commit();
+            } finally {
+                harness.dataset.end();
+            }
+
+            assertEquals(Set.of(NS + "survey1"),
+                queryByFieldValue(harness.textIndex, FIELD_NS + "hasParent", NS + "bh1"));
+
+            harness.dataset.begin(ReadWrite.WRITE);
+            try {
+                Model model = harness.dataset.getDefaultModel();
+                model.remove(ResourceFactory.createResource(NS + "bh1"),
+                    RDF.type, ResourceFactory.createResource(BOREHOLE_CLASS.getURI()));
+                harness.dataset.commit();
+            } finally {
+                harness.dataset.end();
+            }
+
+            assertEquals(Collections.emptySet(),
+                queryByFieldValue(harness.textIndex, FIELD_NS + "hasParent", NS + "bh1"));
+        }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates,
+                                              Node requiredClass,
+                                              ShaclIndexMapping.NodeKindConstraint nodeKind,
+                                              String datatypeUri) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            requiredClass,
+            nodeKind,
+            datatypeUri != null ? NodeFactory.createURI(datatypeUri) : null,
+            null);
+    }
+
+    private static Set<String> queryByFieldValue(ShaclTextIndexLucene textIndex, String fieldIri, String value) {
+        CqlExpression cql = CqlParser.parse("""
+            {"op":"=","args":[{"property":"%s"},"%s"]}
+            """.formatted(fieldIri, value));
+
+        Set<String> uris = new LinkedHashSet<>();
+        for (TextHit hit : textIndex.queryWithCql(null, null, cql, null, null, null, 10, null)) {
+            uris.add(hit.getNode().getURI());
+        }
+        return uris;
+    }
+
+    private static Harness createHarness(List<IndexProfile> profiles) {
+        TextQuery.init();
+        ShaclIndexMapping mapping = new ShaclIndexMapping(profiles);
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(baseDs.asDatasetGraph(), textIndex, mapping);
+        Dataset dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+        return new Harness(dataset, textIndex);
+    }
+
+    private record Harness(Dataset dataset, ShaclTextIndexLucene textIndex) implements AutoCloseable {
+        @Override
+        public void close() {
+            dataset.close();
+        }
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
@@ -104,9 +104,9 @@ public class TestSortSpec {
         Node yearPred = NodeFactory.createURI("http://example.org/year");
         Node statePred = NodeFactory.createURI("http://example.org/state");
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, false, true, false, false, Collections.emptySet());
+            true, true, false, true, false, false);
         FieldDef stateField = new FieldDef("state", FieldType.KEYWORD, null,
-            true, true, true, true, false, false, Collections.emptySet());
+            true, true, true, true, false, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred)),
@@ -156,7 +156,7 @@ public class TestSortSpec {
     public void testBuildLuceneSortNull() {
         Node yearPred = NodeFactory.createURI("http://example.org/year");
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, false, true, false, false, Collections.emptySet());
+            true, true, false, true, false, false);
 
         List<FieldOccurrence> rootOccurrences = Collections.singletonList(
             occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred)));
@@ -189,7 +189,7 @@ public class TestSortSpec {
     public void testBuildLuceneSortAscendingUsesMinSelector() {
         Node yearPred = NodeFactory.createURI("http://example.org/year");
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, false, true, true, false, Collections.emptySet());
+            true, true, false, true, true, false);
 
         List<FieldOccurrence> rootOccurrences = Collections.singletonList(
             occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred)));
@@ -226,7 +226,7 @@ public class TestSortSpec {
     public void testBuildLuceneSortTextFieldThrows() {
         Node titlePred = NodeFactory.createURI("http://example.org/title");
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true, Collections.emptySet());
+            true, true, false, false, false, true);
 
         List<FieldOccurrence> rootOccurrences = Collections.singletonList(
             occurrence(titleField, PathFactory.pathLink(titlePred), Collections.singleton(titlePred)));

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
@@ -25,10 +25,15 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
+import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSelector;
@@ -42,6 +47,15 @@ import org.junit.Test;
 public class TestSortSpec {
 
     private static final String FP = "urn:jena:lucene:field#";
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
+    }
 
     @Test
     public void testParseSingleAsc() {
@@ -87,16 +101,25 @@ public class TestSortSpec {
 
     @Test
     public void testBuildLuceneSort() {
+        Node yearPred = NodeFactory.createURI("http://example.org/year");
+        Node statePred = NodeFactory.createURI("http://example.org/state");
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
             true, true, false, true, false, false, Collections.emptySet());
         FieldDef stateField = new FieldDef("state", FieldType.KEYWORD, null,
             true, true, true, true, false, false, Collections.emptySet());
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred)),
+            occurrence(stateField, PathFactory.pathLink(statePred), Collections.singleton(statePred)));
+
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/Shape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
             "uri", "docType",
-            Arrays.asList(yearField, stateField));
+            Arrays.asList(yearField, stateField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = org.apache.jena.query.text.assembler.ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -131,14 +154,21 @@ public class TestSortSpec {
 
     @Test
     public void testBuildLuceneSortNull() {
+        Node yearPred = NodeFactory.createURI("http://example.org/year");
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
             true, true, false, true, false, false, Collections.emptySet());
+
+        List<FieldOccurrence> rootOccurrences = Collections.singletonList(
+            occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred)));
 
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/Shape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
             "uri", "docType",
-            Collections.singletonList(yearField));
+            Collections.singletonList(yearField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = org.apache.jena.query.text.assembler.ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -157,14 +187,21 @@ public class TestSortSpec {
 
     @Test
     public void testBuildLuceneSortAscendingUsesMinSelector() {
+        Node yearPred = NodeFactory.createURI("http://example.org/year");
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
             true, true, false, true, true, false, Collections.emptySet());
+
+        List<FieldOccurrence> rootOccurrences = Collections.singletonList(
+            occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred)));
 
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/Shape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
             "uri", "docType",
-            Collections.singletonList(yearField));
+            Collections.singletonList(yearField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = org.apache.jena.query.text.assembler.ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -187,14 +224,21 @@ public class TestSortSpec {
 
     @Test(expected = TextIndexException.class)
     public void testBuildLuceneSortTextFieldThrows() {
+        Node titlePred = NodeFactory.createURI("http://example.org/title");
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
             true, true, false, false, false, true, Collections.emptySet());
+
+        List<FieldOccurrence> rootOccurrences = Collections.singletonList(
+            occurrence(titleField, PathFactory.pathLink(titlePred), Collections.singleton(titlePred)));
 
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/Shape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
             "uri", "docType",
-            Collections.singletonList(titleField));
+            Collections.singletonList(titleField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = org.apache.jena.query.text.assembler.ShaclIndexAssembler.deriveEntityDefinition(mapping);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSpatialFiltering.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSpatialFiltering.java
@@ -31,9 +31,12 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.query.text.cql.CqlExpression;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
@@ -70,11 +73,18 @@ public class TestSpatialFiltering {
             true, true, false, false, false, false,
             Collections.singleton(ASWKT_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(locationField, PathFactory.pathLink(ASWKT_PRED), Collections.singleton(ASWKT_PRED)));
+
         IndexProfile siteProfile = new IndexProfile(
             NodeFactory.createURI(NS + "SiteShape"),
             Collections.singleton(SITE_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, locationField));
+            Arrays.asList(titleField, locationField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         mapping = new ShaclIndexMapping(Collections.singletonList(siteProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -138,6 +148,15 @@ public class TestSpatialFiltering {
             ResourceFactory.createTypedLiteral(wkt,
                 org.apache.jena.datatypes.TypeMapper.getInstance()
                     .getSafeTypeByName(GEO + "wktLiteral")));
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSpatialFiltering.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSpatialFiltering.java
@@ -66,12 +66,10 @@ public class TestSpatialFiltering {
     @Before
     public void setUp() {
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef locationField = new FieldDef("location", FieldType.LATLON, null,
-            true, true, false, false, false, false,
-            Collections.singleton(ASWKT_PRED));
+            true, true, false, false, false, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
@@ -68,22 +68,18 @@ public class TestTextFacetPF {
         TextQuery.init();
 
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, false, true, false);
 
         FieldDef authorField = new FieldDef("author", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(AUTHOR_PRED));
+            true, true, true, false, false, false);
 
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, true, true, true, false,
-            Collections.singleton(YEAR_PRED));
+            true, true, true, true, true, false);
         FieldDef publishedOnField = new FieldDef("publishedOn", FieldType.DATE, null, null,
-            true, true, true, true, false, false, true, Collections.singleton(PUBLISHED_ON_PRED), null, null);
+            true, true, true, true, false, false, true);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
@@ -25,14 +25,19 @@ import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -80,11 +85,21 @@ public class TestTextFacetPF {
         FieldDef publishedOnField = new FieldDef("publishedOn", FieldType.DATE, null, null,
             true, true, true, true, false, false, true, Collections.singleton(PUBLISHED_ON_PRED), null, null);
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(categoryField, PathFactory.pathLink(CATEGORY_PRED), Collections.singleton(CATEGORY_PRED)),
+            occurrence(authorField, PathFactory.pathLink(AUTHOR_PRED), Collections.singleton(AUTHOR_PRED)),
+            occurrence(yearField, PathFactory.pathLink(YEAR_PRED), Collections.singleton(YEAR_PRED)),
+            occurrence(publishedOnField, PathFactory.pathLink(PUBLISHED_ON_PRED), Collections.singleton(PUBLISHED_ON_PRED)));
+
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, authorField, yearField, publishedOnField));
+            Arrays.asList(titleField, categoryField, authorField, yearField, publishedOnField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -132,6 +147,15 @@ public class TestTextFacetPF {
         for (int year : years) {
             model.add(book, ResourceFactory.createProperty(NS + "year"), ResourceFactory.createTypedLiteral(year));
         }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
@@ -29,9 +29,12 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -66,11 +69,18 @@ public class TestTextMatchPF {
             true, true, true, false, true, false,
             Collections.singleton(CATEGORY_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(categoryField, PathFactory.pathLink(CATEGORY_PRED), Collections.singleton(CATEGORY_PRED)));
+
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField));
+            Arrays.asList(titleField, categoryField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -110,6 +120,15 @@ public class TestTextMatchPF {
         model.add(book, RDF.type, ResourceFactory.createResource(NS + "Book"));
         model.add(book, ResourceFactory.createProperty(NS + "title"), title);
         model.add(book, ResourceFactory.createProperty(NS + "category"), ResourceFactory.createResource(categoryUri));
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
@@ -62,12 +62,10 @@ public class TestTextMatchPF {
         TextQuery.init();
 
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, false, true, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -29,9 +29,12 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.*;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -76,11 +79,20 @@ public class TestTextQueryPFFilters {
             true, true, false, true, false, false,
             Collections.singleton(YEAR_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(categoryField, PathFactory.pathLink(CATEGORY_PRED), Collections.singleton(CATEGORY_PRED)),
+            occurrence(authorField, PathFactory.pathLink(AUTHOR_PRED), Collections.singleton(AUTHOR_PRED)),
+            occurrence(yearField, PathFactory.pathLink(YEAR_PRED), Collections.singleton(YEAR_PRED)));
+
         IndexProfile bookProfile = new IndexProfile(
             NodeFactory.createURI(NS + "BookShape"),
             Collections.singleton(BOOK_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField, authorField, yearField));
+            Arrays.asList(titleField, categoryField, authorField, yearField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(bookProfile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -115,6 +127,15 @@ public class TestTextQueryPFFilters {
         } finally {
             dataset.end();
         }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     private void addBook(Model model, String id, String title, String categoryUri, String authorUri, int year) {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -64,20 +64,16 @@ public class TestTextQueryPFFilters {
         TextQuery.init();
 
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, false, true, false);
 
         FieldDef authorField = new FieldDef("author", FieldType.KEYWORD, null,
-            true, true, true, false, false, false,
-            Collections.singleton(AUTHOR_PRED));
+            true, true, true, false, false, false);
 
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, false, true, false, false,
-            Collections.singleton(YEAR_PRED));
+            true, true, false, true, false, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestUpdateDocumentFacets.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestUpdateDocumentFacets.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -35,6 +36,8 @@ import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.text.ShaclIndexMapping.*;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -69,11 +72,18 @@ public class TestUpdateDocumentFacets {
             true, true, true, false, true, false,
             Collections.singleton(CATEGORY_PRED));
 
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(categoryField, PathFactory.pathLink(CATEGORY_PRED), Collections.singleton(CATEGORY_PRED)));
+
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI(NS + "DocShape"),
             Collections.singleton(DOC_CLASS),
             "uri", "docType",
-            Arrays.asList(titleField, categoryField));
+            Arrays.asList(titleField, categoryField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
@@ -89,6 +99,15 @@ public class TestUpdateDocumentFacets {
         ShaclTextDocProducer producer = new ShaclTextDocProducer(
             baseDs.asDatasetGraph(), textIndex, mapping);
         dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
     }
 
     @After

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestUpdateDocumentFacets.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestUpdateDocumentFacets.java
@@ -65,12 +65,10 @@ public class TestUpdateDocumentFacets {
     @Before
     public void setUp() {
         FieldDef titleField = new FieldDef("text", FieldType.TEXT, null,
-            true, true, false, false, false, true,
-            Collections.singleton(TITLE_PRED));
+            true, true, false, false, false, true);
 
         FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
-            true, true, true, false, true, false,
-            Collections.singleton(CATEGORY_PRED));
+            true, true, true, false, true, false);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
@@ -27,16 +27,19 @@ import org.apache.jena.assembler.Assembler;
 import org.apache.jena.assembler.exceptions.AssemblerException;
 import org.apache.jena.query.text.ShaclIndexMapping;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
-import org.apache.jena.query.text.TextIndexException;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.NestedDef;
 import org.apache.jena.query.text.ShaclTextIndexLucene;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.sparql.path.*;
+import org.apache.jena.query.text.TextIndexException;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.sparql.path.P_Inverse;
+import org.apache.jena.sparql.path.P_Link;
+import org.apache.jena.sparql.path.P_Seq;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.junit.Test;
 
 /**
@@ -56,26 +59,23 @@ public class TestShaclAssembler {
         return ModelFactory.createDefaultModel();
     }
 
-    /**
-     * Build a valid text:shapes index spec in the model.
-     */
+    private Resource occurrence(Model model, Resource field, RDFNode pathNode) {
+        return model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "field"), field)
+            .addProperty(model.createProperty(SH, "path"), pathNode);
+    }
+
     private Resource buildShaclIndexSpec(Model model) {
-        // Define the shape
+        Resource labelField = model.createResource(EX + "labelField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "label")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
+            .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true));
+
         Resource bookShape = model.createResource(EX + "BookShape")
             .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
-            .addProperty(
-                model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "label")
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
-                    .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true))
-                    .addProperty(model.createProperty(SH, "path"), RDFS.label)
-            );
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, labelField, RDFS.label));
 
-        // Build the shapes list
         RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
-
-        // Build the index spec
         return model.createResource(EX + "index")
             .addProperty(RDF.type, TextVocab.textIndexShacl)
             .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
@@ -89,14 +89,15 @@ public class TestShaclAssembler {
 
         ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
         try {
-            assertTrue("Should be in SHACL mode", index.isShaclMode());
+            assertTrue(index.isShaclMode());
             ShaclIndexMapping mapping = index.getShaclMapping();
             assertNotNull(mapping);
             assertEquals(1, mapping.getProfiles().size());
 
-            ShaclIndexMapping.IndexProfile profile = mapping.getProfiles().get(0);
+            IndexProfile profile = mapping.getProfiles().get(0);
             assertEquals(1, profile.getFields().size());
             assertEquals("label", profile.getFields().get(0).getFieldName());
+            assertEquals(1, profile.getRootOccurrences().size());
         } finally {
             index.close();
         }
@@ -122,26 +123,20 @@ public class TestShaclAssembler {
     public void testInversePathParsed() {
         Model model = createModel();
 
-        // Shape with inverse path: sh:path [ sh:inversePath ex:wrote ]
+        Resource titleField = model.createResource(EX + "titleField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
+            .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true));
+        Resource wroteByField = model.createResource(EX + "wroteByField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "wroteBy")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField);
+
+        Resource inversePath = model.createResource()
+            .addProperty(model.createProperty(SH, "inversePath"), model.createResource(EX + "wrote"));
+
         Resource bookShape = model.createResource(EX + "BookShape")
             .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
-            .addProperty(
-                model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
-                    .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true))
-                    .addProperty(model.createProperty(SH, "path"), RDFS.label)
-            )
-            .addProperty(
-                model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "wroteBy")
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
-                    .addProperty(model.createProperty(SH, "path"),
-                        model.createResource()
-                            .addProperty(model.createProperty(SH, "inversePath"),
-                                model.createResource(EX + "wrote")))
-            );
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, titleField, RDFS.label))
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, wroteByField, inversePath));
 
         RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
         Resource indexSpec = model.createResource(EX + "index")
@@ -151,16 +146,9 @@ public class TestShaclAssembler {
 
         ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
         try {
-            ShaclIndexMapping mapping = index.getShaclMapping();
-            FieldDef wroteByField = null;
-            for (FieldDef f : mapping.getProfiles().get(0).getFields()) {
-                if ("wroteBy".equals(f.getFieldName())) {
-                    wroteByField = f;
-                }
-            }
-            assertNotNull("Should have wroteBy field", wroteByField);
-            assertTrue("wroteBy should have complex path", wroteByField.hasComplexPath());
-            assertTrue("wroteBy path should be P_Inverse", wroteByField.getPath() instanceof P_Inverse);
+            FieldOccurrence wroteBy = findRootOccurrence(index.getShaclMapping().getProfiles().get(0), "wroteBy");
+            assertNotNull(wroteBy);
+            assertTrue(wroteBy.getPath() instanceof P_Inverse);
         } finally {
             index.close();
         }
@@ -170,27 +158,22 @@ public class TestShaclAssembler {
     public void testQueryAnalyzerAssembled() {
         Model model = createModel();
 
-        // Shape with a field that has idx:analyzer (edge n-gram) and idx:queryAnalyzer (lowercase keyword)
+        Resource titleField = model.createResource(EX + "titleField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
+            .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true));
+        Resource identifierField = model.createResource(EX + "identifierField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifier")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
+            .addProperty(model.createProperty(IndexVocab.NS, "analyzer"),
+                model.createResource().addProperty(RDF.type, TextVocab.edgeNGramAnalyzer))
+            .addProperty(model.createProperty(IndexVocab.NS, "queryAnalyzer"),
+                model.createResource().addProperty(RDF.type, TextVocab.lowerCaseKeywordAnalyzer));
+
         Resource bookShape = model.createResource(EX + "BookShape")
             .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
-            .addProperty(
-                model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
-                    .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true))
-                    .addProperty(model.createProperty(SH, "path"), RDFS.label)
-            )
-            .addProperty(
-                model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifier")
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
-                    .addProperty(model.createProperty(IndexVocab.NS, "analyzer"),
-                        model.createResource().addProperty(RDF.type, TextVocab.edgeNGramAnalyzer))
-                    .addProperty(model.createProperty(IndexVocab.NS, "queryAnalyzer"),
-                        model.createResource().addProperty(RDF.type, TextVocab.lowerCaseKeywordAnalyzer))
-                    .addProperty(model.createProperty(SH, "path"), model.createResource(EX + "identifier"))
-            );
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, titleField, RDFS.label))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, identifierField, model.createResource(EX + "identifier")));
 
         RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
         Resource indexSpec = model.createResource(EX + "index")
@@ -200,18 +183,11 @@ public class TestShaclAssembler {
 
         ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
         try {
-            ShaclIndexMapping mapping = index.getShaclMapping();
-            FieldDef idField = null;
-            for (FieldDef f : mapping.getProfiles().get(0).getFields()) {
-                if ("identifier".equals(f.getFieldName())) {
-                    idField = f;
-                }
-            }
-            assertNotNull("Should have identifier field", idField);
-            assertNotNull("identifier should have index analyzer", idField.getAnalyzer());
-            assertNotNull("identifier should have query analyzer", idField.getQueryAnalyzer());
-            assertNotSame("index and query analyzers should be different instances",
-                idField.getAnalyzer(), idField.getQueryAnalyzer());
+            FieldDef idField = index.getShaclMapping().findField(identifierField.getURI());
+            assertNotNull(idField);
+            assertNotNull(idField.getAnalyzer());
+            assertNotNull(idField.getQueryAnalyzer());
+            assertNotSame(idField.getAnalyzer(), idField.getQueryAnalyzer());
         } finally {
             index.close();
         }
@@ -221,15 +197,14 @@ public class TestShaclAssembler {
     public void testDateFieldRequiresLiteralMetadata() {
         Model model = createModel();
 
+        Resource dateField = model.createResource(EX + "eventDateField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "eventDate")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.DateField);
+
         Resource bookShape = model.createResource(EX + "BookShape")
             .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
-            .addProperty(
-                model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "eventDate")
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.DateField)
-                    .addProperty(model.createProperty(SH, "path"), model.createResource(EX + "eventDate"))
-            );
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, dateField, model.createResource(EX + "eventDate")));
 
         RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
         Resource indexSpec = model.createResource(EX + "index")
@@ -247,7 +222,13 @@ public class TestShaclAssembler {
     public void testSequencePathParsed() {
         Model model = createModel();
 
-        // Shape with sequence path: sh:path ( ex:author ex:name )
+        Resource titleField = model.createResource(EX + "titleField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
+            .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true));
+        Resource authorNameField = model.createResource(EX + "authorNameField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "authorName")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField);
+
         Resource authorPath = model.createList(new RDFNode[]{
             model.createResource(EX + "author"),
             model.createResource(EX + "name")
@@ -255,20 +236,8 @@ public class TestShaclAssembler {
 
         Resource bookShape = model.createResource(EX + "BookShape")
             .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
-            .addProperty(
-                model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
-                    .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true))
-                    .addProperty(model.createProperty(SH, "path"), RDFS.label)
-            )
-            .addProperty(
-                model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "authorName")
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
-                    .addProperty(model.createProperty(SH, "path"), authorPath)
-            );
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, titleField, RDFS.label))
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, authorNameField, authorPath));
 
         RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
         Resource indexSpec = model.createResource(EX + "index")
@@ -278,19 +247,10 @@ public class TestShaclAssembler {
 
         ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
         try {
-            ShaclIndexMapping mapping = index.getShaclMapping();
-            FieldDef authorNameField = null;
-            for (FieldDef f : mapping.getProfiles().get(0).getFields()) {
-                if ("authorName".equals(f.getFieldName())) {
-                    authorNameField = f;
-                }
-            }
-            assertNotNull("Should have authorName field", authorNameField);
-            assertTrue("authorName should have complex path", authorNameField.hasComplexPath());
-            assertTrue("authorName path should be P_Seq", authorNameField.getPath() instanceof P_Seq);
-
-            // Verify leaf predicates extracted for change listener
-            assertEquals("Should have 2 leaf predicates", 2, authorNameField.getPredicates().size());
+            FieldOccurrence authorName = findRootOccurrence(index.getShaclMapping().getProfiles().get(0), "authorName");
+            assertNotNull(authorName);
+            assertTrue(authorName.getPath() instanceof P_Seq);
+            assertEquals(2, authorName.getPredicates().size());
         } finally {
             index.close();
         }
@@ -300,42 +260,39 @@ public class TestShaclAssembler {
     public void testNestedHierarchyParsed() {
         Model model = createModel();
 
+        Resource titleField = model.createResource(EX + "titleField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
+            .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true));
         Resource identifierType = model.createResource("urn:jena:lucene:field#identifierType")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifierType")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
-            .addProperty(model.createProperty(IndexVocab.NS, "facetable"), model.createTypedLiteral(true))
-            .addProperty(model.createProperty(SH, "path"), model.createResource("https://schema.org/propertyID"));
-
+            .addProperty(model.createProperty(IndexVocab.NS, "facetable"), model.createTypedLiteral(true));
         Resource identifierValueExact = model.createResource("urn:jena:lucene:field#identifierValueExact")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifierValueExact")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
-            .addProperty(model.createProperty(IndexVocab.NS, "facetable"), model.createTypedLiteral(true))
-            .addProperty(model.createProperty(SH, "path"), model.createResource("https://schema.org/value"));
-
+            .addProperty(model.createProperty(IndexVocab.NS, "facetable"), model.createTypedLiteral(true));
         Resource identifierValueText = model.createResource("urn:jena:lucene:field#identifierValueText")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifierValueText")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
             .addProperty(model.createProperty(IndexVocab.NS, "analyzer"),
                 model.createResource().addProperty(RDF.type, TextVocab.edgeNGramAnalyzer))
             .addProperty(model.createProperty(IndexVocab.NS, "queryAnalyzer"),
-                model.createResource().addProperty(RDF.type, TextVocab.lowerCaseKeywordAnalyzer))
-            .addProperty(model.createProperty(SH, "path"), model.createResource("https://schema.org/value"));
+                model.createResource().addProperty(RDF.type, TextVocab.lowerCaseKeywordAnalyzer));
 
         Resource nested = model.createResource()
             .addProperty(model.createProperty(IndexVocab.NS, "joinPath"), model.createResource("https://schema.org/identifier"))
-            .addProperty(model.createProperty(IndexVocab.NS, "property"), identifierType)
-            .addProperty(model.createProperty(IndexVocab.NS, "property"), identifierValueExact)
-            .addProperty(model.createProperty(IndexVocab.NS, "property"), identifierValueText)
+            .addProperty(model.createProperty(IndexVocab.NS, "property"),
+                occurrence(model, identifierType, model.createResource("https://schema.org/propertyID")))
+            .addProperty(model.createProperty(IndexVocab.NS, "property"),
+                occurrence(model, identifierValueExact, model.createResource("https://schema.org/value")))
+            .addProperty(model.createProperty(IndexVocab.NS, "property"),
+                occurrence(model, identifierValueText, model.createResource("https://schema.org/value")))
             .addProperty(model.createProperty(IndexVocab.NS, "facetHierarchy"),
                 model.createList(new RDFNode[] { identifierType, identifierValueExact }));
 
         Resource boreholeShape = model.createResource(EX + "BoreholeShape")
             .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Borehole"))
-            .addProperty(model.createProperty(SH, "property"),
-                model.createResource()
-                    .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
-                    .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true))
-                    .addProperty(model.createProperty(SH, "path"), RDFS.label))
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, titleField, RDFS.label))
             .addProperty(model.createProperty(IndexVocab.NS, "nested"), nested);
 
         RDFNode shapesList = model.createList(new RDFNode[] { boreholeShape });
@@ -346,26 +303,18 @@ public class TestShaclAssembler {
 
         ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
         try {
-            ShaclIndexMapping.IndexProfile profile = index.getShaclMapping().getProfiles().get(0);
-            assertEquals("Should parse nested definition", 1, profile.getNestedDefs().size());
-            ShaclIndexMapping.NestedDef nestedDef = profile.getNestedDefs().get(0);
-            assertTrue("joinPath should be a simple predicate", nestedDef.getJoinPath() instanceof P_Link);
-            assertEquals("Nested scope name should be derived from joinPath",
-                "<https://schema.org/identifier>", nestedDef.getNestedName());
-            assertEquals("Simple join path should produce one join step", 1, nestedDef.getJoinSteps().size());
-            assertFalse("Simple join step should be forward", nestedDef.getJoinSteps().get(0).isInverse());
-            assertTrue("join predicates should contain the join predicate",
-                nestedDef.getJoinPredicates().contains(model.createResource("https://schema.org/identifier").asNode()));
-            assertEquals("Nested fields should be available on the profile", 4, profile.getFields().size());
-            assertEquals("Nested block should define one hierarchy", 1, nestedDef.getHierarchies().size());
-            ShaclIndexMapping.HierarchyDef hierarchy = nestedDef.getHierarchies().get(0);
-            assertEquals("identifierType_identifierValueExact", hierarchy.getDimensionName());
-            assertEquals("First hierarchy level should be identifierType",
-                "urn:jena:lucene:field#identifierType", hierarchy.getLevel(0).getFieldIRI().getURI());
-            assertEquals("Second hierarchy level should be identifierValueExact",
-                "urn:jena:lucene:field#identifierValueExact", hierarchy.getLevel(1).getFieldIRI().getURI());
-            assertTrue("Nested fields should carry nested scope metadata",
-                hierarchy.getLevel(0).isNestedScoped());
+            IndexProfile profile = index.getShaclMapping().getProfiles().get(0);
+            assertEquals(1, profile.getNestedDefs().size());
+            NestedDef nestedDef = profile.getNestedDefs().get(0);
+            assertTrue(nestedDef.getJoinPath() instanceof P_Link);
+            assertEquals("<https://schema.org/identifier>", nestedDef.getNestedName());
+            assertEquals(1, nestedDef.getJoinSteps().size());
+            assertFalse(nestedDef.getJoinSteps().get(0).isInverse());
+            assertTrue(nestedDef.getJoinPredicates().contains(model.createResource("https://schema.org/identifier").asNode()));
+            assertEquals(4, profile.getFields().size());
+            assertEquals(1, nestedDef.getHierarchies().size());
+            assertEquals(3, nestedDef.getOccurrences().size());
+            assertEquals("identifierType_identifierValueExact", nestedDef.getHierarchies().get(0).getDimensionName());
         } finally {
             index.close();
         }
@@ -377,14 +326,14 @@ public class TestShaclAssembler {
 
         Resource identifierType = model.createResource("urn:jena:lucene:field#identifierType")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifierType")
-            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
-            .addProperty(model.createProperty(SH, "path"), model.createResource("https://schema.org/propertyID"));
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField);
 
         Resource nested = model.createResource()
             .addProperty(model.createProperty(IndexVocab.NS, "joinPath"),
                 model.createResource().addProperty(model.createProperty(SH, "inversePath"),
                     model.createResource("https://schema.org/about")))
-            .addProperty(model.createProperty(IndexVocab.NS, "property"), identifierType);
+            .addProperty(model.createProperty(IndexVocab.NS, "property"),
+                occurrence(model, identifierType, model.createResource("https://schema.org/propertyID")));
 
         Resource boreholeShape = model.createResource(EX + "BoreholeShape")
             .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Borehole"))
@@ -398,7 +347,7 @@ public class TestShaclAssembler {
 
         ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
         try {
-            ShaclIndexMapping.NestedDef nestedDef = index.getShaclMapping().getProfiles().get(0).getNestedDefs().get(0);
+            NestedDef nestedDef = index.getShaclMapping().getProfiles().get(0).getNestedDefs().get(0);
             assertTrue(nestedDef.getJoinPath() instanceof P_Inverse);
             assertEquals(1, nestedDef.getJoinSteps().size());
             assertTrue(nestedDef.getJoinSteps().get(0).isInverse());
@@ -414,8 +363,7 @@ public class TestShaclAssembler {
 
         Resource identifierType = model.createResource("urn:jena:lucene:field#identifierType")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifierType")
-            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
-            .addProperty(model.createProperty(SH, "path"), model.createResource("https://schema.org/propertyID"));
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField);
 
         Resource joinPath = model.createList(new RDFNode[] {
             model.createResource("https://example.org/hasIdentifierLink"),
@@ -424,7 +372,8 @@ public class TestShaclAssembler {
 
         Resource nested = model.createResource()
             .addProperty(model.createProperty(IndexVocab.NS, "joinPath"), joinPath)
-            .addProperty(model.createProperty(IndexVocab.NS, "property"), identifierType);
+            .addProperty(model.createProperty(IndexVocab.NS, "property"),
+                occurrence(model, identifierType, model.createResource("https://schema.org/propertyID")));
 
         Resource boreholeShape = model.createResource(EX + "BoreholeShape")
             .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Borehole"))
@@ -438,48 +387,131 @@ public class TestShaclAssembler {
 
         ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
         try {
-            ShaclIndexMapping.NestedDef nestedDef = index.getShaclMapping().getProfiles().get(0).getNestedDefs().get(0);
+            NestedDef nestedDef = index.getShaclMapping().getProfiles().get(0).getNestedDefs().get(0);
             assertTrue(nestedDef.getJoinPath() instanceof P_Seq);
             assertEquals(2, nestedDef.getJoinSteps().size());
             assertEquals("https://example.org/hasIdentifierLink", nestedDef.getJoinSteps().get(0).getPredicate().getURI());
             assertEquals("https://example.org/identifierNode", nestedDef.getJoinSteps().get(1).getPredicate().getURI());
-            assertFalse(nestedDef.getJoinSteps().get(0).isInverse());
-            assertFalse(nestedDef.getJoinSteps().get(1).isInverse());
         } finally {
             index.close();
         }
     }
 
     @Test
-    public void testFieldCannotBeUsedInBothRootAndNestedScope() {
+    public void testSharedCanonicalFieldCanAppearInMultipleRootOccurrences() {
         Model model = createModel();
 
-        Resource identifierType = model.createResource("urn:jena:lucene:field#identifierType")
-            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifierType")
+        Resource parentField = model.createResource("urn:jena:lucene:field#hasParent")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "hasParent")
             .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
-            .addProperty(model.createProperty(SH, "path"), model.createResource("https://schema.org/propertyID"));
+            .addProperty(model.createProperty(IndexVocab.NS, "multiValued"), model.createTypedLiteral(true));
 
-        Resource nested = model.createResource()
-            .addProperty(model.createProperty(IndexVocab.NS, "joinPath"), model.createResource("https://schema.org/identifier"))
-            .addProperty(model.createProperty(IndexVocab.NS, "property"), identifierType);
+        Resource surveyShape = model.createResource(EX + "SurveyShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Survey"))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, parentField,
+                    model.createResource().addProperty(model.createProperty(SH, "inversePath"),
+                        model.createResource("https://schema.org/about"))));
 
-        Resource boreholeShape = model.createResource(EX + "BoreholeShape")
-            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Borehole"))
-            .addProperty(model.createProperty(SH, "property"), identifierType)
-            .addProperty(model.createProperty(IndexVocab.NS, "nested"), nested);
+        Resource wellShape = model.createResource(EX + "WellShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Well"))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, parentField, model.createResource("http://purl.org/dc/terms/hasPart")));
 
-        RDFNode shapesList = model.createList(new RDFNode[] { boreholeShape });
+        RDFNode shapesList = model.createList(new RDFNode[] { surveyShape, wellShape });
         Resource indexSpec = model.createResource(EX + "index")
             .addProperty(RDF.type, TextVocab.textIndexShacl)
             .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
             .addProperty(TextVocab.pShapes, shapesList);
 
+        ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
         try {
-            Assembler.general().open(indexSpec);
-            fail("Expected root/nested field reuse to be rejected");
-        } catch (AssemblerException ex) {
-            assertTrue(ex.getMessage().contains("cannot be used both as a root field and as an idx:nested property"));
+            ShaclIndexMapping mapping = index.getShaclMapping();
+            assertNotNull(mapping.findField(parentField.getURI()));
+            assertEquals(2, mapping.getProfiles().size());
+        } finally {
+            index.close();
         }
     }
 
+    @Test
+    public void testOccurrenceConstraintsParsed() {
+        Model model = createModel();
+
+        Resource parentField = model.createResource("urn:jena:lucene:field#hasParent")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "hasParent")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField);
+        Resource valueField = model.createResource("urn:jena:lucene:field#sampleValue")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "sampleValue")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField);
+
+        Resource shape = model.createResource(EX + "SurveyShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Survey"))
+            .addProperty(model.createProperty(SH, "property"),
+                model.createResource()
+                    .addProperty(model.createProperty(IndexVocab.NS, "field"), parentField)
+                    .addProperty(model.createProperty(SH, "path"),
+                        model.createResource().addProperty(model.createProperty(SH, "inversePath"),
+                            model.createResource(EX + "about")))
+                    .addProperty(model.createProperty(SH, "class"), model.createResource(EX + "Borehole"))
+                    .addProperty(model.createProperty(SH, "nodeKind"), model.createResource(SH + "IRI")))
+            .addProperty(model.createProperty(SH, "property"),
+                model.createResource()
+                    .addProperty(model.createProperty(IndexVocab.NS, "field"), valueField)
+                    .addProperty(model.createProperty(SH, "path"), model.createResource(EX + "value"))
+                    .addProperty(model.createProperty(SH, "nodeKind"), model.createResource(SH + "Literal"))
+                    .addProperty(model.createProperty(SH, "datatype"),
+                        model.createResource(XSDDatatype.XSDinteger.getURI())));
+
+        RDFNode shapesList = model.createList(new RDFNode[] { shape });
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, shapesList);
+
+        ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
+        try {
+            IndexProfile profile = index.getShaclMapping().getProfiles().get(0);
+            FieldOccurrence parentOccurrence = findRootOccurrence(profile, "hasParent");
+            FieldOccurrence valueOccurrence = findRootOccurrence(profile, "sampleValue");
+
+            assertEquals(model.createResource(EX + "Borehole").asNode(), parentOccurrence.getRequiredClass());
+            assertEquals(ShaclIndexMapping.NodeKindConstraint.IRI, parentOccurrence.getNodeKindConstraint());
+            assertEquals(ShaclIndexMapping.NodeKindConstraint.LITERAL, valueOccurrence.getNodeKindConstraint());
+            assertEquals(XSDDatatype.XSDinteger.getURI(), valueOccurrence.getDatatype().getURI());
+        } finally {
+            index.close();
+        }
+    }
+
+    @Test
+    public void testLegacyFieldResourceSyntaxRejected() {
+        Model model = createModel();
+
+        Resource legacyField = model.createResource(EX + "legacyField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
+            .addProperty(model.createProperty(SH, "path"), RDFS.label);
+
+        Resource shape = model.createResource(EX + "BookShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
+            .addProperty(model.createProperty(SH, "property"), legacyField);
+
+        RDFNode shapesList = model.createList(new RDFNode[] { shape });
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, shapesList);
+
+        AssemblerException ex = assertThrows(AssemblerException.class,
+            () -> Assembler.general().open(indexSpec));
+        assertTrue(ex.getMessage().contains("mixes occurrence data with canonical field metadata"));
+    }
+
+    private static FieldOccurrence findRootOccurrence(IndexProfile profile, String fieldName) {
+        return profile.getRootOccurrences().stream()
+            .filter(o -> fieldName.equals(o.getField().getFieldName()))
+            .findFirst()
+            .orElse(null);
+    }
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
@@ -508,6 +508,76 @@ public class TestShaclAssembler {
         assertTrue(ex.getMessage().contains("mixes occurrence data with canonical field metadata"));
     }
 
+    @Test
+    public void testRootHierarchyCannotReferenceNestedOnlyField() {
+        Model model = createModel();
+
+        Resource titleField = model.createResource(EX + "titleField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "title")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField);
+        Resource identifierType = model.createResource(EX + "identifierTypeField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifierType")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField);
+
+        Resource nested = model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "joinPath"),
+                model.createResource("https://schema.org/identifier"))
+            .addProperty(model.createProperty(IndexVocab.NS, "property"),
+                occurrence(model, identifierType, model.createResource("https://schema.org/propertyID")));
+
+        Resource shape = model.createResource(EX + "BoreholeShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Borehole"))
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, titleField, RDFS.label))
+            .addProperty(model.createProperty(IndexVocab.NS, "nested"), nested)
+            .addProperty(model.createProperty(IndexVocab.NS, "facetHierarchy"),
+                model.createList(new RDFNode[] { titleField, identifierType }));
+
+        RDFNode shapesList = model.createList(new RDFNode[] { shape });
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, shapesList);
+
+        AssemblerException ex = assertThrows(AssemblerException.class,
+            () -> Assembler.general().open(indexSpec));
+        assertTrue(ex.getCause() instanceof TextIndexException);
+        assertTrue(ex.getCause().getMessage().contains("same scope"));
+    }
+
+    @Test
+    public void testConflictingCanonicalFieldAnalyzersRejected() {
+        Model model = createModel();
+
+        Resource identifierFieldA = model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifier")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
+            .addProperty(model.createProperty(IndexVocab.NS, "analyzer"),
+                model.createResource().addProperty(RDF.type, TextVocab.edgeNGramAnalyzer));
+        Resource identifierFieldB = model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "identifier")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
+            .addProperty(model.createProperty(IndexVocab.NS, "analyzer"),
+                model.createResource().addProperty(RDF.type, TextVocab.lowerCaseKeywordAnalyzer));
+
+        Resource shape = model.createResource(EX + "SpecimenShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Specimen"))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, identifierFieldA, model.createResource(EX + "identifierA")))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, identifierFieldB, model.createResource(EX + "identifierB")));
+
+        RDFNode shapesList = model.createList(new RDFNode[] { shape });
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, shapesList);
+
+        AssemblerException ex = assertThrows(AssemblerException.class,
+            () -> Assembler.general().open(indexSpec));
+        assertTrue(ex.getCause() instanceof TextIndexException);
+        assertTrue(ex.getCause().getMessage().contains("defined inconsistently"));
+    }
+
     private static FieldOccurrence findRootOccurrence(IndexProfile profile, String fieldName) {
         return profile.getRootOccurrences().stream()
             .filter(o -> fieldName.equals(o.getField().getFieldName()))

--- a/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
@@ -25,12 +25,16 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
+import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.text.ShaclIndexMapping;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.HierarchyDef;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.lucene.facet.DrillDownQuery;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.search.*;
@@ -49,24 +53,31 @@ public class TestCqlToLuceneCompiler {
     @Before
     public void setUp() {
         FieldDef stateField = new FieldDef("state", FieldType.KEYWORD, null,
-            true, true, true, false, false, false, Collections.emptySet());
+            true, true, true, false, false, false);
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
-            true, true, false, true, false, false, Collections.emptySet());
+            true, true, false, true, false, false);
         FieldDef depthField = new FieldDef("depth", FieldType.DOUBLE, null,
-            true, true, false, true, false, false, Collections.emptySet());
+            true, true, false, true, false, false);
         FieldDef nameField = new FieldDef("name", FieldType.KEYWORD, null,
-            true, true, false, false, false, false, Collections.emptySet());
+            true, true, false, false, false, false);
         FieldDef locationField = new FieldDef("location", FieldType.LATLON, null,
-            true, true, false, false, false, false, Collections.emptySet());
+            true, true, false, false, false, false);
         FieldDef notIndexedField = new FieldDef("notes", FieldType.TEXT, null,
-            true, false, false, false, false, false, Collections.emptySet());
+            true, false, false, false, false, false);
+        List<FieldOccurrence> rootOccurrences = List.of(
+            occurrence(stateField, "http://example.org/state"),
+            occurrence(yearField, "http://example.org/year"),
+            occurrence(depthField, "http://example.org/depth"),
+            occurrence(nameField, "http://example.org/name"),
+            occurrence(locationField, "http://example.org/location"),
+            occurrence(notIndexedField, "http://example.org/notes"));
 
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/Shape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
             "uri", "docType",
             Arrays.asList(stateField, yearField, depthField, nameField, locationField, notIndexedField),
-            Collections.emptyList(),
+            rootOccurrences,
             Collections.emptyList(),
             Collections.emptyList());
 
@@ -251,13 +262,13 @@ public class TestCqlToLuceneCompiler {
     @Test
     public void testDateEqualityUsesTemporalCompanionField() {
         FieldDef eventDateField = new FieldDef("eventDate", FieldType.DATE, null, null,
-            true, true, false, true, false, false, true, Collections.emptySet(), null, null);
+            true, true, false, true, false, false, true);
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/DateShape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Event")),
             "uri", "docType",
             Collections.singletonList(eventDateField),
-            Collections.emptyList(),
+            Collections.singletonList(occurrence(eventDateField, "http://example.org/eventDate")),
             Collections.emptyList(),
             Collections.emptyList());
 
@@ -275,13 +286,13 @@ public class TestCqlToLuceneCompiler {
     @Test
     public void testDateBetweenUsesTemporalCompanionField() {
         FieldDef eventDateField = new FieldDef("eventDate", FieldType.DATE, null, null,
-            true, true, false, true, false, false, true, Collections.emptySet(), null, null);
+            true, true, false, true, false, false, true);
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/DateShape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Event")),
             "uri", "docType",
             Collections.singletonList(eventDateField),
-            Collections.emptyList(),
+            Collections.singletonList(occurrence(eventDateField, "http://example.org/eventDate")),
             Collections.emptyList(),
             Collections.emptyList());
 
@@ -329,16 +340,20 @@ public class TestCqlToLuceneCompiler {
     @Test
     public void testSingleHierarchyLevelEqualityUsesDrillDownQuery() {
         FieldDef stateField = new FieldDef("state", FieldType.KEYWORD, null,
-            true, true, true, false, false, false, Collections.emptySet());
+            true, true, true, false, false, false);
         FieldDef commodityField = new FieldDef("commodity", FieldType.KEYWORD, null,
-            true, true, true, false, false, false, Collections.emptySet());
+            true, true, true, false, false, false);
         HierarchyDef hierarchy = new HierarchyDef("state_commodity", List.of(stateField, commodityField));
+        List<FieldOccurrence> rootOccurrences = List.of(
+            occurrence(stateField, "http://example.org/state"),
+            occurrence(commodityField, "http://example.org/commodity"));
 
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/Shape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
             "uri", "docType",
             List.of(stateField, commodityField),
+            rootOccurrences,
             List.of(hierarchy),
             Collections.emptyList());
 
@@ -351,5 +366,18 @@ public class TestCqlToLuceneCompiler {
         assertNotNull(r.pushed());
         assertNull(r.residual());
         assertTrue(r.pushed() instanceof DrillDownQuery);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, String predicateUri) {
+        Node predicate = NodeFactory.createURI(predicateUri);
+        return new FieldOccurrence(
+            field,
+            PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null,
+            null,
+            null,
+            null);
     }
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
@@ -65,7 +65,10 @@ public class TestCqlToLuceneCompiler {
             NodeFactory.createURI("http://example.org/Shape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
             "uri", "docType",
-            Arrays.asList(stateField, yearField, depthField, nameField, locationField, notIndexedField));
+            Arrays.asList(stateField, yearField, depthField, nameField, locationField, notIndexedField),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
 
         ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
         compiler = new CqlToLuceneCompiler(mapping);
@@ -253,7 +256,10 @@ public class TestCqlToLuceneCompiler {
             NodeFactory.createURI("http://example.org/DateShape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Event")),
             "uri", "docType",
-            Collections.singletonList(eventDateField));
+            Collections.singletonList(eventDateField),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
 
         CqlToLuceneCompiler dateCompiler =
             new CqlToLuceneCompiler(new ShaclIndexMapping(Collections.singletonList(profile)));
@@ -274,7 +280,10 @@ public class TestCqlToLuceneCompiler {
             NodeFactory.createURI("http://example.org/DateShape"),
             Collections.singleton(NodeFactory.createURI("http://example.org/Event")),
             "uri", "docType",
-            Collections.singletonList(eventDateField));
+            Collections.singletonList(eventDateField),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
 
         CqlToLuceneCompiler dateCompiler =
             new CqlToLuceneCompiler(new ShaclIndexMapping(Collections.singletonList(profile)));


### PR DESCRIPTION
## Summary

  This branch refactors the SHACL text-index model so canonical field resources hold shared Lucene/index metadata, while each shape-local occurrence owns its `sh:path` and optional constraints. That allows multiple shapes and paths to fan in to the same public field IRI, and fixes indexing/facet behavior that previously assumed one field definition also owned one extraction path.

  ## What changed

  - split field metadata from field occurrences in the SHACL assembler and mapping model
  - add occurrence-driven indexing for both root and nested fields, including shared canonical field fan-in
  - support occurrence-level `sh:class`, `sh:nodeKind`, and `sh:datatype` filtering
  - update change tracking/reindexing so predicate and type changes rebuild affected parent entities correctly
  - tighten validation around canonical field reuse and hierarchy scope references
  - fix hierarchical facet/taxonomy handling, including blank hierarchy components and taxonomy reader usage
  - update demo configs and demo UI parsing to the new canonical-field-plus-occurrence structure
  - add a design note and regression coverage for shared field occurrences, assembler validation, hierarchical facets, and related query/indexing paths

  ## Testing

  - Added/updated JUnit coverage across `TestSharedFieldOccurrences`, `TestShaclIndexMapping`, `TestShaclTextDocProducer`, `TestHierarchicalFacets`, `TestShaclAssembler`, and related SHACL text index tests