### PR TITLE
Bulk Loader Improvements

### DIFF
--- a/build-files/docker/Dockerfile.loader
+++ b/build-files/docker/Dockerfile.loader
@@ -1,6 +1,6 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-FROM maven:3.9.9-eclipse-temurin-21-alpine AS builder
+FROM maven:3.9.9-eclipse-temurin-21 AS builder
 
 WORKDIR /build
 

--- a/build-files/docker/Dockerfile.loader
+++ b/build-files/docker/Dockerfile.loader
@@ -4,10 +4,42 @@ FROM maven:3.9.9-eclipse-temurin-21-alpine AS builder
 
 WORKDIR /build
 
-COPY . .
+# Copy only jena modules and pom.xml for caching
+COPY pom.xml ./
+COPY build-files/license-header build-files/license-header
+COPY build-files/rat-exclusions.txt build-files/rat-exclusions.txt
+COPY apache-jena/ apache-jena/
+COPY apache-jena-libs/ apache-jena-libs/
+COPY jena-arq/ jena-arq/
+COPY jena-base/ jena-base/
+COPY jena-benchmarks/ jena-benchmarks/
+COPY jena-bom/ jena-bom/
+COPY jena-cmds/ jena-cmds/
+COPY jena-commonsrdf/ jena-commonsrdf/
+COPY jena-core/ jena-core/
+COPY jena-db/ jena-db/
+COPY jena-examples/ jena-examples/
+COPY jena-fuseki2/ jena-fuseki2/
+COPY jena-geosparql/ jena-geosparql/
+COPY jena-integration-tests/ jena-integration-tests/
+COPY jena-iri3986/ jena-iri3986/
+COPY jena-langtag/ jena-langtag/
+COPY jena-ontapi/ jena-ontapi/
+COPY jena-querybuilder/ jena-querybuilder/
+COPY jena-rdfconnection/ jena-rdfconnection/
+COPY jena-rdfpatch/ jena-rdfpatch/
+COPY jena-serviceenhancer/ jena-serviceenhancer/
+COPY jena-shacl/ jena-shacl/
+COPY jena-shex/ jena-shex/
+COPY jena-tdb1/ jena-tdb1/
+COPY jena-tdb2/ jena-tdb2/
+COPY jena-text/ jena-text/
 
 RUN mvn --batch-mode --quiet --no-transfer-progress -Dstyle.color=never \
     clean package -pl jena-fuseki2/jena-fuseki-server -am -DskipTests -Dmaven.javadoc.skip=true
+
+# Copy remaining files
+COPY . .
 
 FROM eclipse-temurin:21-jre-ubi10-minimal
 
@@ -15,7 +47,5 @@ WORKDIR /fuseki
 
 COPY --from=builder /build/jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-*.jar ./jena-fuseki-server.jar
 COPY build-files/docker/loader-entrypoint.sh ./entrypoint.sh
-
-RUN chmod +x ./entrypoint.sh
 
 ENTRYPOINT ["/fuseki/entrypoint.sh"]

--- a/build-files/docker/Dockerfile.loader
+++ b/build-files/docker/Dockerfile.loader
@@ -35,17 +35,22 @@ COPY jena-tdb1/ jena-tdb1/
 COPY jena-tdb2/ jena-tdb2/
 COPY jena-text/ jena-text/
 
-RUN mvn --batch-mode --quiet --no-transfer-progress -Dstyle.color=never \
-    clean package -pl jena-fuseki2/jena-fuseki-server -am -DskipTests -Dmaven.javadoc.skip=true
+RUN mvn clean package -Pcomplete -DskipTests -Dmaven.javadoc.skip=true
 
 # Copy remaining files
 COPY . .
 
 FROM eclipse-temurin:21-jre-ubi10-minimal
 
+RUN microdnf install jq -y
+
 WORKDIR /fuseki
 
-COPY --from=builder /build/jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-*.jar ./jena-fuseki-server.jar
 COPY build-files/docker/loader-entrypoint.sh ./entrypoint.sh
+COPY --from=builder /build/jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-*.jar ./jena-fuseki-server.jar
+COPY --from=builder /build/apache-jena/target/apache-jena-*-SNAPSHOT.tar.gz .
+RUN mkdir -p /fuseki/apache-jena && \
+    tar -xzf apache-jena-*-SNAPSHOT.tar.gz -C /fuseki/apache-jena --strip-components=1 && \
+    rm apache-jena-*-SNAPSHOT.tar.gz
 
 ENTRYPOINT ["/fuseki/entrypoint.sh"]

--- a/build-files/docker/Dockerfile.runtime
+++ b/build-files/docker/Dockerfile.runtime
@@ -1,6 +1,6 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-FROM maven:3.9.9-eclipse-temurin-21-alpine AS builder
+FROM maven:3.9.9-eclipse-temurin-21 AS builder
 
 WORKDIR /build
 

--- a/build-files/docker/Dockerfile.runtime
+++ b/build-files/docker/Dockerfile.runtime
@@ -4,10 +4,42 @@ FROM maven:3.9.9-eclipse-temurin-21-alpine AS builder
 
 WORKDIR /build
 
-COPY . .
+# Copy only jena modules and pom.xml for caching
+COPY pom.xml ./
+COPY build-files/license-header build-files/license-header
+COPY build-files/rat-exclusions.txt build-files/rat-exclusions.txt
+COPY apache-jena/ apache-jena/
+COPY apache-jena-libs/ apache-jena-libs/
+COPY jena-arq/ jena-arq/
+COPY jena-base/ jena-base/
+COPY jena-benchmarks/ jena-benchmarks/
+COPY jena-bom/ jena-bom/
+COPY jena-cmds/ jena-cmds/
+COPY jena-commonsrdf/ jena-commonsrdf/
+COPY jena-core/ jena-core/
+COPY jena-db/ jena-db/
+COPY jena-examples/ jena-examples/
+COPY jena-fuseki2/ jena-fuseki2/
+COPY jena-geosparql/ jena-geosparql/
+COPY jena-integration-tests/ jena-integration-tests/
+COPY jena-iri3986/ jena-iri3986/
+COPY jena-langtag/ jena-langtag/
+COPY jena-ontapi/ jena-ontapi/
+COPY jena-querybuilder/ jena-querybuilder/
+COPY jena-rdfconnection/ jena-rdfconnection/
+COPY jena-rdfpatch/ jena-rdfpatch/
+COPY jena-serviceenhancer/ jena-serviceenhancer/
+COPY jena-shacl/ jena-shacl/
+COPY jena-shex/ jena-shex/
+COPY jena-tdb1/ jena-tdb1/
+COPY jena-tdb2/ jena-tdb2/
+COPY jena-text/ jena-text/
 
 RUN mvn --batch-mode --quiet --no-transfer-progress -Dstyle.color=never \
     clean package -pl jena-fuseki2/jena-fuseki-server -am -DskipTests -Dmaven.javadoc.skip=true
+
+# Copy remaining files
+COPY . .
 
 FROM eclipse-temurin:21-jre-ubi10-minimal
 
@@ -15,4 +47,4 @@ WORKDIR /fuseki
 
 COPY --from=builder /build/jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-*.jar ./jena-fuseki-server.jar
 
-ENTRYPOINT ["java", "-jar", "/fuseki/jena-fuseki-server.jar", "--config", "/config/config.ttl"]
+ENTRYPOINT ["java", "-jar", "--add-modules", "jdk.incubator.vector", "--enable-native-access", "ALL-UNNAMED", "/fuseki/jena-fuseki-server.jar", "--config", "/config/config.ttl"]

--- a/build-files/docker/Dockerfile.runtime
+++ b/build-files/docker/Dockerfile.runtime
@@ -47,4 +47,4 @@ WORKDIR /fuseki
 
 COPY --from=builder /build/jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-*.jar ./jena-fuseki-server.jar
 
-ENTRYPOINT ["java", "-jar", "--add-modules", "jdk.incubator.vector", "--enable-native-access", "ALL-UNNAMED", "/fuseki/jena-fuseki-server.jar", "--config", "/config/config.ttl"]
+ENTRYPOINT ["java", "-jar", "--add-modules", "jdk.incubator.vector", "--enable-native-access", "ALL-UNNAMED", "/fuseki/jena-fuseki-server.jar", "--config", "/config.ttl"]

--- a/build-files/docker/README.md
+++ b/build-files/docker/README.md
@@ -1,0 +1,155 @@
+# Docker Images
+
+This directory contains two Docker images for building and running Fuseki with
+SHACL-based text indexing, spatial indexing, and TDB2 datasets.
+
+## Images
+
+**Dockerfile.loader** — Bulk data loading and index building. Builds the Fuseki
+server jar from source, then runs `loader-entrypoint.sh` to load RDF data into
+TDB2 and optionally build text and spatial indexes.
+
+**Dockerfile.runtime** — Runs a Fuseki server with a mounted config and
+pre-built databases.
+
+## Loader Usage
+
+Load RDF files into a TDB2 dataset:
+
+```bash
+docker run \
+  -v "./data:/rdf" \
+  -v "./databases:/databases" \
+  -v "./config.ttl:/config.ttl" \
+  --rm \
+  ghcr.io/aiworkerjohns/jena-loader:latest
+```
+
+The loader reads the assembler config at `/config.ttl` to discover the TDB2
+location, text index directory, and spatial index file path via SPARQL queries
+against the config itself.
+
+Load with all indexes:
+
+```bash
+docker run \
+  -e "MODE=all" \
+  -v "./data:/rdf" \
+  -v "./databases:/databases" \
+  -v "./config.ttl:/config.ttl" \
+  --rm \
+  ghcr.io/aiworkerjohns/jena-loader:latest
+```
+
+## Environment Variables
+
+| Variable         | Purpose                                                        | Default                          |
+|------------------|----------------------------------------------------------------|----------------------------------|
+| `CONFIG`         | Path to the assembler config file inside the container         | `/config.ttl`                    |
+| `INPUT_DIR`      | Directory containing RDF files to load                         | `/rdf`                           |
+| `MODE`           | Processing mode (see below)                                    | `all`                            |
+| `TARGET_GRAPH`   | Named graph URI for triples (see TARGET_GRAPH section below)   | unset                            |
+| `NO_VALIDATION`  | If set, skip RDF validation with riot                          | unset (validation enabled)       |
+| `TDB2_MODE`      | Loader mode for tdb2.tdbloader: `phased`, `basic`, `sequential`, `parallel`, `light` | `phased` |
+| `NO_STATS`       | If set, skip tdb2.tdbstats generation after loading            | unset (stats generated)          |
+| `THREADS`        | Number of threads for xloader sort                             | `nproc - 1`                      |
+| `JAVA_OPTS`      | JVM arguments passed to the text and spatial indexer commands   | unset                            |
+
+## Modes
+
+| Mode             | What it does                                           |
+|------------------|--------------------------------------------------------|
+| `all`            | TDB2 load + text index + spatial index + stats         |
+| `tdb2`           | TDB2 load with tdb2.tdbloader + stats                 |
+| `tdb2.xloader`   | TDB2 load with tdb2.xloader + stats                   |
+| `index`          | Text index + spatial index (no TDB2 load)              |
+| `text`           | Text index only                                        |
+| `spatial`        | Spatial index only                                     |
+
+## Supported RDF Formats
+
+The loader discovers files in `INPUT_DIR` with extensions: `.trig`, `.nq`,
+`.ttl`, `.nt`, `.rdf`, `.xml`.
+
+## TARGET_GRAPH and Named Graphs
+
+`TARGET_GRAPH` sets `--graph` on the underlying Jena loader command, directing
+triples into a specific named graph. Its behavior depends on the loader and data
+format:
+
+| Scenario                   | tdb2.tdbloader                                       | tdb2.xloader        |
+|----------------------------|------------------------------------------------------|---------------------|
+| Triples + `TARGET_GRAPH`   | Loads into the named graph                           | **Not supported**   |
+| Quads + `TARGET_GRAPH`     | Only default graph triples go to named graph (warns) | **Not supported**   |
+| Quads, no `TARGET_GRAPH`   | Respects graph URIs in the data                      | Respects graph URIs in the data |
+| Triples, no `TARGET_GRAPH` | Loads into the default graph                         | Loads into the default graph    |
+
+**tdb2.tdbloader**: When `TARGET_GRAPH` is set and quad files (`.nq`, `.trig`)
+are provided, only the default graph portion is loaded into the target graph.
+Named graph data in the file is silently dropped, with a warning to stderr.
+
+**tdb2.xloader**: Does not accept `--graph` at all. It only recognizes `--loc`,
+`--tmpdir`, and `--threads`. Setting `TARGET_GRAPH` with `MODE=tdb2.xloader`
+will cause an error. To load triples into a named graph with xloader, convert
+the data to a quad format (`.nq` or `.trig`) with the desired graph URI before
+loading.
+
+**Quad files without TARGET_GRAPH**: Both loaders respect the graph URIs
+embedded in the data. This is the expected way to load data into named graphs.
+
+**xloader volume mounts**: xloader requires `--loc` to point to a directory that
+does not yet exist (it creates it). When using Docker, mount the volume at the
+**parent** of the `tdb2:location` path, not the location itself. For example, if
+the config has `tdb2:location "/data/DB/ds"`, mount the volume at `/data/DB`:
+
+```yaml
+volumes:
+  - my-volume:/data/DB    # parent of tdb2:location
+```
+
+If the volume is mounted directly at the `tdb2:location` path, xloader will fail
+because Docker pre-creates the mount point directory.
+
+## Runtime Usage
+
+Run Fuseki with pre-built databases:
+
+```bash
+docker run \
+  -v "./databases:/databases" \
+  -v "./config.ttl:/config/config.ttl" \
+  -p 3030:3030 \
+  ghcr.io/aiworkerjohns/jena-runtime:latest
+```
+
+The runtime image starts Fuseki with `--config /config/config.ttl` and enables
+the `jdk.incubator.vector` module for native access.
+
+## Building Locally
+
+From the repository root:
+
+```bash
+# Loader image
+docker build -f build-files/docker/Dockerfile.loader -t jena-loader:dev .
+
+# Runtime image
+docker build -f build-files/docker/Dockerfile.runtime -t jena-runtime:dev .
+```
+
+Both Dockerfiles use a multi-stage build: Maven builds `jena-fuseki-server.jar`
+from source (skipping tests and javadoc), then copies the jar into an
+`eclipse-temurin:21-jre` runtime image.
+
+## Testing xloader
+
+A test harness in `test-xloader/` verifies xloader behavior with multiple input
+files:
+
+```bash
+cd build-files/docker/test-xloader
+task test
+```
+
+This loads two TTL files (4 subjects total) via xloader and queries the result
+to confirm all data was loaded.

--- a/build-files/docker/loader-entrypoint.sh
+++ b/build-files/docker/loader-entrypoint.sh
@@ -221,32 +221,61 @@ if [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; 
   echo "=== TDB2 Dataset Build ==="
   
   if [ "$MODE" = "tdb2.xloader" ]; then
-    echo "Setting JENA_HOME to /fuseki/apache-jena"
+    echo "Using tdb2.xloader (shell script)"
+    if [ -n "$TARGET_GRAPH" ]; then
+      echo "WARNING: TARGET_GRAPH is set but tdb2.xloader does not support --graph."
+      echo "WARNING: To load into a named graph with xloader, convert data to .nq/.trig format."
+      echo "WARNING: TARGET_GRAPH will be ignored."
+    fi
+    XLOADER_TMPDIR="${XLOADER_TMPDIR:-/tmp}"
+    echo "WARNING: XLOADER TMPDIR IS SET TO $XLOADER_TMPDIR."
+    echo "WARNING: FOR LARGE DATASETS, SET XLOADER_TMPDIR TO A SEPARATE FAST DISK (NVME IF POSSIBLE)."
+
+    # xloader shell script requires --loc to not exist (it creates it).
+    # Mount Docker volumes at the PARENT of the tdb2:location, not the location
+    # itself, so xloader can create the leaf directory.
+    CLEAN_LOC=$(echo "$TDB2_LOCATION" | sed 's/^"//; s/"$//')
+    if [ -d "$CLEAN_LOC" ]; then
+      echo "ERROR: TDB2 location $CLEAN_LOC already exists."
+      echo "ERROR: xloader requires --loc to not exist. Mount the Docker volume at"
+      echo "ERROR: the PARENT directory and set tdb2:location to a subdirectory."
+      echo "ERROR: e.g. mount at /data/DB, set tdb2:location to /data/DB/ds"
+      exit 1
+    fi
+
     export JENA_HOME="/fuseki/apache-jena"
-    echo "Using tdb2.xloader"
-    LOADER_CMD="$TDB2_XLOADER_CMD --loc $TDB2_LOCATION"
+    export JVM_ARGS="${JAVA_OPTS:--Xmx4G}"
+    LOADER_CMD="$TDB2_XLOADER_CMD --loc $CLEAN_LOC --tmpdir $XLOADER_TMPDIR"
+    if [ -n "$THREADS" ]; then
+      LOADER_CMD="$LOADER_CMD --threads $THREADS"
+    fi
+
+    # Add all files to loader command
+    for file in $FILES; do
+      LOADER_CMD="$LOADER_CMD \"$file\""
+    done
+
+    echo "Loader command: $LOADER_CMD"
+    eval "$LOADER_CMD"
+
+    EFFECTIVE_TDB2_LOCATION="$CLEAN_LOC"
   else
     echo "Using tdb2.tdbloader with mode $TDB2_MODE"
     LOADER_CMD="$TDB2_LOADER_CMD --loader=$TDB2_MODE --loc $TDB2_LOCATION"
+    if [ -n "$TARGET_GRAPH" ]; then
+      LOADER_CMD="$LOADER_CMD --graph $TARGET_GRAPH"
+    fi
+
+    # Add all files to loader command
+    for file in $FILES; do
+      LOADER_CMD="$LOADER_CMD \"$file\""
+    done
+
+    echo "Loader command: $LOADER_CMD"
+    eval "$LOADER_CMD"
+
+    EFFECTIVE_TDB2_LOCATION=$(echo "$TDB2_LOCATION" | sed 's/^"//; s/"$//')
   fi
-  
-  # Add target graph if specified
-  if [ -n "$TARGET_GRAPH" ]; then
-    LOADER_CMD="$LOADER_CMD --graph $TARGET_GRAPH"
-  fi
-  
-  # Add threads if specified (only for xloader)
-  if [ "$MODE" = "tdb2.xloader" ] && [ -n "$THREADS" ]; then
-    LOADER_CMD="$LOADER_CMD --threads $THREADS"
-  fi
-  
-  # Add all files to loader command
-  for file in $FILES; do
-    LOADER_CMD="$LOADER_CMD \"$file\""
-  done
-  
-  echo "Loader command: $LOADER_CMD"
-  eval "$LOADER_CMD"
 fi
 
 # Text Indexing
@@ -278,28 +307,27 @@ fi
 # Statistics
 if [ -z "$NO_STATS" ] && { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; }; then
   echo "=== Generating Statistics ==="
-  # Clean up TDB2_LOCATION in case it has extra quotes
-  CLEAN_TDB2_LOCATION=$(echo "$TDB2_LOCATION" | sed 's/^"//; s/"$//')
-  STATS_FILE="${CLEAN_TDB2_LOCATION}/stats.opt"
-  
-  echo "DEBUG: Clean TDB2 location: $CLEAN_TDB2_LOCATION"
-  echo "DEBUG: Stats file path: $STATS_FILE"
-  
+  STATS_LOC="${EFFECTIVE_TDB2_LOCATION}"
+  STATS_FILE="${STATS_LOC}/stats.opt"
+
+  echo "TDB2 location for stats: $STATS_LOC"
+  echo "Stats file path: $STATS_FILE"
+
   # Run stats command and capture both output and exit code
-  STATS_OUTPUT=$($TDB2_STATS_CMD --graph "urn:x-arq:UnionGraph" --loc "$CLEAN_TDB2_LOCATION" 2>&1)
-  
+  STATS_OUTPUT=$($TDB2_STATS_CMD --graph "urn:x-arq:UnionGraph" --loc "$STATS_LOC" 2>&1)
+
   # Show warnings to user but still create stats file
   echo "$STATS_OUTPUT" | grep -v "^WARN" > "$STATS_FILE"
-  
+
   # Show any warnings to the user
   echo "$STATS_OUTPUT" | grep "^WARN" | while read -r warning; do
     echo "$warning"
   done
-  
+
   # If stats file is empty, try without the UnionGraph
   if [ ! -s "$STATS_FILE" ]; then
-    echo "DEBUG: Stats file empty, trying without UnionGraph"
-    $TDB2_STATS_CMD --loc "$CLEAN_TDB2_LOCATION" > "$STATS_FILE" 2>&1
+    echo "Stats file empty, trying without UnionGraph"
+    $TDB2_STATS_CMD --loc "$STATS_LOC" > "$STATS_FILE" 2>&1
   fi
   
   # Show final result

--- a/build-files/docker/loader-entrypoint.sh
+++ b/build-files/docker/loader-entrypoint.sh
@@ -182,7 +182,7 @@ if { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]
   WARNING_FILES=""
   
   for file in $FILES; do
-    validation_output=$($RIOT_CMD --validate "$file" 2>&1)
+    validation_output="$($RIOT_CMD --validate "$file" 2>&1 || true)"
     
     if echo "$validation_output" | grep -q 'ERROR'; then
       echo "$file: ❌"

--- a/build-files/docker/loader-entrypoint.sh
+++ b/build-files/docker/loader-entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
-set -e
 
 # Configuration variables
 CONFIG="${CONFIG:-/config.ttl}"
@@ -14,11 +13,11 @@ THREADS="${THREADS:-$(($(nproc) > 1 ? $(nproc) - 1 : 1))}"
 JAVA_OPTS="${JAVA_OPTS:-}"
 
 # Define all Jena command variables
-SPARQL_CMD="java -cp /fuseki/jena-fuseki-server.jar arq.sparql"
-RIOT_CMD="java -cp /fuseki/jena-fuseki-server.jar riotcmd.riot"
-TDB2_LOADER_CMD="java -cp /fuseki/jena-fuseki-server.jar tdb2.tdbloader"
-TDB2_XLOADER_CMD="/fuseki/apache-jena/bin/tdb2.xloader"
-TDB2_STATS_CMD="java -cp /fuseki/jena-fuseki-server.jar tdb2.tdbstats"
+SPARQL_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar arq.sparql"
+RIOT_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar riotcmd.riot"
+TDB2_LOADER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar tdb2.tdbloader"
+TDB2_XLOADER_CMD="JVM_ARGS=\"${JAVA_OPTS}\" /fuseki/apache-jena/bin/tdb2.xloader"
+TDB2_STATS_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar tdb2.tdbstats"
 TEXT_INDEXER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.query.text.cmd.shacltextindexer"
 SPATIAL_INDEXER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.geosparql.spatial.cmd.SpatialIndexBuilder"
 
@@ -55,7 +54,7 @@ SRS_QUERY="/tmp/srs_uri.rq"
   echo '  ?s a tdb2:DatasetTDB2 ;'
   echo '     tdb2:location ?tdb2Location .'
   echo '}'
-} > "$TDB2_QUERY"
+} >"$TDB2_QUERY"
 
 # Write text index location query
 {
@@ -64,7 +63,7 @@ SRS_QUERY="/tmp/srs_uri.rq"
   echo '  ?s a text:TextIndexShacl ;'
   echo '     text:directory ?shaclIndexDirectory .'
   echo '}'
-} > "$TEXT_QUERY"
+} >"$TEXT_QUERY"
 
 # Write spatial index location query
 {
@@ -73,7 +72,7 @@ SRS_QUERY="/tmp/srs_uri.rq"
   echo '  ?s a geosparql:geosparqlDataset ;'
   echo '     geosparql:spatialIndexFile ?spatialIndexFile .'
   echo '}'
-} > "$SPATIAL_QUERY"
+} >"$SPATIAL_QUERY"
 
 # Write SRS URI query
 {
@@ -82,19 +81,47 @@ SRS_QUERY="/tmp/srs_uri.rq"
   echo '  ?s a geosparql:geosparqlDataset ;'
   echo '     geosparql:srsUri ?srsUri .'
   echo '}'
-} > "$SRS_QUERY"
+} >"$SRS_QUERY"
 
 # Extract TDB2 location using Java-based SPARQL
-TDB2_LOCATION=$($SPARQL_CMD --query="$TDB2_QUERY" --data="$CONFIG" --results=tsv 2>/dev/null | awk 'NR==2 {print $1}')
+tdb2_result_and_status="$($SPARQL_CMD --query="$TDB2_QUERY" --data="$CONFIG" --results=tsv 2>&1)"
+tdb2_status=$?
+if [ "$tdb2_status" -ne 0 ]; then
+  echo "ERROR extracting TDB2 location:" >&2
+  echo "$tdb2_result_and_status" >&2
+  exit 1
+fi
+TDB2_LOCATION=$(echo "$tdb2_result_and_status" | awk 'NR==2 {print $1}')
 
 # Extract text index location using Java-based SPARQL
-TEXT_INDEX_LOCATION=$($SPARQL_CMD --query="$TEXT_QUERY" --data="$CONFIG" --results=tsv 2>/dev/null | awk 'NR==2 {print $1}')
+text_result_and_status="$($SPARQL_CMD --query="$TEXT_QUERY" --data="$CONFIG" --results=tsv 2>&1)"
+text_status=$?
+if [ "$text_status" -ne 0 ]; then
+  echo "ERROR extracting text index location:" >&2
+  echo "$text_result_and_status" >&2
+  exit 1
+fi
+TEXT_INDEX_LOCATION=$(echo "$text_result_and_status" | awk 'NR==2 {print $1}')
 
 # Extract spatial index location using Java-based SPARQL
-SPATIAL_INDEX_LOCATION=$($SPARQL_CMD --query="$SPATIAL_QUERY" --data="$CONFIG" --results=tsv 2>/dev/null | awk 'NR==2 {print $1}')
+spatial_result_and_status="$($SPARQL_CMD --query="$SPATIAL_QUERY" --data="$CONFIG" --results=tsv 2>&1)"
+spatial_status=$?
+if [ "$spatial_status" -ne 0 ]; then
+  echo "ERROR extracting spatial index location:" >&2
+  echo "$spatial_result_and_status" >&2
+  exit 1
+fi
+SPATIAL_INDEX_LOCATION=$(echo "$spatial_result_and_status" | awk 'NR==2 {print $1}')
 
 # Extract SRS URI for spatial indexing using Java-based SPARQL
-SRS_URI=$($SPARQL_CMD --query="$SRS_QUERY" --data="$CONFIG" --results=tsv 2>/dev/null | awk 'NR==2 {print $1}' | sed 's/^[<>]//g; s/[<>]$//g')
+srs_result_and_status="$($SPARQL_CMD --query="$SRS_QUERY" --data="$CONFIG" --results=tsv 2>&1)"
+srs_status=$?
+if [ "$srs_status" -ne 0 ]; then
+  echo "ERROR extracting SRS URI:" >&2
+  echo "$srs_result_and_status" >&2
+  exit 1
+fi
+SRS_URI=$(echo "$srs_result_and_status" | awk 'NR==2 {print $1}' | sed 's/^[<>]//g; s/[<>]$//g')
 
 # Clean up temporary query files
 rm -f "$TDB2_QUERY" "$TEXT_QUERY" "$SPATIAL_QUERY" "$SRS_QUERY"
@@ -108,7 +135,7 @@ echo "SRS_URI: ${SRS_URI:-Not specified in config (will use default behavior)}"
 check_volume_mount() {
   path="$1"
   parent_path=""
-  
+
   # Check if path or any parent is mounted
   while [ "$path" != "/" ]; do
     if grep -q " $path " /proc/mounts; then
@@ -120,7 +147,7 @@ check_volume_mount() {
     fi
     path="$parent_path"
   done
-  
+
   echo "WARNING: No volume mount found for $path or its parents"
   return 1
 }
@@ -176,14 +203,14 @@ fi
 # Validation (only for TDB2 loading modes and when not disabled)
 if { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; } && [ -z "$NO_VALIDATION" ]; then
   echo "=== Validating RDF files ==="
-  
+
   VALID_FILES=""
   INVALID_FILES=""
   WARNING_FILES=""
-  
+
   for file in $FILES; do
     validation_output="$($RIOT_CMD --validate "$file" 2>&1 || true)"
-    
+
     if echo "$validation_output" | grep -q 'ERROR'; then
       echo "$file: ❌"
       INVALID_FILES="$INVALID_FILES $file"
@@ -196,8 +223,7 @@ if { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]
       VALID_FILES="$VALID_FILES $file"
     fi
   done
-  
-  
+
   echo "Validation Summary:"
   valid_count=$(echo "$VALID_FILES" | wc -w)
   echo "  Valid files: $valid_count"
@@ -205,7 +231,7 @@ if { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]
   echo "  Files with warnings: $warning_count"
   invalid_count=$(echo "$INVALID_FILES" | wc -w)
   echo "  Invalid files: $invalid_count"
-  
+
   # Exclude invalid files from processing
   FILES="$VALID_FILES"
   if [ -z "$FILES" ]; then
@@ -219,7 +245,7 @@ fi
 # TDB2 Loading
 if [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; then
   echo "=== TDB2 Dataset Build ==="
-  
+
   if [ "$MODE" = "tdb2.xloader" ]; then
     echo "Using tdb2.xloader (shell script)"
     if [ -n "$TARGET_GRAPH" ]; then
@@ -283,7 +309,7 @@ if [ "$MODE" = "all" ] || [ "$MODE" = "index" ] || [ "$MODE" = "text" ]; then
   echo "=== SHACL Text Index Build ==="
   echo "Config: $CONFIG"
   echo "Text index location: $TEXT_INDEX_LOCATION"
-  
+
   $TEXT_INDEXER_CMD --desc="$CONFIG"
 fi
 
@@ -293,14 +319,14 @@ if [ "$MODE" = "all" ] || [ "$MODE" = "index" ] || [ "$MODE" = "spatial" ]; then
   echo "Dataset: $TDB2_LOCATION"
   echo "Spatial index location: $SPATIAL_INDEX_LOCATION"
   echo "SRS_URI: ${SRS_URI:-auto-detect}"
-  
+
   SPATIAL_CMD="$SPATIAL_INDEXER_CMD --loc=\"$TDB2_LOCATION\" --output=\"$SPATIAL_INDEX_LOCATION\""
-  
+
   # Add SRS_URI if specified in config
   if [ -n "$SRS_URI" ]; then
     SPATIAL_CMD="$SPATIAL_CMD --srs=\"$SRS_URI\""
   fi
-  
+
   eval "$SPATIAL_CMD"
 fi
 
@@ -317,7 +343,7 @@ if [ -z "$NO_STATS" ] && { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MO
   STATS_OUTPUT=$($TDB2_STATS_CMD --graph "urn:x-arq:UnionGraph" --loc "$STATS_LOC" 2>&1)
 
   # Show warnings to user but still create stats file
-  echo "$STATS_OUTPUT" | grep -v "^WARN" > "$STATS_FILE"
+  echo "$STATS_OUTPUT" | grep -v "^WARN" >"$STATS_FILE"
 
   # Show any warnings to the user
   echo "$STATS_OUTPUT" | grep "^WARN" | while read -r warning; do
@@ -327,16 +353,16 @@ if [ -z "$NO_STATS" ] && { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MO
   # If stats file is empty, try without the UnionGraph
   if [ ! -s "$STATS_FILE" ]; then
     echo "Stats file empty, trying without UnionGraph"
-    $TDB2_STATS_CMD --loc "$STATS_LOC" > "$STATS_FILE" 2>&1
+    $TDB2_STATS_CMD --loc "$STATS_LOC" >"$STATS_FILE" 2>&1
   fi
-  
+
   # Show final result
   if [ -s "$STATS_FILE" ]; then
     echo "Statistics generated successfully at $STATS_FILE"
   else
     echo "WARNING: Statistics file is empty - dataset may be empty or have issues"
   fi
-  
+
   echo "Statistics generated at $STATS_FILE"
   echo "First 5 lines:"
   head -n 5 "$STATS_FILE"

--- a/build-files/docker/loader-entrypoint.sh
+++ b/build-files/docker/loader-entrypoint.sh
@@ -17,7 +17,7 @@ JAVA_OPTS="${JAVA_OPTS:-}"
 SPARQL_CMD="java -cp /fuseki/jena-fuseki-server.jar arq.sparql"
 RIOT_CMD="java -cp /fuseki/jena-fuseki-server.jar riotcmd.riot"
 TDB2_LOADER_CMD="java -cp /fuseki/jena-fuseki-server.jar tdb2.tdbloader"
-TDB2_XLOADER_CMD="java -cp /fuseki/jena-fuseki-server.jar tdb2.xloader"
+TDB2_XLOADER_CMD="/fuseki/apache-jena/bin/tdb2.xloader"
 TDB2_STATS_CMD="java -cp /fuseki/jena-fuseki-server.jar tdb2.tdbstats"
 TEXT_INDEXER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.query.text.cmd.shacltextindexer"
 SPATIAL_INDEXER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.geosparql.spatial.cmd.SpatialIndexBuilder"
@@ -221,6 +221,8 @@ if [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; 
   echo "=== TDB2 Dataset Build ==="
   
   if [ "$MODE" = "tdb2.xloader" ]; then
+    echo "Setting JENA_HOME to /fuseki/apache-jena"
+    export JENA_HOME="/fuseki/apache-jena"
     echo "Using tdb2.xloader"
     LOADER_CMD="$TDB2_XLOADER_CMD --loc $TDB2_LOCATION"
   else

--- a/build-files/docker/loader-entrypoint.sh
+++ b/build-files/docker/loader-entrypoint.sh
@@ -2,63 +2,318 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 set -e
 
-CONFIG="${CONFIG:-/config/config.ttl}"
-INPUT_DIR="${INPUT_DIR:-/input}"
-OUTPUT_DIR="${OUTPUT_DIR:-/output/ds}"
+# Configuration variables
+CONFIG="${CONFIG:-/config.ttl}"
+INPUT_DIR="${INPUT_DIR:-/rdf}"
 MODE="${MODE:-all}"
-SHACL_INDEX_FIRST_N="${SHACL_INDEX_FIRST_N:-}"
-SPATIAL_INDEX_SRS="${SPATIAL_INDEX_SRS:-}"
+TARGET_GRAPH="${TARGET_GRAPH:-}"
+NO_VALIDATION="${NO_VALIDATION:-}"
+TDB2_MODE="${TDB2_MODE:-phased}"
+NO_STATS="${NO_STATS:-}"
+THREADS="${THREADS:-$(($(nproc) > 1 ? $(nproc) - 1 : 1))}"
 JAVA_OPTS="${JAVA_OPTS:-}"
 
+# Define all Jena command variables
+SPARQL_CMD="java -cp /fuseki/jena-fuseki-server.jar arq.sparql"
+RIOT_CMD="java -cp /fuseki/jena-fuseki-server.jar riotcmd.riot"
+TDB2_LOADER_CMD="java -cp /fuseki/jena-fuseki-server.jar tdb2.tdbloader"
+TDB2_XLOADER_CMD="java -cp /fuseki/jena-fuseki-server.jar tdb2.xloader"
+TDB2_STATS_CMD="java -cp /fuseki/jena-fuseki-server.jar tdb2.tdbstats"
+TEXT_INDEXER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.query.text.cmd.shacltextindexer"
+SPATIAL_INDEXER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.geosparql.spatial.cmd.SpatialIndexBuilder"
+
+echo "=== Loader Configuration ==="
+echo "CONFIG: $CONFIG"
+echo "INPUT_DIR: $INPUT_DIR"
+echo "MODE: $MODE"
+echo "TARGET_GRAPH: ${TARGET_GRAPH:-default graph}"
+echo "NO_VALIDATION: ${NO_VALIDATION:-false}"
+echo "TDB2_MODE: $TDB2_MODE"
+echo "THREADS: $THREADS (default: nproc-1)"
+echo "NO_STATS: ${NO_STATS:-false}"
+echo "==========================="
+
+# Early failure checks
 if [ ! -f "$CONFIG" ]; then
-  echo "Missing config: $CONFIG"
+  echo "ERROR: Missing config file at $CONFIG"
   exit 1
 fi
 
-# Step 1: Load data files into TDB2
-if [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ]; then
-  echo "=== TDB2 Dataset Build ==="
-  FILES=$(ls "$INPUT_DIR"/*.nq "$INPUT_DIR"/*.ttl "$INPUT_DIR"/*.nt 2>/dev/null || true)
-  if [ -z "$FILES" ]; then
-    echo "No data files found in $INPUT_DIR"
+# Extract locations from config
+echo "=== Extracting locations from config ==="
+
+# Create temporary query files
+TDB2_QUERY="/tmp/tdb2_location.rq"
+TEXT_QUERY="/tmp/text_location.rq"
+SPATIAL_QUERY="/tmp/spatial_location.rq"
+SRS_QUERY="/tmp/srs_uri.rq"
+
+# Write TDB2 location query
+{
+  echo 'PREFIX tdb2: <http://jena.apache.org/2016/tdb#>'
+  echo 'SELECT ?tdb2Location WHERE {'
+  echo '  ?s a tdb2:DatasetTDB2 ;'
+  echo '     tdb2:location ?tdb2Location .'
+  echo '}'
+} > "$TDB2_QUERY"
+
+# Write text index location query
+{
+  echo 'PREFIX text: <http://jena.apache.org/text#>'
+  echo 'SELECT ?shaclIndexDirectory WHERE {'
+  echo '  ?s a text:TextIndexShacl ;'
+  echo '     text:directory ?shaclIndexDirectory .'
+  echo '}'
+} > "$TEXT_QUERY"
+
+# Write spatial index location query
+{
+  echo 'PREFIX geosparql: <http://jena.apache.org/geosparql#>'
+  echo 'SELECT ?spatialIndexFile WHERE {'
+  echo '  ?s a geosparql:geosparqlDataset ;'
+  echo '     geosparql:spatialIndexFile ?spatialIndexFile .'
+  echo '}'
+} > "$SPATIAL_QUERY"
+
+# Write SRS URI query
+{
+  echo 'PREFIX geosparql: <http://jena.apache.org/geosparql#>'
+  echo 'SELECT ?srsUri WHERE {'
+  echo '  ?s a geosparql:geosparqlDataset ;'
+  echo '     geosparql:srsUri ?srsUri .'
+  echo '}'
+} > "$SRS_QUERY"
+
+# Extract TDB2 location using Java-based SPARQL
+TDB2_LOCATION=$($SPARQL_CMD --query="$TDB2_QUERY" --data="$CONFIG" --results=tsv 2>/dev/null | awk 'NR==2 {print $1}')
+
+# Extract text index location using Java-based SPARQL
+TEXT_INDEX_LOCATION=$($SPARQL_CMD --query="$TEXT_QUERY" --data="$CONFIG" --results=tsv 2>/dev/null | awk 'NR==2 {print $1}')
+
+# Extract spatial index location using Java-based SPARQL
+SPATIAL_INDEX_LOCATION=$($SPARQL_CMD --query="$SPATIAL_QUERY" --data="$CONFIG" --results=tsv 2>/dev/null | awk 'NR==2 {print $1}')
+
+# Extract SRS URI for spatial indexing using Java-based SPARQL
+SRS_URI=$($SPARQL_CMD --query="$SRS_QUERY" --data="$CONFIG" --results=tsv 2>/dev/null | awk 'NR==2 {print $1}' | sed 's/^[<>]//g; s/[<>]$//g')
+
+# Clean up temporary query files
+rm -f "$TDB2_QUERY" "$TEXT_QUERY" "$SPATIAL_QUERY" "$SRS_QUERY"
+
+echo "TDB2_LOCATION: ${TDB2_LOCATION:-Not found in config}"
+echo "TEXT_INDEX_LOCATION: ${TEXT_INDEX_LOCATION:-Not found in config}"
+echo "SPATIAL_INDEX_LOCATION: ${SPATIAL_INDEX_LOCATION:-Not found in config}"
+echo "SRS_URI: ${SRS_URI:-Not specified in config (will use default behavior)}"
+
+# Validate required locations based on mode
+check_volume_mount() {
+  path="$1"
+  parent_path=""
+  
+  # Check if path or any parent is mounted
+  while [ "$path" != "/" ]; do
+    if grep -q " $path " /proc/mounts; then
+      return 0
+    fi
+    parent_path="$(dirname "$path")"
+    if [ "$parent_path" = "$path" ]; then
+      break
+    fi
+    path="$parent_path"
+  done
+  
+  echo "WARNING: No volume mount found for $path or its parents"
+  return 1
+}
+
+# Check required locations
+if [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; then
+  if [ -z "$TDB2_LOCATION" ]; then
+    echo "ERROR: TDB2 location not found in config but required for mode $MODE"
     exit 1
   fi
-  java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar tdb2.tdbloader --loc "$OUTPUT_DIR" $FILES
+  if ! check_volume_mount "$TDB2_LOCATION"; then
+    echo "WARNING: TDB2 location volume check failed, but continuing anyway"
+  fi
 fi
 
-# Build SHACL Lucene index
-if [ "$MODE" = "all" ] || [ "$MODE" = "text" ]; then
+if [ "$MODE" = "all" ] || [ "$MODE" = "index" ] || [ "$MODE" = "text" ]; then
+  if [ -z "$TEXT_INDEX_LOCATION" ]; then
+    echo "ERROR: Text index location not found in config but required for mode $MODE"
+    exit 1
+  fi
+  if ! check_volume_mount "$TEXT_INDEX_LOCATION"; then
+    echo "WARNING: Text index location volume check failed, but continuing anyway"
+  fi
+fi
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "index" ] || [ "$MODE" = "spatial" ]; then
+  if [ -z "$SPATIAL_INDEX_LOCATION" ]; then
+    echo "ERROR: Spatial index location not found in config but required for mode $MODE"
+    exit 1
+  fi
+  if ! check_volume_mount "$SPATIAL_INDEX_LOCATION"; then
+    echo "WARNING: Spatial index location volume check failed, but continuing anyway"
+  fi
+fi
+
+# Find all RDF files (only needed for TDB2 loading modes)
+if [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; then
+  echo "=== Finding RDF files ==="
+  FILES=$(find "$INPUT_DIR" -type f \( -name "*.trig" -o -name "*.nq" -o -name "*.ttl" -o -name "*.nt" -o -name "*.rdf" -o -name "*.xml" \) 2>/dev/null || true)
+
+  if [ -z "$FILES" ]; then
+    echo "ERROR: No RDF files found in $INPUT_DIR"
+    exit 1
+  fi
+
+  file_count=$(echo "$FILES" | wc -l)
+  echo "Found $file_count RDF files:"
+  for file in $FILES; do
+    echo "  - $file"
+  done
+fi
+
+# Validation (only for TDB2 loading modes and when not disabled)
+if { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; } && [ -z "$NO_VALIDATION" ]; then
+  echo "=== Validating RDF files ==="
+  
+  VALID_FILES=""
+  INVALID_FILES=""
+  WARNING_FILES=""
+  
+  for file in $FILES; do
+    validation_output=$($RIOT_CMD --validate "$file" 2>&1)
+    
+    if echo "$validation_output" | grep -q 'ERROR'; then
+      echo "$file: ❌"
+      INVALID_FILES="$INVALID_FILES $file"
+    elif echo "$validation_output" | grep -q 'WARN'; then
+      echo "$file: ⚠️"
+      WARNING_FILES="$WARNING_FILES $file"
+      VALID_FILES="$VALID_FILES $file"
+    else
+      echo "$file: ✅"
+      VALID_FILES="$VALID_FILES $file"
+    fi
+  done
+  
+  
+  echo "Validation Summary:"
+  valid_count=$(echo "$VALID_FILES" | wc -w)
+  echo "  Valid files: $valid_count"
+  warning_count=$(echo "$WARNING_FILES" | wc -w)
+  echo "  Files with warnings: $warning_count"
+  invalid_count=$(echo "$INVALID_FILES" | wc -w)
+  echo "  Invalid files: $invalid_count"
+  
+  # Exclude invalid files from processing
+  FILES="$VALID_FILES"
+  if [ -z "$FILES" ]; then
+    echo "ERROR: No valid files to process"
+    exit 1
+  fi
+else
+  echo "Skipping validation (NO_VALIDATION set or mode doesn't require it)"
+fi
+
+# TDB2 Loading
+if [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; then
+  echo "=== TDB2 Dataset Build ==="
+  
+  if [ "$MODE" = "tdb2.xloader" ]; then
+    echo "Using tdb2.xloader"
+    LOADER_CMD="$TDB2_XLOADER_CMD --loc $TDB2_LOCATION"
+  else
+    echo "Using tdb2.tdbloader with mode $TDB2_MODE"
+    LOADER_CMD="$TDB2_LOADER_CMD --loader=$TDB2_MODE --loc $TDB2_LOCATION"
+  fi
+  
+  # Add target graph if specified
+  if [ -n "$TARGET_GRAPH" ]; then
+    LOADER_CMD="$LOADER_CMD --graph $TARGET_GRAPH"
+  fi
+  
+  # Add threads if specified (only for xloader)
+  if [ "$MODE" = "tdb2.xloader" ] && [ -n "$THREADS" ]; then
+    LOADER_CMD="$LOADER_CMD --threads $THREADS"
+  fi
+  
+  # Add all files to loader command
+  for file in $FILES; do
+    LOADER_CMD="$LOADER_CMD \"$file\""
+  done
+  
+  echo "Loader command: $LOADER_CMD"
+  eval "$LOADER_CMD"
+fi
+
+# Text Indexing
+if [ "$MODE" = "all" ] || [ "$MODE" = "index" ] || [ "$MODE" = "text" ]; then
   echo "=== SHACL Text Index Build ==="
   echo "Config: $CONFIG"
-  if [ -n "$SHACL_INDEX_FIRST_N" ]; then
-    echo "Limit: first $SHACL_INDEX_FIRST_N entities per SHACL profile"
-  else
-    echo "Limit: full index"
-  fi
-
-  java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar \
-    org.apache.jena.query.text.cmd.shacltextindexer --desc="$CONFIG"
+  echo "Text index location: $TEXT_INDEX_LOCATION"
+  
+  $TEXT_INDEXER_CMD --desc="$CONFIG"
 fi
 
-# Build Spatial Index
-if [ "$MODE" = "all" ] || [ "$MODE" = "spatial" ]; then
+# Spatial Indexing
+if [ "$MODE" = "all" ] || [ "$MODE" = "index" ] || [ "$MODE" = "spatial" ]; then
   echo "=== Spatial Index Build ==="
-  echo "Dataset: $OUTPUT_DIR"
-  if [ -n "$SPATIAL_INDEX_SRS" ]; then
-    echo "SRS: $SPATIAL_INDEX_SRS"
-  else
-    echo "SRS: auto-detect"
-  fi
-
-  SPATIAL_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar \
-    org.apache.jena.geosparql.spatial.cmd.SpatialIndexBuilder --loc=\"$OUTPUT_DIR\" \
-    --output=\"$OUTPUT_DIR/spatial.index\""
+  echo "Dataset: $TDB2_LOCATION"
+  echo "Spatial index location: $SPATIAL_INDEX_LOCATION"
+  echo "SRS_URI: ${SRS_URI:-auto-detect}"
   
-  if [ -n "$SPATIAL_INDEX_SRS" ]; then
-    SPATIAL_CMD="$SPATIAL_CMD --srs=\"$SPATIAL_INDEX_SRS\""
+  SPATIAL_CMD="$SPATIAL_INDEXER_CMD --loc=\"$TDB2_LOCATION\" --output=\"$SPATIAL_INDEX_LOCATION\""
+  
+  # Add SRS_URI if specified in config
+  if [ -n "$SRS_URI" ]; then
+    SPATIAL_CMD="$SPATIAL_CMD --srs=\"$SRS_URI\""
   fi
   
   eval "$SPATIAL_CMD"
 fi
 
+# Statistics
+if [ -z "$NO_STATS" ] && { [ "$MODE" = "all" ] || [ "$MODE" = "tdb2" ] || [ "$MODE" = "tdb2.xloader" ]; }; then
+  echo "=== Generating Statistics ==="
+  # Clean up TDB2_LOCATION in case it has extra quotes
+  CLEAN_TDB2_LOCATION=$(echo "$TDB2_LOCATION" | sed 's/^"//; s/"$//')
+  STATS_FILE="${CLEAN_TDB2_LOCATION}/stats.opt"
+  
+  echo "DEBUG: Clean TDB2 location: $CLEAN_TDB2_LOCATION"
+  echo "DEBUG: Stats file path: $STATS_FILE"
+  
+  # Run stats command and capture both output and exit code
+  STATS_OUTPUT=$($TDB2_STATS_CMD --graph "urn:x-arq:UnionGraph" --loc "$CLEAN_TDB2_LOCATION" 2>&1)
+  
+  # Show warnings to user but still create stats file
+  echo "$STATS_OUTPUT" | grep -v "^WARN" > "$STATS_FILE"
+  
+  # Show any warnings to the user
+  echo "$STATS_OUTPUT" | grep "^WARN" | while read -r warning; do
+    echo "$warning"
+  done
+  
+  # If stats file is empty, try without the UnionGraph
+  if [ ! -s "$STATS_FILE" ]; then
+    echo "DEBUG: Stats file empty, trying without UnionGraph"
+    $TDB2_STATS_CMD --loc "$CLEAN_TDB2_LOCATION" > "$STATS_FILE" 2>&1
+  fi
+  
+  # Show final result
+  if [ -s "$STATS_FILE" ]; then
+    echo "Statistics generated successfully at $STATS_FILE"
+  else
+    echo "WARNING: Statistics file is empty - dataset may be empty or have issues"
+  fi
+  
+  echo "Statistics generated at $STATS_FILE"
+  echo "First 5 lines:"
+  head -n 5 "$STATS_FILE"
+  echo "..."
+  echo "Last 5 lines:"
+  tail -n 5 "$STATS_FILE"
+fi
+
 echo "=== Done ==="
+echo "Processing complete."

--- a/build-files/docker/test-xloader/Taskfile.yml
+++ b/build-files/docker/test-xloader/Taskfile.yml
@@ -10,15 +10,15 @@
 #
 version: '3'
 
-vars:
-  IMAGE_NAME: '{{.IMAGE_NAME | default "fuseki-loader"}}'
-  IMAGE_TAG: '{{.IMAGE_TAG | default "6.1.0-SNAPSHOT"}}'
+includes:
+  rootTaskfile: ../../../Taskfile.yml
 
 tasks:
-  clean:
-    desc: Remove volumes from previous runs
+  build:
+    desc: Build the text-only SHACL indexer image from the repo root
+    dir: ../../../
     cmds:
-      - docker compose down -v 2>/dev/null || true
+      - docker build -f build-files/docker/Dockerfile.loader -t {{.IMAGE_NAME}}:{{.IMAGE_TAG}} .
 
   load:
     desc: Run xloader with two input files
@@ -43,9 +43,15 @@ tasks:
         docker compose run --rm -T query \
           --loc /data/DB/ds --query=-
 
+  clean:
+    desc: Remove volumes from previous runs
+    cmds:
+      - docker compose down -v 2>/dev/null || true
+
   test:
     desc: "Load two files via xloader then verify all 4 subjects are present"
     cmds:
+      - task: build
       - task: load
       - echo ""
       - echo "=== Subject count (expect 4) ==="

--- a/build-files/docker/test-xloader/Taskfile.yml
+++ b/build-files/docker/test-xloader/Taskfile.yml
@@ -1,0 +1,57 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# https://taskfile.dev
+#
+# Test: confirm xloader loads all files (not just the first).
+#
+# file1.ttl has ex:thing1, ex:thing2 (Widgets)
+# file2.ttl has ex:thing3, ex:thing4 (Gadgets)
+#
+# Expected: 4 subjects total. If xloader only loads the first file, we get 2.
+#
+version: '3'
+
+vars:
+  IMAGE_NAME: '{{.IMAGE_NAME | default "fuseki-loader"}}'
+  IMAGE_TAG: '{{.IMAGE_TAG | default "6.1.0-SNAPSHOT"}}'
+
+tasks:
+  clean:
+    desc: Remove volumes from previous runs
+    cmds:
+      - docker compose down -v 2>/dev/null || true
+
+  load:
+    desc: Run xloader with two input files
+    deps: [clean]
+    cmds:
+      - docker compose run --rm xloader
+
+  count:
+    desc: Count distinct subjects in the loaded TDB2 store
+    cmds:
+      - |
+        echo 'SELECT (COUNT(DISTINCT ?s) AS ?total) WHERE { ?s ?p ?o }' | \
+        docker compose run --rm -T query \
+          --loc /data/DB/ds --query=-
+    silent: false
+
+  count-by-type:
+    desc: Count subjects by rdf:type
+    cmds:
+      - |
+        echo 'PREFIX ex: <http://example.org/> SELECT ?type (COUNT(?s) AS ?n) WHERE { ?s a ?type } GROUP BY ?type ORDER BY ?type' | \
+        docker compose run --rm -T query \
+          --loc /data/DB/ds --query=-
+
+  test:
+    desc: "Load two files via xloader then verify all 4 subjects are present"
+    cmds:
+      - task: load
+      - echo ""
+      - echo "=== Subject count (expect 4) ==="
+      - task: count
+      - echo ""
+      - echo "=== By type (expect Widget=2, Gadget=2) ==="
+      - task: count-by-type
+      - echo ""
+      - task: clean

--- a/build-files/docker/test-xloader/config.ttl
+++ b/build-files/docker/test-xloader/config.ttl
@@ -1,0 +1,7 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX tdb2: <http://jena.apache.org/2016/tdb#>
+PREFIX ja:   <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+<#dataset> a tdb2:DatasetTDB2 ;
+    tdb2:location "/data/DB/ds" .

--- a/build-files/docker/test-xloader/data/file1.ttl
+++ b/build-files/docker/test-xloader/data/file1.ttl
@@ -1,0 +1,11 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+@prefix ex: <http://example.org/> .
+
+ex:thing1 a ex:Widget ;
+    ex:label "Widget Alpha" ;
+    ex:count 10 .
+
+ex:thing2 a ex:Widget ;
+    ex:label "Widget Beta" ;
+    ex:count 20 .

--- a/build-files/docker/test-xloader/data/file2.ttl
+++ b/build-files/docker/test-xloader/data/file2.ttl
@@ -1,0 +1,11 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+@prefix ex: <http://example.org/> .
+
+ex:thing3 a ex:Gadget ;
+    ex:label "Gadget Gamma" ;
+    ex:count 30 .
+
+ex:thing4 a ex:Gadget ;
+    ex:label "Gadget Delta" ;
+    ex:count 40 .

--- a/build-files/docker/test-xloader/docker-compose.yml
+++ b/build-files/docker/test-xloader/docker-compose.yml
@@ -1,0 +1,25 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+services:
+  xloader:
+    image: ${IMAGE_NAME:-fuseki-loader}:${IMAGE_TAG:-6.1.0-SNAPSHOT}
+    volumes:
+      - ./config.ttl:/config.ttl:ro
+      - ./data:/rdf:ro
+      - xloader-db:/data/DB
+      - xloader-tmp:/tmp
+    environment:
+      - MODE=tdb2.xloader
+      - NO_STATS=true
+
+  # Used to inspect TDB2 contents after loading
+  query:
+    image: ${IMAGE_NAME:-fuseki-loader}:${IMAGE_TAG:-6.1.0-SNAPSHOT}
+    volumes:
+      - xloader-db:/data/DB
+    entrypoint: ["java", "-cp", "/fuseki/jena-fuseki-server.jar", "tdb2.tdbquery"]
+    command: ["--loc", "/data/DB/ds", "--query=-"]
+    stdin_open: true
+
+volumes:
+  xloader-db:
+  xloader-tmp:

--- a/jena-benchmarks/jena-benchmarks-shadedJena480/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena480/pom.xml
@@ -89,6 +89,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <classifier>early</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -98,7 +101,7 @@
                 <executions>
                     <execution>
                         <id>shade-benchmark-fixture</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -145,7 +148,7 @@
                 <executions>
                     <execution>
                         <id>unpack-shaded-classes</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>

--- a/jena-benchmarks/jena-benchmarks-shadedJena510/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena510/pom.xml
@@ -94,6 +94,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <classifier>early</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -103,7 +106,7 @@
                 <executions>
                     <execution>
                         <id>shade-benchmark-fixture</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -151,7 +154,7 @@
                 <executions>
                     <execution>
                         <id>unpack-shaded-classes</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>

--- a/jena-benchmarks/jena-benchmarks-shadedJena550/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena550/pom.xml
@@ -99,6 +99,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <classifier>early</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -108,7 +111,7 @@
                 <executions>
                     <execution>
                         <id>shade-benchmark-fixture</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -156,7 +159,7 @@
                 <executions>
                     <execution>
                         <id>unpack-shaded-classes</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <ver.jakarta.json>2.0.1</ver.jakarta.json>
 
     <!-- These two must be in-step -->
-    <ver.jetty>12.1.6</ver.jetty>
+    <ver.jetty>12.1.7</ver.jetty>
     <ver.jakarta-servlet>6.1.0</ver.jakarta-servlet>
 
     <!--


### PR DESCRIPTION
Adds the following improvements to the bulk loader/indexer
  - All paths computed automatically from the given jena config
    (tdb2 location, spatial index file location, text index directory)
  - extended MODE support
    [ all (default), tdb2, tdb2.xloader, index, text, spatial ]
  - added TDB2_MODE variable
    [ basic, parallel, phased (default), sequential ]
  - added TARGET_GRAPH variable so that triples can be loaded to
    a specific named graph
  - input file searching is now recursive and handles more formats
  - added RDF validation for input files which can be toggled
    OFF by setting the new NO_VALIDATION variable
  - added tdb2stats generation which can be toggled OFF by
    setting the new NO_STATS variable.
  - added support for loading with tdb2.tdbxloader as per the
    MODE variable
  - added a THREADS variable to control how many threads to
    use for xloader. Defaults to num cpu cores - 1.
  - improved logging
  - improved early failure checks for missing or misconfigured
    volumes.

Changed behaviour:
  - /config/config.ttl moved to /config.ttl
  - /input moved to /rdf
  - removed OUTPUT_DIR variable
