### PR TITLE
Fix build error regression

### DIFF
--- a/jena-benchmarks/jena-benchmarks-shadedJena480/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena480/pom.xml
@@ -89,6 +89,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <classifier>early</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -98,7 +101,7 @@
                 <executions>
                     <execution>
                         <id>shade-benchmark-fixture</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -145,7 +148,7 @@
                 <executions>
                     <execution>
                         <id>unpack-shaded-classes</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>

--- a/jena-benchmarks/jena-benchmarks-shadedJena510/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena510/pom.xml
@@ -94,6 +94,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <classifier>early</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -103,7 +106,7 @@
                 <executions>
                     <execution>
                         <id>shade-benchmark-fixture</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -151,7 +154,7 @@
                 <executions>
                     <execution>
                         <id>unpack-shaded-classes</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>

--- a/jena-benchmarks/jena-benchmarks-shadedJena550/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena550/pom.xml
@@ -99,6 +99,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <classifier>early</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -108,7 +111,7 @@
                 <executions>
                     <execution>
                         <id>shade-benchmark-fixture</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
@@ -156,7 +159,7 @@
                 <executions>
                     <execution>
                         <id>unpack-shaded-classes</id>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>


### PR DESCRIPTION
Caused by introduction of the maven-antrun-plugin in
jena-benchmarks/
