### PR TITLE
Document offset paging for luc:query

### DIFF
--- a/demo/lucene_sparq_one_page.html
+++ b/demo/lucene_sparq_one_page.html
@@ -392,7 +392,7 @@
   <div class="cal L g" style="top:110px;"><span class="lbl">?hit</span><span class="desc">blank-node join key for <code>luc:match</code> (required)</span></div>
   <div class="cal L g" style="top:130px;"><span class="lbl">?entity</span><span class="desc">matched entity IRI</span></div>
   <div class="cal L g" style="top:150px;"><span class="lbl">?score</span><span class="desc">Lucene relevance score (<code>xsd:float</code>)</span></div>
-  <div class="cal L g" style="top:170px;"><span class="lbl">?totalHits</span><span class="desc">total hits before <code>limit</code> - only computed when projected</span></div>
+  <div class="cal L g" style="top:170px;"><span class="lbl">?totalHits</span><span class="desc">full match count across the result set, independent of <code>limit</code> / <code>offset</code> - only computed when projected</span></div>
 
   <div class="cal L g" style="top:370px;"><span class="lbl">?hit</span><span class="desc">same blank-node as <code>luc:query</code> - this is the join</span></div>
   <div class="cal L g" style="top:390px;"><span class="lbl">?field</span><span class="desc">field IRI that matched</span></div>

--- a/docs/01-user-guide.md
+++ b/docs/01-user-guide.md
@@ -64,7 +64,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" "default" "machine learning" "" "" 20) .
+    luc:query ("default" "default" "machine learning" "" "" 20 0) .
 }
 ORDER BY DESC(?score)
 ```
@@ -82,7 +82,7 @@ These are separate on purpose.
 
 ```sparql
 (?hit ?entity ?score ?totalHits)
-  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
+  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
 ```
 
 Example with filter:
@@ -96,6 +96,7 @@ Example with filter:
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
     ""
     20
+    0
   ) .
 ```
 
@@ -110,7 +111,15 @@ Example with sort:
     ""
     '{"field":"urn:jena:lucene:field#year","order":"desc"}'
     10
+    0
   ) .
+```
+
+Paging — second page of 10:
+
+```sparql
+(?hit ?entity ?score ?totalHits)
+  luc:query ("default" "default" "learning" "" "" 10 10) .
 ```
 
 Notes:
@@ -118,6 +127,8 @@ Notes:
 - `fieldSpec` is `"default"` or a JSON array of field IRIs.
 - `cqlFilter` is a JSON object or `""`.
 - `sortSpec` is a JSON object/array or `""`.
+- `limit` is the page size; negative means unlimited.
+- `offset` is the number of leading hits to skip; must be non-negative. `?totalHits` is independent of `offset`.
 - `?match` is not part of `luc:query`.
 
 ### Graph Scoping
@@ -139,6 +150,7 @@ Example target filter:
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#sourceGraph"},"http://example.org/graph/A"]}'
     ""
     20
+    0
   ) .
 ```
 
@@ -159,7 +171,7 @@ Use it when you need to know which field matched:
 ```sparql
 SELECT ?entity ?field ?value WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10 0) .
   (?hit ?field ?value) luc:match () .
 }
 ```
@@ -219,7 +231,7 @@ External SPARQL always uses field IRIs:
 
 The SHACL API is strict:
 
-- `luc:query` object arity is exactly 6
+- `luc:query` object arity is exactly 7
 - `luc:facet` object arity is exactly 7
 - no argument-shape guessing
 - missing arguments fail fast
@@ -232,7 +244,7 @@ If you configure multiple indexes, use different `text:indexId` values and selec
 
 ```sparql
 (?hit ?entity ?score)
-  luc:query ("objects" "default" "gold" "" "" 20) .
+  luc:query ("objects" "default" "gold" "" "" 20 0) .
 ```
 
 The selector may also be the index resource IRI if the index was configured as a URI resource.

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -29,7 +29,7 @@ Public API rules:
 
 ```sparql
 (?hit ?entity ?score ?totalHits)
-  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit)
+  luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
 ```
 
 Subject arity may be 1 to 4:
@@ -39,7 +39,7 @@ Subject arity may be 1 to 4:
 - `?hit ?entity ?score`
 - `?hit ?entity ?score ?totalHits`
 
-Object arity is always exactly 6.
+Object arity is always exactly 7.
 
 ### Arguments
 
@@ -50,7 +50,8 @@ Object arity is always exactly 6.
 | 3 | `queryString` | string literal | Yes | Lucene query string |
 | 4 | `cqlFilter` | string literal | Yes | CQL2-JSON object, or `""` |
 | 5 | `sortSpec` | string literal | Yes | JSON sort object/array, or `""` |
-| 6 | `limit` | integer literal | Yes | Negative means unlimited |
+| 6 | `limit` | integer literal | Yes | Page size. Negative means unlimited |
+| 7 | `offset` | integer literal | Yes | Number of leading hits to skip. `0` = first page. Must be non-negative. `offset + limit` must fit in a signed 32-bit int |
 
 ### `fieldSpec`
 
@@ -69,7 +70,7 @@ Unknown field IRIs fail fast.
 | `?hit` | blank node | Query-scoped join key for `luc:match` |
 | `?entity` | IRI | Matched entity |
 | `?score` | float | Lucene relevance score |
-| `?totalHits` | `xsd:integer` | Total matching hits before limit |
+| `?totalHits` | `xsd:integer` | Total matching hits across the whole result set, independent of `limit` and `offset` |
 
 `?match` is not part of `luc:query`.
 
@@ -79,7 +80,7 @@ Search all default-search fields:
 
 ```sparql
 (?hit ?entity ?score)
-  luc:query ("default" "default" "machine learning" "" "" 20) .
+  luc:query ("default" "default" "machine learning" "" "" 20 0) .
 ```
 
 Search a specific field IRI:
@@ -93,6 +94,7 @@ Search a specific field IRI:
     ""
     ""
     20
+    0
   ) .
 ```
 
@@ -107,6 +109,7 @@ Search with a CQL filter:
     '{"op":"=","args":[{"property":"urn:jena:lucene:field#category"},"Technology"]}'
     ""
     20
+    0
   ) .
 ```
 
@@ -121,6 +124,7 @@ Search with sort:
     ""
     '{"field":"urn:jena:lucene:field#year","order":"desc"}'
     10
+    0
   ) .
 ```
 
@@ -135,8 +139,25 @@ Multi-sort:
     ""
     '[{"field":"urn:jena:lucene:field#year","order":"desc"},{"field":"urn:jena:lucene:field#title"}]'
     10
+    0
   ) .
 ```
+
+### Paging
+
+`limit` and `offset` form a page window. Fetch the second page of 10 results:
+
+```sparql
+(?hit ?entity ?score ?totalHits)
+  luc:query ("default" "default" "learning" "" "" 10 10) .
+```
+
+Notes:
+
+- `?totalHits` always reflects the full match count, not the page size. Use it to compute page counts.
+- Lucene fetches `offset + limit` hits internally and the PF exposes only the slice. Very deep offsets therefore cost proportionally more.
+- When `luc:query` and `luc:facet` share a search (same selector, field spec, query string, filter, sort), the cached hit list grows to the largest window seen in the query; each caller gets its own slice.
+- A negative `offset` is a query error. A negative `limit` is still accepted and means unlimited (offset then has no effect beyond skipping).
 
 ## luc:match
 
@@ -166,7 +187,7 @@ The object is always `()`.
 ```sparql
 SELECT ?entity ?score ?field ?value WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10 0) .
   (?hit ?field ?value) luc:match () .
 }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ This doc set covers the SHACL/entity-per-document search model in `jena-text`.
 
 ## Core Rules
 
-- `luc:query` object arguments are exactly `(indexSelector fieldSpec queryString cqlFilter sortSpec limit)`.
+- `luc:query` object arguments are exactly `(indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)`.
 - `luc:facet` object arguments are exactly `(indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)`.
 - `luc:query` does not expose `?match`.
 - `luc:match` is the only match-detail API.
@@ -33,7 +33,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?score WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" "default" "learning" "" "" 20) .
+    luc:query ("default" "default" "learning" "" "" 20 0) .
 }
 ```
 
@@ -42,7 +42,7 @@ PREFIX luc: <urn:jena:lucene:index#>
 
 SELECT ?entity ?field ?value WHERE {
   (?hit ?entity ?score)
-    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10) .
+    luc:query ("default" '["urn:jena:lucene:field#title"]' "copper" "" "" 10 0) .
   (?hit ?field ?value) luc:match () .
 }
 ```


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                        
Follow-up docs for #63, which added an `offset` argument to `luc:query`.                                                                                                                                                                                  
The merged PR updated the demo queries, code, and the one-page HTML
explainer, but the written docs still described the old 6-arg signature.                                                                                                                                                                                  
                                                                                                                                                                                                                                                        
This PR brings the docs in line:                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                        
- **`docs/02-sparql-api.md`** — signature updated to 7 args, new row in                                                                                                                                                                                   
the arguments table for `offset`, `limit` clarified as "page size",                                                                                                                                                                                   
`?totalHits` clarified as independent of `limit`/`offset`, every                                                                                                                                                                                        
covers second-page retrieval, deep-offset cost, shared-execution                                                                                                                                                                                        
windowing, and negative-value behaviour.                                                                                                                                                                                                                
- **`docs/01-user-guide.md`** — same signature/example updates (9 call                                                                                                                                                                                    
sites), added a paging example, "Fixed Arity" section now says 7.                                                                                                                                                                                       
- **`docs/README.md`** — core-rules line and examples updated.                                                                                                                                                                                          
- **`demo/lucene_sparq_one_page.html`** — tightened the `?totalHits`                                                                                                                                                                                      
callout so it reads correctly under paging (the body already had                                                                                                                                                                                        
`offset` from #63).                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                        
No code or test changes. Dated design docs under `docs/2026-*` and                                                                                                                                                                                        
`docs/archive/**` are left as historical.                                   