### PR TITLE
Add offset paging to luc:query

### DIFF
--- a/demo/app-static/app.css
+++ b/demo/app-static/app.css
@@ -1038,6 +1038,42 @@ code {
   color: var(--amber);
 }
 
+.pagination-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 1rem 0;
+}
+
+.pagination-btn {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.pagination-btn:hover:not(:disabled):not(.is-current) {
+  background: var(--bg-hover);
+  border-color: var(--border-focus);
+}
+
+.pagination-btn.is-current {
+  background: var(--accent);
+  color: var(--bg-base);
+  border-color: var(--accent);
+  font-weight: 600;
+}
+
+.pagination-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .result-description {
   font-size: 0.8rem;
   color: var(--text-secondary);

--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -746,6 +746,7 @@ function searchApp() {
         identifier: '',
         identifierSuggestions: [],
         limit: DEFAULT_LIMIT,
+        currentPage: 1,
         resultLimits: RESULT_LIMITS,
         maxFacetValues: DEFAULT_FACET_LIMIT,
         facetLimits: FACET_LIMITS,
@@ -771,6 +772,7 @@ function searchApp() {
         showLoading: false,
         _loadingTimer: null,
         description: '',
+        _lastTotalHits: 0,
         endpoint: '',
         queryLog: [],
         spatialBbox: null,
@@ -989,6 +991,7 @@ function searchApp() {
                 this.buildHierarchyParentClauses()
             );
             if (cql) params.set('filter', cql);
+            if (this.currentPage > 1) params.set('page', this.currentPage);
             const qs = params.toString();
             const url = qs ? '?' + qs : window.location.pathname;
             history.pushState(null, '', url);
@@ -1010,13 +1013,40 @@ function searchApp() {
             this.hierarchySelected = this.inferHierarchySelections(this.selected);
             this.spatialBbox = bbox;
             this.spatialPolygon = polygon;
+            this.currentPage = Math.max(1, parseInt(params.get('page'), 10) || 1);
         },
 
         // --- Actions ---
 
         async search() {
+            this.currentPage = 1;
             this.pushUrl();
             await this.executeSearch();
+        },
+
+        async goToPage(page) {
+            this.currentPage = page;
+            this.pushUrl();
+            await this.executeSearch();
+        },
+
+        totalPages() {
+            if (!this._lastTotalHits || this.limit <= 0) return 1;
+            return Math.ceil(this._lastTotalHits / this.limit);
+        },
+
+        paginationRange() {
+            const tp = this.totalPages();
+            const cur = this.currentPage;
+            if (tp <= 7) return Array.from({ length: tp }, (_, i) => i + 1);
+            const pages = [1];
+            if (cur > 3) pages.push('...');
+            for (let p = Math.max(2, cur - 1); p <= Math.min(tp - 1, cur + 1); p++) {
+                pages.push(p);
+            }
+            if (cur < tp - 2) pages.push('...');
+            pages.push(tp);
+            return pages;
         },
 
         updateIdentifierSuggestions() {
@@ -1473,7 +1503,7 @@ SELECT ?field ?value ?low ?high ?count WHERE {
             return `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?totalHits) luc:query ('default' ${sparqlQuote(searchField)} ${sparqlQuote(term)} ${filterArg} ${sortArg} ${this.limit}) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' ${sparqlQuote(searchField)} ${sparqlQuote(term)} ${filterArg} ${sortArg} ${this.limit} ${(this.currentPage - 1) * this.limit}) }
     UNION
     { (?field ?value ?low ?high ?count) luc:facet ('default' ${sparqlQuote(searchField)} ${sparqlQuote(term)} ${sparqlQuote(facetFieldsJson)} ${filterArg} ${this.maxFacetValues} 0) }
 }`;
@@ -1484,7 +1514,7 @@ WHERE {
             return `${SPARQL_PREFIXES}
 SELECT DISTINCT ?identifier
 WHERE {
-    (?hit ?entity ?score) luc:query ('default' ${sparqlQuote(fieldSpec)} ${sparqlQuote(identifier)} '' '' 8) .
+    (?hit ?entity ?score) luc:query ('default' ${sparqlQuote(fieldSpec)} ${sparqlQuote(identifier)} '' '' 8 0) .
     ?entity ex:identifier ?identifier .
 }
 ORDER BY LCASE(STR(?identifier))
@@ -1799,10 +1829,15 @@ DESCRIBE <${uri}>`;
             }
 
             let result = parts.join(' ') + ' \u2014 ';
+            const total = totalHits || hitCount;
             if (totalHits != null && totalHits > hitCount) {
                 result += `<strong>${hitCount.toLocaleString()}</strong> of <strong>${totalHits.toLocaleString()}</strong> results`;
             } else {
-                result += `<strong>${(totalHits || hitCount).toLocaleString()}</strong> results`;
+                result += `<strong>${total.toLocaleString()}</strong> results`;
+            }
+            const tp = this.totalPages();
+            if (tp > 1) {
+                result += ` \u2014 page <strong>${this.currentPage}</strong> of <strong>${tp.toLocaleString()}</strong>`;
             }
             if (totalSec != null) {
                 result += ` in <strong>${totalSec.toFixed(2)}s</strong>`;
@@ -1853,10 +1888,11 @@ DESCRIBE <${uri}>`;
                 this.logQuery(`Search: ${searchLabel}`, searchQuery, searchMs);
 
                 const { hits, facets, totalHits } = this.parseUnionResults(data);
+                this._lastTotalHits = totalHits || hits.length;
                 this.facets = this.mergeFacets(facets);
 
                 if (hits.length > 0) {
-                    const uris = hits.slice(0, this.limit).map(h => h.uri);
+                    const uris = hits.map(h => h.uri);
                     const scores = Object.fromEntries(hits.map(h => [h.uri, h.score]));
                     const detailQuery = this.buildDetailQuery(uris);
 
@@ -2303,7 +2339,7 @@ function statsApp() {
                 const statsQuery = `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?totalHits) luc:query ('default' 'default' '*' '' '' 0) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' 'default' '*' '' '' 0 0) }
     UNION
     { (?field ?value ?low ?high ?count) luc:facet ('default' 'default' '*' ${sparqlQuote(facetFieldsJson)} '' 0 0) }
 }`;

--- a/demo/app-static/index.html
+++ b/demo/app-static/index.html
@@ -387,6 +387,21 @@
             </div>
           </template>
 
+          <template x-if="totalPages() > 1">
+            <nav class="pagination-bar" aria-label="pagination">
+              <button class="pagination-btn" :disabled="currentPage <= 1"
+                      @click="goToPage(currentPage - 1)">&lsaquo; Prev</button>
+              <template x-for="p in paginationRange()" :key="p">
+                <button class="pagination-btn" :class="{ 'is-current': p === currentPage }"
+                        x-text="p === '...' ? '\u2026' : p"
+                        :disabled="p === '...'"
+                        @click="p !== '...' && goToPage(p)"></button>
+              </template>
+              <button class="pagination-btn" :disabled="currentPage >= totalPages()"
+                      @click="goToPage(currentPage + 1)">Next &rsaquo;</button>
+            </nav>
+          </template>
+
         </div>
 
         <!-- Resize handle -->

--- a/demo/lucene_sparq_one_page.html
+++ b/demo/lucene_sparq_one_page.html
@@ -319,6 +319,7 @@
         <span class="sync-star">★</span><span class="str" id="rq-cqlFilter">""</span>
         <span class="json" id="rq-sortSpec">'{"field":"urn:year","order":"desc"}'</span>
         <span class="num" id="rq-limit">20</span>
+        <span class="num" id="rq-offset">0</span>
     <span class="brc">)</span> .
     <span class="brc">(</span>
         <span class="var">?hit</span>
@@ -375,6 +376,7 @@
       <line class="rhs-link" data-target="rq-cqlFilter" x1="540" y1="280" x2="590" y2="280" stroke="#2a5d9f"/><circle class="rhs-dot" data-target="rq-cqlFilter" cx="540" cy="280" r="2.2" fill="#2a5d9f"/>
       <line class="rhs-link" data-target="rq-sortSpec" x1="760" y1="300" x2="810" y2="300" stroke="#2a5d9f"/><circle class="rhs-dot" data-target="rq-sortSpec" cx="760" cy="300" r="2.2" fill="#2a5d9f"/>
       <line class="rhs-link" data-target="rq-limit" x1="540" y1="320" x2="590" y2="320" stroke="#6a1b9a"/><circle class="rhs-dot" data-target="rq-limit" cx="540" cy="320" r="2.2" fill="#6a1b9a"/>
+      <line class="rhs-link" data-target="rq-offset" x1="540" y1="340" x2="590" y2="340" stroke="#6a1b9a"/><circle class="rhs-dot" data-target="rq-offset" cx="540" cy="340" r="2.2" fill="#6a1b9a"/>
       <line class="rhs-link" data-target="pf-match" x1="620" y1="460" x2="670" y2="460" stroke="#b94700"/><circle class="rhs-dot" data-target="pf-match" cx="620" cy="460" r="2.2" fill="#b94700"/>
       <line class="rhs-link" data-target="pf-facet" x1="620" y1="660" x2="670" y2="660" stroke="#b94700"/><circle class="rhs-dot" data-target="pf-facet" cx="620" cy="660" r="2.2" fill="#b94700"/>
       <line class="rhs-link" data-target="rf-indexSelector" x1="620" y1="680" x2="670" y2="680" stroke="#b94700"/><circle class="rhs-dot" data-target="rf-indexSelector" cx="620" cy="680" r="2.2" fill="#b94700"/>
@@ -410,6 +412,7 @@
   <div class="cal R b rhs-cal" data-target="rq-cqlFilter" style="top:270px;"><span class="lbl">cqlFilter</span><span class="desc">CQL2-JSON object, or <code>""</code> when intentionally absent</span></div>
   <div class="cal R b rhs-cal" data-target="rq-sortSpec" style="top:290px;"><span class="lbl">sortSpec</span><span class="desc">JSON sort object or array using field IRIs, or <code>""</code></span></div>
   <div class="cal R p rhs-cal" data-target="rq-limit" style="top:310px;"><span class="lbl">limit</span><span class="desc">integer literal cap; lexical forms like <code>"10"</code> are accepted; negative = unlimited</span></div>
+  <div class="cal R p rhs-cal" data-target="rq-offset" style="top:330px;"><span class="lbl">offset</span><span class="desc">number of leading hits to skip; <code>0</code> = first page; must be non-negative</span></div>
 
   <div class="cal R pred rhs-cal" data-target="pf-match" style="top:450px;"><span class="lbl">luc:match</span><span class="desc">the only per-hit match-detail API; object is always <code>()</code></span></div>
 
@@ -497,7 +500,7 @@
     <span><span class="sw" style="background:#e6f2ea;border:1px solid #2e7d4f;"></span>subject / bindings</span>
   </div>
   <div>
-    <strong>Fixed arity:</strong> <code>luc:query</code> takes 6 object args and <code>luc:facet</code> takes 7.
+    <strong>Fixed arity:</strong> <code>luc:query</code> takes 7 object args and <code>luc:facet</code> takes 7.
     &nbsp;&middot;&nbsp;
     <strong>Empty slots:</strong> use <code>""</code> for absent <code>cqlFilter</code> / <code>sortSpec</code>.
     &nbsp;&middot;&nbsp;

--- a/demo/test/queries/01-basic-search.rq
+++ b/demo/test/queries/01-basic-search.rq
@@ -7,6 +7,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" "default" "copper" "" "" 10)
+    (?hit ?entity ?score) luc:query ("default" "default" "copper" "" "" 10 0)
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/02-filtered-search.rq
+++ b/demo/test/queries/02-filtered-search.rq
@@ -14,6 +14,7 @@ WHERE {
         '{"op":"=","args":[{"property":"urn:jena:lucene:field#state"},"http://example.org/mining/state/QLD"]}'
         ""
         10
+        0
     )
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/05-combined.rq
+++ b/demo/test/queries/05-combined.rq
@@ -8,7 +8,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score) luc:query ("default" "default" "iron ore" "" "" 10) }
+    { (?hit ?entity ?score) luc:query ("default" "default" "iron ore" "" "" 10 0) }
     UNION
     { (?field ?value ?low ?high ?count) luc:facet ("default" "default" "iron ore" '["urn:jena:lucene:field#state", "urn:jena:lucene:field#status"]' "" 10 0) }
 }

--- a/demo/test/queries/07-filter-by-author.rq
+++ b/demo/test/queries/07-filter-by-author.rq
@@ -8,7 +8,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?entity ?score ?label
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" "default" "*" '{"op":"=","args":[{"property":"urn:jena:lucene:field#authorName"},"Dr Sarah Jones"]}' "" 10) .
+    (?hit ?entity ?score) luc:query ("default" "default" "*" '{"op":"=","args":[{"property":"urn:jena:lucene:field#authorName"},"Dr Sarah Jones"]}' "" 10 0) .
     ?entity rdfs:label ?label .
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/08-spatial-bbox.rq
+++ b/demo/test/queries/08-spatial-bbox.rq
@@ -6,5 +6,6 @@ SELECT ?entity ?score WHERE {
   (?hit ?entity ?score) luc:query ("default" "default" "*"
     '{"op":"s_intersects","args":[{"property":"urn:jena:lucene:field#location"},{"bbox":[112,-44,154,-10]}]}'
     ""
-    20)
+    20
+    0)
 }

--- a/demo/test/queries/09-matchraw-multivalue.rq
+++ b/demo/test/queries/09-matchraw-multivalue.rq
@@ -8,7 +8,7 @@ PREFIX ex:  <http://example.org/mining/>
 
 SELECT ?entity ?score ?matchRaw ?identifier
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#identifier"]' "94130" "" "" 10) .
+    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#identifier"]' "94130" "" "" 10 0) .
     (?hit ?field ?matchRaw) luc:match () .
     ?entity ex:identifier ?identifier .
 }

--- a/demo/test/queries/10-match-field-details.rq
+++ b/demo/test/queries/10-match-field-details.rq
@@ -8,7 +8,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?entity ?score ?field ?value
 WHERE {
-    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
+    (?hit ?entity ?score) luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10 0) .
     (?hit ?field ?value) luc:match () .
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/15-nested-identifier-prefix-search.rq
+++ b/demo/test/queries/15-nested-identifier-prefix-search.rq
@@ -5,6 +5,6 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?s ?score
 WHERE {
-    (?hit ?s ?score) luc:query ("default" '["urn:jena:lucene:field#identifierValueText"]' "bod" "" "" 10)
+    (?hit ?s ?score) luc:query ("default" '["urn:jena:lucene:field#identifierValueText"]' "bod" "" "" 10 0)
 }
 ORDER BY DESC(?score) ?s

--- a/demo/test/queries/16-sort-by-year-desc.rq
+++ b/demo/test/queries/16-sort-by-year-desc.rq
@@ -13,6 +13,7 @@ WHERE {
         '{"op":"=","args":[{"property":"urn:jena:lucene:field#entityType"},"http://example.org/mining/MiningReport"]}'
         '{"field":"urn:jena:lucene:field#year","order":"desc"}'
         10
+        0
     ) .
     ?entity ex:year ?year .
 }

--- a/demo/test/queries/17-sort-boreholes-by-depth-asc.rq
+++ b/demo/test/queries/17-sort-boreholes-by-depth-asc.rq
@@ -13,6 +13,7 @@ WHERE {
         '{"op":"=","args":[{"property":"urn:jena:lucene:field#entityType"},"http://example.org/mining/Borehole"]}'
         '{"field":"urn:jena:lucene:field#depth","order":"asc"}'
         10
+        0
     ) .
     ?entity ex:depth ?depth .
 }

--- a/demo/test/queries/19-nested-identifier-exact-pair.rq
+++ b/demo/test/queries/19-nested-identifier-exact-pair.rq
@@ -12,6 +12,7 @@ WHERE {
         '{"op":"and","args":[{"op":"=","args":[{"property":"urn:jena:lucene:field#identifierType"},"company"]},{"op":"=","args":[{"property":"urn:jena:lucene:field#identifierValueExact"},"Newmont"]}]}'
         ""
         10
+        0
     )
 }
 ORDER BY DESC(?score) ?s

--- a/demo/test/queries/20-date-range-filter.rq
+++ b/demo/test/queries/20-date-range-filter.rq
@@ -12,6 +12,7 @@ WHERE {
         '{"op":"and","args":[{"op":"=","args":[{"property":"urn:jena:lucene:field#entityType"},"http://example.org/mining/MiningReport"]},{"op":"between","args":[{"property":"urn:jena:lucene:field#publishedOn"},"2024-01-01","2024-12-31"]}]}'
         '{"field":"urn:jena:lucene:field#publishedOn","order":"desc"}'
         10
+        0
     )
 }
 ORDER BY DESC(?score)

--- a/demo/test/queries/21-match-review-note-languages.rq
+++ b/demo/test/queries/21-match-review-note-languages.rq
@@ -12,6 +12,7 @@ WHERE {
         ""
         ""
         10
+        0
     ) .
     (?hit ?field ?value) luc:match () .
 }

--- a/demo/test/queries/22-match-qa-passed-boolean.rq
+++ b/demo/test/queries/22-match-qa-passed-boolean.rq
@@ -12,6 +12,7 @@ WHERE {
         ""
         ""
         10
+        0
     ) .
     (?hit ?field ?value) luc:match () .
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/SearchExecution.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SearchExecution.java
@@ -54,10 +54,10 @@ public class SearchExecution {
     // Lazy results
     private List<TextHit> hits;
     private List<SearchHit> searchHits;
+    private int searchHitsFetchedWindow = 0;
     private final Map<FacetRequestKey, Map<String, List<FacetValue>>> facetCountsCache = new HashMap<>();
     private long totalHits = -1;
     private boolean hitsComputed = false;
-    private boolean searchHitsComputed = false;
 
     public SearchExecution(String indexIdentity, List<String> searchFields, String queryString,
                            CqlExpression filter, List<SortSpec> sortSpecs,
@@ -153,21 +153,31 @@ public class SearchExecution {
 
     /**
      * Get search hits with stable hit IDs and field match data.
-     * Uses NamedMatches for field-level match attribution.
+     * Caches the largest window seen so far and returns the requested page slice.
+     *
+     * @param offset number of leading hits to skip
+     * @param limit  maximum number of hits to return
+     * @return the page slice of search hits
      */
-    public synchronized List<SearchHit> getSearchHits(int limit) {
-        if (!searchHitsComputed) {
+    public synchronized List<SearchHit> getSearchHits(int offset, int limit) {
+        int requestedWindow = offset + limit;
+        if (searchHits == null || requestedWindow > searchHitsFetchedWindow) {
             try {
                 List<String> resolved = textIndex.resolveSearchFields(searchFields);
                 searchHits = textIndex.searchWithHitIds(resolved, queryString, filter,
-                    sortSpecs, graphURI, lang, limit);
+                    sortSpecs, graphURI, lang, requestedWindow);
+                searchHitsFetchedWindow = requestedWindow;
             } catch (Exception e) {
                 log.error("Error computing search hits: {}", e.getMessage());
                 searchHits = Collections.emptyList();
+                searchHitsFetchedWindow = 0;
             }
-            searchHitsComputed = true;
         }
-        return searchHits;
+        if (offset >= searchHits.size()) {
+            return Collections.emptyList();
+        }
+        int end = Math.min(offset + limit, searchHits.size());
+        return searchHits.subList(offset, end);
     }
 
     /**

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
@@ -47,7 +47,6 @@ import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.binding.BindingBuilder;
 import org.apache.jena.sparql.engine.iterator.QueryIterPlainWrapper;
-import org.apache.jena.sparql.engine.iterator.QueryIterSlice;
 import org.apache.jena.sparql.pfunction.PropFuncArg;
 import org.apache.jena.sparql.pfunction.PropertyFunctionBase;
 import org.apache.jena.sparql.util.IterLib;
@@ -60,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Supported argument format:
  * <pre>
- * (?hit ?entity ?score ?totalHits ?graph) luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
+ * (?hit ?entity ?score ?totalHits ?graph) luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
  * </pre>
  * <p>
  * {@code ?hit} is a query-scoped blank node identifier for joining with {@code luc:match}.
@@ -71,7 +70,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ShaclTextQueryPF extends PropertyFunctionBase {
     private static final Logger log = LoggerFactory.getLogger(ShaclTextQueryPF.class);
-    private static final int QUERY_ARG_ARITY = 6;
+    private static final int QUERY_ARG_ARITY = 7;
 
     private ShaclTextIndexLucene textIndex = null;
     private boolean warningIssued = false;
@@ -92,12 +91,12 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
 
         if (!argObject.isList()) {
             throw new QueryBuildException("luc:query expects exactly " + QUERY_ARG_ARITY
-                + " object arguments: (indexSelector fieldSpec queryString cqlFilter sortSpec limit)");
+                + " object arguments: (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)");
         }
         int size = argObject.getArgListSize();
         if (size != QUERY_ARG_ARITY) {
             throw new QueryBuildException("luc:query expects exactly " + QUERY_ARG_ARITY
-                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit), got " + size);
+                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset), got " + size);
         }
     }
 
@@ -203,26 +202,25 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
             args.cqlFilter, args.sortSpecs, textIndex, null, null);
 
         int limit = args.limit > 0 ? args.limit : 10000;
-        List<SearchHit> allHits = se.getSearchHits(limit);
+        int offset = args.offset;
+        List<SearchHit> pageHits = se.getSearchHits(offset, limit);
 
         Collection<SearchHit> hits;
         if (entity != null && !Var.isVar(entity)) {
             String entityStr = TextQueryFuncs.subjectToString(entity);
             hits = new ArrayList<>();
-            for (SearchHit sh : allHits) {
+            for (SearchHit sh : pageHits) {
                 if (entityStr.equals(TextQueryFuncs.subjectToString(sh.getEntityNode()))) {
                     hits.add(sh);
                 }
             }
         } else {
-            hits = allHits;
+            hits = pageHits;
         }
 
         long totalHits = totalHitsNode != null ? se.getTotalHits() : -1;
         QueryIterator qIter = resultsToQueryIterator(binding, hit, entity, score,
             totalHitsNode, totalHits, graph, hits, execCxt);
-        if (args.limit >= 0)
-            qIter = new QueryIterSlice(qIter, 0, args.limit, execCxt);
         return qIter;
     }
 
@@ -255,17 +253,17 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
     /**
      * Parse object arguments.
      * <p>
-     * Arg order: (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
+     * Arg order: (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
      */
     private QueryArgs parseArgs(PropFuncArg argObject) {
         if (!argObject.isList()) {
             throw new QueryExecException("luc:query expects exactly " + QUERY_ARG_ARITY
-                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit)");
+                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)");
         }
         List<Node> list = argObject.getArgList();
         if (list.size() != QUERY_ARG_ARITY) {
             throw new QueryExecException("luc:query expects exactly " + QUERY_ARG_ARITY
-                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit), got " + list.size());
+                + " object arguments (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset), got " + list.size());
         }
 
         String indexSelector = requireLiteralString(list.get(0), "indexSelector");
@@ -275,8 +273,15 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         CqlExpression cqlFilter = parseCqlFilter(requireLiteralString(list.get(3), "cqlFilter"));
         List<SortSpec> sortSpecs = parseSortSpec(requireLiteralString(list.get(4), "sortSpec"));
         int limit = parseLimit(list.get(5));
+        int offset = parseOffset(list.get(6));
 
-        return new QueryArgs(indexSelector, searchFields, queryString, cqlFilter, sortSpecs, limit);
+        long windowSize = (long) offset + limit;
+        if (windowSize > Integer.MAX_VALUE) {
+            throw new QueryExecException("luc:query offset + limit exceeds maximum (" +
+                Integer.MAX_VALUE + "): offset=" + offset + ", limit=" + limit);
+        }
+
+        return new QueryArgs(indexSelector, searchFields, queryString, cqlFilter, sortSpecs, limit, offset);
     }
 
     private static String requireLiteralString(Node node, String label) {
@@ -323,6 +328,18 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         }
     }
 
+    private static int parseOffset(Node node) {
+        try {
+            int value = Integer.parseInt(requireLiteralString(node, "offset"));
+            if (value < 0) {
+                throw new QueryExecException("luc:query offset must be non-negative, got: " + value);
+            }
+            return value;
+        } catch (NumberFormatException ex) {
+            throw new QueryExecException("luc:query offset must be an integer literal, got: " + node);
+        }
+    }
+
     private static class QueryArgs {
         final String indexSelector;
         final List<String> searchFields;
@@ -330,16 +347,18 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         final CqlExpression cqlFilter;
         final List<SortSpec> sortSpecs;
         final int limit;
+        final int offset;
 
         QueryArgs(String indexSelector, List<String> searchFields, String queryString,
                   CqlExpression cqlFilter, List<SortSpec> sortSpecs,
-                  int limit) {
+                  int limit, int offset) {
             this.indexSelector = indexSelector;
             this.searchFields = searchFields;
             this.queryString = queryString;
             this.cqlFilter = cqlFilter;
             this.sortSpecs = sortSpecs;
             this.limit = limit;
+            this.offset = offset;
         }
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextMatchPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextMatchPF.java
@@ -116,8 +116,8 @@ public class TextMatchPF extends PropertyFunctionBase {
             return IterLib.noResults(execCxt);
         }
 
-        // Get search hits (already computed by luc:query)
-        List<SearchHit> allHits = se.getSearchHits(10000);
+        // Get search hits (already computed and cached by luc:query)
+        List<SearchHit> allHits = se.getSearchHits(0, 10000);
 
         // Build result bindings
         Var hitVar = Var.isVar(hitNode) ? Var.alloc(hitNode) : null;

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -117,6 +117,9 @@ import org.junit.runners.Suite.SuiteClasses;
     , TestNestedHierarchicalFacets.class
     , TestNestedJoinPathSupport.class
 
+    // Offset paging
+    , TestOffsetPaging.class
+
     // Range facets
     , TestRangeFacetCounts.class
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDemoMiningScenarios.java
@@ -696,7 +696,7 @@ public class TestDemoMiningScenarios {
     public void testCombinedQueryAndFacet() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?entity ?score ?f ?v ?low ?high ?c WHERE {\n" +
-            "  { (?hit ?entity ?score) luc:query (\"default\" \"default\" \"iron ore\" \"\" \"\" 20) }\n" +
+            "  { (?hit ?entity ?score) luc:query (\"default\" \"default\" \"iron ore\" \"\" \"\" 20 0) }\n" +
             "  UNION\n" +
             "  { (?f ?v ?low ?high ?c) luc:facet (\"default\" \"default\" \"iron ore\" '[\"" + FP + "state\"]' \"\" 10 0) }\n" +
             "}";
@@ -763,7 +763,7 @@ public class TestDemoMiningScenarios {
         sb.append("SELECT ?s WHERE {\n");
         sb.append("  (?hit ?s ?score) luc:query (\"default\" \"default\" \"").append(queryText).append("\" ");
         sb.append(filter != null ? "'" + filter + "'" : "\"\"");
-        sb.append(" \"\" ").append(limit).append(")\n}");
+        sb.append(" \"\" ").append(limit).append(" 0)\n}");
 
         Set<String> results = new HashSet<>();
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestOffsetPaging.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestOffsetPaging.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.*;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.apache.jena.sparql.path.PathFactory;
+
+/**
+ * Tests for offset paging support in luc:query.
+ */
+public class TestOffsetPaging {
+
+    private static final String NS = "http://example.org/";
+    private static final Node ITEM_CLASS = NodeFactory.createURI(NS + "Item");
+    private static final Node TITLE_PRED = NodeFactory.createURI(NS + "title");
+    private static final Node CATEGORY_PRED = NodeFactory.createURI(NS + "category");
+
+    private Dataset dataset;
+
+    @Before
+    public void setUp() {
+        FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, false, true);
+        FieldDef categoryField = new FieldDef("category", FieldType.KEYWORD, null,
+            true, true, true, false, true, false);
+
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, TITLE_PRED),
+            occurrence(categoryField, CATEGORY_PRED));
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + "ItemShape"),
+            Collections.singleton(ITEM_CLASS),
+            "uri", "docType",
+            Arrays.asList(titleField, categoryField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+
+        ByteBuffersDirectory dir = new ByteBuffersDirectory();
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(dir, config);
+
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), textIndex, mapping);
+
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+
+        // Load 10 items all matching "item"
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            for (int i = 1; i <= 10; i++) {
+                var res = ResourceFactory.createResource(NS + "item" + i);
+                model.add(res, RDF.type, ResourceFactory.createResource(NS + "Item"));
+                model.add(res, ResourceFactory.createProperty(NS + "title"),
+                    "item number " + i);
+                model.add(res, ResourceFactory.createProperty(NS + "category"), "cat");
+            }
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Node predicate) {
+        return new FieldOccurrence(
+            field,
+            PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null, null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) dataset.close();
+    }
+
+    private List<String> runQuery(int limit, int offset) {
+        String q =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"item\" \"\" \"\" " + limit + " " + offset + ")\n" +
+            "}";
+        dataset.begin(ReadWrite.READ);
+        try {
+            List<String> results = new ArrayList<>();
+            try (QueryExecution qe = QueryExecutionFactory.create(QueryFactory.create(q), dataset)) {
+                ResultSet rs = qe.execSelect();
+                while (rs.hasNext()) {
+                    results.add(rs.next().getResource("s").getURI());
+                }
+            }
+            return results;
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testOffsetZeroSameAsNoOffset() {
+        List<String> page = runQuery(10, 0);
+        assertEquals("offset=0 with limit=10 should return all 10 items", 10, page.size());
+    }
+
+    @Test
+    public void testFirstPage() {
+        List<String> page = runQuery(3, 0);
+        assertEquals("First page should have 3 results", 3, page.size());
+    }
+
+    @Test
+    public void testSecondPage() {
+        List<String> page1 = runQuery(3, 0);
+        List<String> page2 = runQuery(3, 3);
+        assertEquals(3, page2.size());
+        // Pages should not overlap
+        Set<String> overlap = new HashSet<>(page1);
+        overlap.retainAll(page2);
+        assertTrue("Pages should not overlap", overlap.isEmpty());
+    }
+
+    @Test
+    public void testPagesExhaustResults() {
+        Set<String> all = new HashSet<>();
+        for (int offset = 0; offset < 10; offset += 3) {
+            all.addAll(runQuery(3, offset));
+        }
+        assertEquals("Paging through all results should yield 10 unique items", 10, all.size());
+    }
+
+    @Test
+    public void testOffsetBeyondResults() {
+        List<String> page = runQuery(10, 100);
+        assertTrue("Offset beyond total hits should return empty", page.isEmpty());
+    }
+
+    @Test
+    public void testPartialLastPage() {
+        // 10 items, offset=8, limit=5 → should get 2
+        List<String> page = runQuery(5, 8);
+        assertEquals("Partial last page should return remaining items", 2, page.size());
+    }
+
+    @Test
+    public void testTotalHitsUnchangedByOffset() {
+        String q =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?totalHits WHERE {\n" +
+            "  (?hit ?s ?score ?totalHits) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 3 5)\n" +
+            "} LIMIT 1";
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(QueryFactory.create(q), dataset)) {
+                ResultSet rs = qe.execSelect();
+                assertTrue(rs.hasNext());
+                long total = rs.next().getLiteral("totalHits").getLong();
+                assertEquals("totalHits should reflect full match count, not page size", 10, total);
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test(expected = QueryExecException.class)
+    public void testNegativeOffsetRejected() {
+        runQuery(10, -1);
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestPerFieldQueryAnalyzer.java
@@ -227,7 +227,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'Pilbara' \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'Pilbara' \"\" \"\" 10 0) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -253,7 +253,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'GSWA' \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#label\"]' 'GSWA' \"\" \"\" 10 0) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -309,7 +309,7 @@ public class TestPerFieldQueryAnalyzer {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "' \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"urn:jena:lucene:field#identifier\"]' '" + prefix + "' \"\" \"\" 10 0) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclEntityPerDocument.java
@@ -168,7 +168,7 @@ public class TestShaclEntityPerDocument {
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <" + NS + ">\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine learning\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine learning\" \"\" \"\" 10 0) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java
@@ -133,7 +133,7 @@ public class TestShaclLucQueryRawValueOnMultiValuedField {
     public void testLucMatchReturnsMatchedValueForMultiValuedField() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?matchRaw WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "identifier\"]' \"94130\" \"\" \"\" 10 0) .\n" +
             "  (?hit ?field ?matchRaw) luc:match ()\n" +
             "}";
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclPathSupport.java
@@ -208,7 +208,7 @@ public class TestShaclPathSupport {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10 0) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -258,7 +258,7 @@ public class TestShaclPathSupport {
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <" + NS + ">\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10 0) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -318,7 +318,7 @@ public class TestShaclPathSupport {
         String queryStr =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning OR physics OR deep\" '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#authorName\"},\"Jane Smith\"]}' \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning OR physics OR deep\" '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#authorName\"},\"Jane Smith\"]}' \"\" 10 0) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java
@@ -140,7 +140,7 @@ public class TestTextMatchPF {
     public void testMatchReturnsSingleFieldForSingleFieldQuery() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10 0) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -168,7 +168,7 @@ public class TestTextMatchPF {
         // Verify that ?hit from luc:query joins correctly with luc:match
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?field WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"machine\" \"\" \"\" 10 0) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -192,7 +192,7 @@ public class TestTextMatchPF {
         // Use OPTIONAL so hits without field matches still appear
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10 0) .\n" +
             "  OPTIONAL { (?hit ?field ?value) luc:match () . }\n" +
             "}";
 
@@ -217,7 +217,7 @@ public class TestTextMatchPF {
         // For TEXT fields, ?value should be a literal
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"\" \"\" 10 0) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -255,7 +255,7 @@ public class TestTextMatchPF {
     public void testHitIdIsBlankNode() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10 0) .\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -154,7 +154,7 @@ public class TestTextQueryPFFilters {
     public void testLucQueryWithoutFilters() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -179,7 +179,7 @@ public class TestTextQueryPFFilters {
     public void testLucQueryAcceptsEmptyPlaceholdersAndStringLimit() {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" \"10\")\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" \"10\" 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -198,7 +198,7 @@ public class TestTextQueryPFFilters {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
             "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"\" 20)\n" +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"\" 20 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -228,7 +228,7 @@ public class TestTextQueryPFFilters {
             "    '{\"op\":\"and\",\"args\":[" +
             "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}," +
             "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#author\"},\"http://example.org/author/Smith\"]}" +
-            "    ]}' \"\" 20)\n" +
+            "    ]}' \"\" 20 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -255,7 +255,7 @@ public class TestTextQueryPFFilters {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s WHERE {\n" +
             "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/nonexistent\"]}' \"\" 20)\n" +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/nonexistent\"]}' \"\" 20 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -274,7 +274,7 @@ public class TestTextQueryPFFilters {
         // Search only the "title" field via its IRI (JSON array)
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -299,7 +299,7 @@ public class TestTextQueryPFFilters {
         // Search multiple fields via JSON array of IRIs
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10)\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -323,7 +323,7 @@ public class TestTextQueryPFFilters {
         // Search a single field and check that luc:match returns ?field bound to the field IRI
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?score ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" \"\" \"\" 10 0) .\n" +
             "  (?hit ?field ?value) luc:match () .\n" +
             "}";
 
@@ -352,7 +352,7 @@ public class TestTextQueryPFFilters {
         // The fourth luc:query slot now binds ?totalHits rather than a raw match literal
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score ?totalHits WHERE {\n" +
-            "  (?hit ?s ?score ?totalHits) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"\" \"\" 10)\n" +
+            "  (?hit ?s ?score ?totalHits) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"\" \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -380,7 +380,7 @@ public class TestTextQueryPFFilters {
         // With "default", luc:match should still return field matches
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?hit ?s ?field ?value WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" \"\" 10 0) .\n" +
             "  OPTIONAL { (?hit ?field ?value) luc:match () . }\n" +
             "}";
 
@@ -408,7 +408,7 @@ public class TestTextQueryPFFilters {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score WHERE {\n" +
             "  (?hit ?s ?score) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"learning\" " +
-            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"\" 20)\n" +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' \"\" 20 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);
@@ -435,7 +435,7 @@ public class TestTextQueryPFFilters {
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "PREFIX ex: <http://example.org/>\n" +
             "SELECT ?s ?year WHERE {\n" +
-            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" '{\"field\":\"urn:jena:lucene:field#year\",\"order\":\"desc\"}' 10) .\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" \"\" '{\"field\":\"urn:jena:lucene:field#year\",\"order\":\"desc\"}' 10 0) .\n" +
             "  ?s ex:year ?year .\n" +
             "}";
 
@@ -461,7 +461,7 @@ public class TestTextQueryPFFilters {
             "SELECT ?s ?year WHERE {\n" +
             "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
             "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\"http://example.org/category/technology\"]}' " +
-            "    '{\"field\":\"urn:jena:lucene:field#year\",\"order\":\"asc\"}' 10) .\n" +
+            "    '{\"field\":\"urn:jena:lucene:field#year\",\"order\":\"asc\"}' 10 0) .\n" +
             "  ?s ex:year ?year .\n" +
             "}";
 


### PR DESCRIPTION
## Summary
- Adds a 7th positional argument (`offset`) to `luc:query`, enabling page-windowed retrieval
- `SearchExecution` caches the largest fetched window and returns `subList` views, avoiding redundant Lucene queries
- `totalHits` semantics unchanged — always reflects full match count
- 8 new tests in `TestOffsetPaging` covering page boundaries, exhaustive paging, partial pages, offset-beyond-results, and negative offset rejection
- All 14 demo `.rq` files and 7 existing test files updated to 7-arg format

## API
```sparql
(?hit ?entity ?score ?totalHits ?graph)
  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
```

## Test plan
- [x] All 571 jena-text tests pass (8 skipped, same as baseline)
- [x] RAT license checks pass
- [x] New `TestOffsetPaging` covers: offset=0 equivalence, first/second page, non-overlapping pages, exhaustive paging, offset beyond results, partial last page, totalHits independence, negative offset rejection
- [x] Demo queries validated against running Fuseki server

Closes #62