### PR TITLE
Feat standalone spatial indexing.

### DIFF
--- a/build-files/docker/Dockerfile.loader
+++ b/build-files/docker/Dockerfile.loader
@@ -9,7 +9,7 @@ COPY . .
 RUN mvn --batch-mode --quiet --no-transfer-progress -Dstyle.color=never \
     clean package -pl jena-fuseki2/jena-fuseki-server -am -DskipTests -Dmaven.javadoc.skip=true
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-ubi10-minimal
 
 WORKDIR /fuseki
 

--- a/build-files/docker/Dockerfile.runtime
+++ b/build-files/docker/Dockerfile.runtime
@@ -9,7 +9,7 @@ COPY . .
 RUN mvn --batch-mode --quiet --no-transfer-progress -Dstyle.color=never \
     clean package -pl jena-fuseki2/jena-fuseki-server -am -DskipTests -Dmaven.javadoc.skip=true
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-ubi10-minimal
 
 WORKDIR /fuseki
 

--- a/build-files/docker/loader-entrypoint.sh
+++ b/build-files/docker/loader-entrypoint.sh
@@ -3,23 +3,62 @@
 set -e
 
 CONFIG="${CONFIG:-/config/config.ttl}"
-JAVA_OPTS="${JAVA_OPTS:-}"
+INPUT_DIR="${INPUT_DIR:-/input}"
+OUTPUT_DIR="${OUTPUT_DIR:-/output/ds}"
+MODE="${MODE:-all}"
 SHACL_INDEX_FIRST_N="${SHACL_INDEX_FIRST_N:-}"
+SPATIAL_INDEX_SRS="${SPATIAL_INDEX_SRS:-}"
+JAVA_OPTS="${JAVA_OPTS:-}"
 
 if [ ! -f "$CONFIG" ]; then
   echo "Missing config: $CONFIG"
   exit 1
 fi
 
-echo "=== SHACL Text Index Build ==="
-echo "Config: $CONFIG"
-if [ -n "$SHACL_INDEX_FIRST_N" ]; then
-  echo "Limit: first $SHACL_INDEX_FIRST_N entities per SHACL profile"
-else
-  echo "Limit: full index"
+# Step 1: Load data files into TDB2
+if [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ]; then
+  echo "=== TDB2 Dataset Build ==="
+  FILES=$(ls "$INPUT_DIR"/*.nq "$INPUT_DIR"/*.ttl "$INPUT_DIR"/*.nt 2>/dev/null || true)
+  if [ -z "$FILES" ]; then
+    echo "No data files found in $INPUT_DIR"
+    exit 1
+  fi
+  java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar tdb2.tdbloader --loc "$OUTPUT_DIR" $FILES
 fi
 
-java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar \
-  org.apache.jena.query.text.cmd.shacltextindexer --desc="$CONFIG"
+# Build SHACL Lucene index
+if [ "$MODE" = "all" ] || [ "$MODE" = "text" ]; then
+  echo "=== SHACL Text Index Build ==="
+  echo "Config: $CONFIG"
+  if [ -n "$SHACL_INDEX_FIRST_N" ]; then
+    echo "Limit: first $SHACL_INDEX_FIRST_N entities per SHACL profile"
+  else
+    echo "Limit: full index"
+  fi
+
+  java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar \
+    org.apache.jena.query.text.cmd.shacltextindexer --desc="$CONFIG"
+fi
+
+# Build Spatial Index
+if [ "$MODE" = "all" ] || [ "$MODE" = "spatial" ]; then
+  echo "=== Spatial Index Build ==="
+  echo "Dataset: $OUTPUT_DIR"
+  if [ -n "$SPATIAL_INDEX_SRS" ]; then
+    echo "SRS: $SPATIAL_INDEX_SRS"
+  else
+    echo "SRS: auto-detect"
+  fi
+
+  SPATIAL_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar \
+    org.apache.jena.geosparql.spatial.cmd.SpatialIndexBuilder --loc=\"$OUTPUT_DIR\" \
+    --output=\"$OUTPUT_DIR/spatial.index\""
+  
+  if [ -n "$SPATIAL_INDEX_SRS" ]; then
+    SPATIAL_CMD="$SPATIAL_CMD --srs=\"$SPATIAL_INDEX_SRS\""
+  fi
+  
+  eval "$SPATIAL_CMD"
+fi
 
 echo "=== Done ==="

--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -46,6 +46,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-tdb2</artifactId>
+      <version>6.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-cmds</artifactId>
+      <version>6.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.sis.core</groupId>
       <artifactId>sis-referencing</artifactId>
     </dependency>

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/InitGeoSPARQL.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/InitGeoSPARQL.java
@@ -28,6 +28,7 @@ import org.apache.jena.geosparql.assembler.GeoAssembler;
 import org.apache.jena.geosparql.assembler.VocabGeoSPARQL;
 import org.apache.jena.geosparql.configuration.GeoSPARQLConfig;
 import org.apache.jena.geosparql.implementation.datatype.GeometryDatatype;
+import org.apache.jena.geosparql.spatial.cmd.InitSpatialCmds;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sys.JenaSubsystemLifecycle;
 import org.apache.jena.sys.JenaSystem;
@@ -68,6 +69,10 @@ public class InitGeoSPARQL implements JenaSubsystemLifecycle {
 
             AssemblerUtils.registerDataset(VocabGeoSPARQL.tGeoDataset,    assembler);
             AssemblerUtils.registerDataset(VocabGeoSPARQL.tGeoDatasetAlt, assembler);
+            
+            // Register spatial index command-line tools
+            InitSpatialCmds.cmds();
+            
             JenaSystem.logLifecycle("InitGeoSPARQL - finish");
         }
     }

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/cmd/InitSpatialCmds.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/cmd/InitSpatialCmds.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.geosparql.spatial.cmd;
+
+import org.apache.jena.cmd.Cmds;
+
+public class InitSpatialCmds {
+    public static void cmds() {
+        Cmds.injectCmd("spatialindexbuilder", a->SpatialIndexBuilder.main(a));
+    }
+}

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/cmd/SpatialIndexBuilder.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/cmd/SpatialIndexBuilder.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.geosparql.spatial.cmd;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.jena.atlas.logging.LogCtlJUL;
+import org.apache.jena.cmd.ArgDecl;
+import org.apache.jena.cmd.CmdException;
+import org.apache.jena.geosparql.InitGeoSPARQL;
+import org.apache.jena.geosparql.configuration.GeoSPARQLOperations;
+import org.apache.jena.geosparql.spatial.SpatialIndexException;
+import org.apache.jena.geosparql.spatial.index.v2.SpatialIndexIoKryo;
+import org.apache.jena.geosparql.spatial.index.v2.SpatialIndexLib;
+import org.apache.jena.geosparql.spatial.index.v2.SpatialIndexPerGraph;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.tdb2.TDB2Factory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import arq.cmdline.CmdARQ;
+
+/**
+ * CLI tool that builds a spatial index for a TDB2 dataset.
+ * <p>
+ * Use this after loading data with {@code tdb2.tdbloader}, which bypasses
+ * the normal spatial indexing.
+ * <p>
+ * Usage: {@code spatialindexbuilder --loc=DATASET_PATH [--srs=SRS_URI] [--verbose]}
+ */
+public class SpatialIndexBuilder extends CmdARQ {
+
+    private static Logger log = LoggerFactory.getLogger(SpatialIndexBuilder.class);
+
+    private static final ArgDecl argLoc = new ArgDecl(ArgDecl.HasValue, "loc");
+    private static final ArgDecl argSrs = new ArgDecl(ArgDecl.HasValue, "srs");
+    private static final ArgDecl argOutput = new ArgDecl(ArgDecl.HasValue, "output");
+
+    private String location = null;
+    private String srsURI = null;
+    private Path outputPath = null;
+
+    static public void main(String... argv) {
+        LogCtlJUL.routeJULtoSLF4J();
+        InitGeoSPARQL.init();  // Ensure GeoSPARQL is initialized
+        new SpatialIndexBuilder(argv).mainRun();
+    }
+
+    static public void testMain(String... argv) {
+        new SpatialIndexBuilder(argv).mainMethod();
+    }
+
+    protected SpatialIndexBuilder(String[] argv) {
+        super(argv);
+        super.add(argLoc, "--loc=", "Location of TDB2 dataset");
+        super.add(argSrs, "--srs=", "Spatial Reference System URI (optional)");
+        super.add(argOutput, "--output=", "Output file path for spatial index (optional)");
+        // Note: --verbose is provided by the base CmdARQ class, no need to add it here
+    }
+
+    @Override
+    protected void processModulesAndArgs() {
+        super.processModulesAndArgs();
+
+        if (!super.contains(argLoc)) {
+            throw new CmdException("No dataset location specified. Use --loc=PATH");
+        }
+        location = getValue(argLoc);
+
+        if (super.contains(argSrs)) {
+            srsURI = getValue(argSrs);
+        }
+        
+        if (super.contains(argOutput)) {
+            outputPath = Paths.get(getValue(argOutput));
+        }
+        
+        // Verbose logging is handled by the base class and logging configuration
+        // The --verbose flag is automatically available from CmdARQ
+    }
+
+    @Override
+    protected String getSummary() {
+        return getCommandName() + " --loc=DATASET_PATH [--srs=SRS_URI] [--output=OUTPUT_PATH] [--verbose]";
+    }
+
+    @Override
+    protected void exec() {
+        try {
+            // Load the TDB2 dataset
+            Dataset dataset = TDB2Factory.connectDataset(location);
+            
+            try {
+                // Auto-detect SRS if not provided
+                if (srsURI == null) {
+                    srsURI = GeoSPARQLOperations.findModeSRS(dataset);
+                }
+
+                log.info("Starting spatial index build...");
+                log.info("  Dataset: {}", location);
+                log.info("  SRS: {}", srsURI);
+                if (outputPath != null) {
+                    log.info("  Output: {}", outputPath.toAbsolutePath());
+                }
+
+                long startTime = System.currentTimeMillis();
+
+                // Build the spatial index
+                // Note: SpatialIndexLib.buildSpatialIndex handles its own transactions via AutoTxn
+                SpatialIndexPerGraph spatialIndex = SpatialIndexLib.buildSpatialIndex(dataset.asDatasetGraph(), srsURI);
+
+                long elapsed = System.currentTimeMillis() - startTime;
+                long seconds = Math.max(elapsed / 1000, 1);
+                log.info("Spatial index build complete in {} seconds", seconds);
+
+                // Save the spatial index to disk if output path is specified
+                if (outputPath != null) {
+                    log.info("Writing spatial index to disk...");
+                    spatialIndex.setLocation(outputPath);
+                    SpatialIndexIoKryo.save(outputPath, spatialIndex);
+                    log.info("Spatial index written to: {}", outputPath.toAbsolutePath());
+                }
+
+                // No transaction management needed here - SpatialIndexLib handles it internally
+            } finally {
+                dataset.close();
+            }
+        } catch (SpatialIndexException e) {
+            throw new CmdException("Failed to build spatial index: " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new CmdException("Error building spatial index: " + e.getMessage(), e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <!-- Logging -->
     <ver.slf4j>2.0.17</ver.slf4j>
-    <ver.log4j2>2.25.3</ver.log4j2>
+    <ver.log4j2>2.25.4</ver.log4j2>
 
     <!-- JSON-LD 1.1 -->
     <ver.titanium-json-ld>1.7.0</ver.titanium-json-ld>


### PR DESCRIPTION
Exposes the buildSpatialIndex method as a cmdline
cmd for the fuseki-server jar. Enables creation of
a spatial index without starting the main process.

Extends the capabilities already exposed in the entrypoint
script for the Dockerfile.loader so that the new spatial
index cmd can be called as part of the TDB2 building and
text indexing process.

Also:
  - adds TDB2 building back to the loader entrypoint

Security:
  - moves the Final Docker image base to `eclipse-temurin:21-jre-ubi10-minimal`
    to resolve critical security vulnerabilities in alpine
  - bumps the log4j-core version from 2.25.3 --> 2.25.4 to
    resolve another critical vulnerability

GitHub issue resolved #

Pull request Description:



----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
