### PR TITLE
Skip blank-node entities, multi-index bulk indexer, TEMPORAL field type

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 **/.venv
 **/.cache
 **/node_modules
+**/node/
 **/target
 **/DB
 **/Lucene

--- a/build-files/docker/Dockerfile.runtime
+++ b/build-files/docker/Dockerfile.runtime
@@ -1,6 +1,6 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-FROM maven:3.9.9-eclipse-temurin-21 AS builder
+FROM --platform=linux/amd64 maven:3.9.9-eclipse-temurin-21 AS builder
 
 WORKDIR /build
 

--- a/demo/test/config.ttl
+++ b/demo/test/config.ttl
@@ -87,14 +87,14 @@ field:year
 
 field:publishedOn
     idx:fieldName "publishedOn" ;
-    idx:fieldType idx:DateField ;
+    idx:fieldType idx:TemporalField ;
     idx:sortable true ;
     idx:facetable true ;
     idx:storeLiteralMetadata true .
 
 field:indexedAt
     idx:fieldName "indexedAt" ;
-    idx:fieldType idx:DateTimeField ;
+    idx:fieldType idx:TemporalField ;
     idx:sortable true ;
     idx:storeLiteralMetadata true .
 

--- a/demo/test/queries/20-date-range-filter.rq
+++ b/demo/test/queries/20-date-range-filter.rq
@@ -1,5 +1,5 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
-# Date range filter on idx:DateField using CQL2-JSON between.
+# Date range filter on idx:TemporalField using CQL2-JSON between.
 
 PREFIX luc: <urn:jena:lucene:index#>
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/LiteralFieldSupport.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/LiteralFieldSupport.java
@@ -51,24 +51,20 @@ public final class LiteralFieldSupport {
     }
 
     public static String queryFieldName(FieldDef fieldDef) {
-        return fieldDef != null && fieldDef.isDateLike()
+        return fieldDef != null && fieldDef.isTemporal()
             ? epochField(fieldDef.getFieldName())
             : fieldDef != null ? fieldDef.getFieldName() : null;
     }
 
     public static Long toEpochMillis(FieldType fieldType, Object rawValue) {
-        if (rawValue == null) {
+        if (rawValue == null || fieldType != FieldType.TEMPORAL) {
             return null;
         }
         String lexical = rawValue instanceof Node node && node.isLiteral()
             ? node.getLiteralLexicalForm()
             : String.valueOf(rawValue);
         try {
-            return switch (fieldType) {
-                case DATE -> parseDateEpochMillis(lexical);
-                case DATETIME -> parseDateTimeEpochMillis(lexical);
-                default -> null;
-            };
+            return parseTemporalEpochMillis(lexical);
         } catch (DateTimeException ex) {
             return null;
         }
@@ -94,8 +90,10 @@ public final class LiteralFieldSupport {
             case INT -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDinteger);
             case LONG -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong);
             case DOUBLE -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdouble);
-            case DATE -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdate);
-            case DATETIME -> NodeFactory.createLiteralDT(lexical, org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime);
+            case TEMPORAL -> NodeFactory.createLiteralDT(lexical,
+                lexical.contains("T")
+                    ? org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime
+                    : org.apache.jena.datatypes.xsd.XSDDatatype.XSDdate);
             case LATLON -> null;
         };
     }
@@ -104,19 +102,22 @@ public final class LiteralFieldSupport {
         return value == null || value.isEmpty() ? null : value;
     }
 
-    private static long parseDateEpochMillis(String lexical) {
+    /**
+     * Parse an xsd:date or xsd:dateTime lexical form into epoch milliseconds (UTC).
+     * Date-only forms are treated as start-of-day UTC.
+     */
+    private static long parseTemporalEpochMillis(String lexical) {
+        if (lexical.contains("T")) {
+            try {
+                return OffsetDateTime.parse(lexical, DateTimeFormatter.ISO_DATE_TIME)
+                    .toInstant().toEpochMilli();
+            } catch (DateTimeException ex) {
+                LocalDateTime localDateTime = LocalDateTime.parse(lexical, DateTimeFormatter.ISO_DATE_TIME);
+                return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+            }
+        }
         TemporalAccessor parsed = DateTimeFormatter.ISO_DATE.parse(lexical);
         LocalDate date = LocalDate.from(parsed);
         return date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
-    }
-
-    private static long parseDateTimeEpochMillis(String lexical) {
-        try {
-            return OffsetDateTime.parse(lexical, DateTimeFormatter.ISO_DATE_TIME)
-                .toInstant().toEpochMilli();
-        } catch (DateTimeException ex) {
-            LocalDateTime localDateTime = LocalDateTime.parse(lexical, DateTimeFormatter.ISO_DATE_TIME);
-            return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
-        }
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclBulkIndexer.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclBulkIndexer.java
@@ -129,6 +129,11 @@ public class ShaclBulkIndexer {
                         }
                         Quad quad = quadIter.next();
                         Node subject = quad.getSubject();
+                        if (subject.isBlank()) {
+                            log.warn("Skipping blank-node entity (cannot be indexed): {} for shape {}",
+                                subject, profile.getShapeNode());
+                            continue;
+                        }
                         String entityUri = TextQueryFuncs.subjectToString(subject);
 
                         String dedupKey = entityUri + "|" + profile.getShapeNode().toString();
@@ -172,6 +177,11 @@ public class ShaclBulkIndexer {
                 }
                 Triple t = typeTriples.next();
                 Node subject = t.getSubject();
+                if (subject.isBlank()) {
+                    log.warn("Skipping blank-node entity (cannot be indexed): {} for shape {}",
+                        subject, profile.getShapeNode());
+                    continue;
+                }
                 String entityUri = TextQueryFuncs.subjectToString(subject);
 
                 String dedupKey = entityUri + "|" + profile.getShapeNode().toString();

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
@@ -143,7 +143,7 @@ final class ShaclEntityBuilder {
 
     static Object nodeToValue(Node obj, FieldType fieldType, boolean preserveLiteralMetadata) {
         if (obj.isLiteral()) {
-            if (preserveLiteralMetadata || fieldType == FieldType.DATE || fieldType == FieldType.DATETIME) {
+            if (preserveLiteralMetadata || fieldType == FieldType.TEMPORAL) {
                 return obj;
             }
             return switch (fieldType) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -37,7 +37,7 @@ import org.apache.lucene.analysis.Analyzer;
 public class ShaclIndexMapping {
 
     public enum FieldType {
-        TEXT, KEYWORD, INT, LONG, DOUBLE, DATE, DATETIME, LATLON
+        TEXT, KEYWORD, INT, LONG, DOUBLE, TEMPORAL, LATLON
     }
 
     public enum NodeKindConstraint {
@@ -164,8 +164,10 @@ public class ShaclIndexMapping {
         public boolean isMultiValued()       { return multiValued; }
         public boolean isDefaultSearch()     { return defaultSearch; }
         public boolean isStoreLiteralMetadata() { return storeLiteralMetadata; }
-        public boolean isDateLike()          { return fieldType == FieldType.DATE || fieldType == FieldType.DATETIME; }
-        public boolean preservesLiteralMetadata() { return storeLiteralMetadata || isDateLike(); }
+        public boolean isTemporal()          { return fieldType == FieldType.TEMPORAL; }
+        /** @deprecated use {@link #isTemporal()}. Kept for backwards compat with PR-merge windows. */
+        @Deprecated public boolean isDateLike() { return isTemporal(); }
+        public boolean preservesLiteralMetadata() { return storeLiteralMetadata || isTemporal(); }
 
         @Override
         public boolean equals(Object o) {
@@ -635,7 +637,7 @@ public class ShaclIndexMapping {
     private void validateLiteralMetadataRequirements() {
         for (IndexProfile profile : profiles) {
             for (FieldDef field : profile.getFields()) {
-                if (field.isDateLike() && !field.isStoreLiteralMetadata()) {
+                if (field.isTemporal() && !field.isStoreLiteralMetadata()) {
                     throw new TextIndexException(
                         "Field " + field.getFieldIRI().getURI() + " uses " + field.getFieldType()
                         + " and requires idx:storeLiteralMetadata true");

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java
@@ -235,6 +235,15 @@ public class ShaclTextDocProducer implements TextDocProducer {
             return;
         }
 
+        if (subject.isBlank()) {
+            List<String> shapes = new ArrayList<>();
+            for (IndexProfile profile : matchedProfiles) {
+                shapes.add(profile.getShapeNode().toString());
+            }
+            log.warn("Skipping blank-node entity (cannot be indexed): {} matched shapes {}", entityUri, shapes);
+            return;
+        }
+
         for (IndexProfile profile : matchedProfiles) {
             Entity entity = buildEntity(subject, entityUri, profile);
             indexer.updateEntityForProfile(entity, profile);

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -247,7 +247,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
     private static boolean isNumericField(ShaclIndexMapping.FieldDef fieldDef) {
         if (fieldDef == null) return false;
         return switch (fieldDef.getFieldType()) {
-            case INT, LONG, DOUBLE, DATE, DATETIME -> true;
+            case INT, LONG, DOUBLE, TEMPORAL -> true;
             default -> false;
         };
     }
@@ -736,8 +736,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                 break;
             }
 
-            case DATE:
-            case DATETIME:
+            case TEMPORAL:
                 if (fieldDef.isStored()) {
                     doc.add(new StoredField(fieldName, value.toString()));
                 }
@@ -794,7 +793,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
             case INT -> addIntegerLiteralField(doc, fieldDef, lexical);
             case LONG -> addLongLiteralField(doc, fieldDef, lexical);
             case DOUBLE -> addDoubleLiteralField(doc, fieldDef, lexical);
-            case DATE, DATETIME -> addTemporalLiteralField(doc, fieldDef, lexical);
+            case TEMPORAL -> addTemporalLiteralField(doc, fieldDef, lexical);
             case LATLON -> {
                 List<IndexableField> spatialFields = parseWktToLuceneFields(fieldName, lexical, fieldDef.isStored());
                 for (IndexableField f : spatialFields) {
@@ -1184,7 +1183,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                 case INT -> collectIntRangeFacetResults(fieldName, spec.boundaries(), collector, maxValues, minCount);
                 case LONG -> collectLongRangeFacetResults(fieldName, spec.boundaries(), collector, maxValues, minCount);
                 case DOUBLE -> collectDoubleRangeFacetResults(fieldName, spec.boundaries(), collector, maxValues, minCount);
-                case DATE, DATETIME -> collectDateRangeFacetResults(fieldDef, collector, spec.boundaries(), maxValues, minCount);
+                case TEMPORAL -> collectDateRangeFacetResults(fieldDef, collector, spec.boundaries(), maxValues, minCount);
                 default -> throw new TextIndexException("Range facet field '" + spec.fieldIri() + "' is not numeric");
             };
             result.put(fieldDef.getFieldName(), buckets);
@@ -1924,7 +1923,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                     case INT -> SortField.Type.INT;
                     case LONG -> SortField.Type.LONG;
                     case DOUBLE -> SortField.Type.DOUBLE;
-                    case DATE, DATETIME -> SortField.Type.LONG;
+                    case TEMPORAL -> SortField.Type.LONG;
                     case TEXT -> throw new TextIndexException(
                         "Cannot sort on TEXT field '" + spec.field() + "'. Use KEYWORD for sortable fields.");
                     case LATLON -> throw new TextIndexException(

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextFacetPF.java
@@ -235,8 +235,8 @@ public class TextFacetPF extends PropertyFunctionBase {
             case INT     -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDinteger);
             case LONG    -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDlong);
             case DOUBLE  -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDdouble);
-            case DATE    -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDdate);
-            case DATETIME -> NodeFactory.createLiteralDT(value, XSDDatatype.XSDdateTime);
+            case TEMPORAL -> NodeFactory.createLiteralDT(value,
+                value.contains("T") ? XSDDatatype.XSDdateTime : XSDDatatype.XSDdate);
             case LATLON  -> NodeFactory.createLiteralString(value);
         };
     }
@@ -403,7 +403,7 @@ public class TextFacetPF extends PropertyFunctionBase {
                         throw new QueryExecException("DOUBLE range boundaries must be finite");
                     }
                 }
-                case DATE, DATETIME -> LiteralFieldSupport.toEpochMillis(fd.getFieldType(), boundary);
+                case TEMPORAL -> LiteralFieldSupport.toEpochMillis(fd.getFieldType(), boundary);
                 default -> throw new QueryExecException("Range object field <" + spec.fieldIri() + "> is not numeric; use a string facet target instead");
             }
             if (i > 0 && boundaries.get(i - 1) != null) {
@@ -419,7 +419,7 @@ public class TextFacetPF extends PropertyFunctionBase {
             case INT -> Integer.compare(Integer.parseInt(left), Integer.parseInt(right));
             case LONG -> Long.compare(Long.parseLong(left), Long.parseLong(right));
             case DOUBLE -> Double.compare(Double.parseDouble(left), Double.parseDouble(right));
-            case DATE, DATETIME -> Long.compare(
+            case TEMPORAL -> Long.compare(
                 LiteralFieldSupport.toEpochMillis(fd.getFieldType(), left),
                 LiteralFieldSupport.toEpochMillis(fd.getFieldType(), right));
             default -> throw new IllegalArgumentException("Field is not numeric: " + fd.getFieldName());
@@ -428,7 +428,7 @@ public class TextFacetPF extends PropertyFunctionBase {
 
     private static boolean isNumericField(ShaclIndexMapping.FieldDef fd) {
         return switch (fd.getFieldType()) {
-            case INT, LONG, DOUBLE, DATE, DATETIME -> true;
+            case INT, LONG, DOUBLE, TEMPORAL -> true;
             default -> false;
         };
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
@@ -48,8 +48,11 @@ public class IndexVocab {
     public static final Resource IntField       = Vocab.resource(NS, "IntField");
     public static final Resource LongField      = Vocab.resource(NS, "LongField");
     public static final Resource DoubleField    = Vocab.resource(NS, "DoubleField");
-    public static final Resource DateField      = Vocab.resource(NS, "DateField");
-    public static final Resource DateTimeField  = Vocab.resource(NS, "DateTimeField");
+    public static final Resource TemporalField  = Vocab.resource(NS, "TemporalField");
+    /** @deprecated alias for {@link #TemporalField}; both resolve to {@code FieldType.TEMPORAL}. */
+    @Deprecated public static final Resource DateField      = Vocab.resource(NS, "DateField");
+    /** @deprecated alias for {@link #TemporalField}; both resolve to {@code FieldType.TEMPORAL}. */
+    @Deprecated public static final Resource DateTimeField  = Vocab.resource(NS, "DateTimeField");
     public static final Resource LatLonField    = Vocab.resource(NS, "LatLonField");
 
     // Shape-level properties

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
@@ -671,8 +671,10 @@ public class ShaclIndexAssembler {
         if (IndexVocab.IntField.getURI().equals(uri)) return FieldType.INT;
         if (IndexVocab.LongField.getURI().equals(uri)) return FieldType.LONG;
         if (IndexVocab.DoubleField.getURI().equals(uri)) return FieldType.DOUBLE;
-        if (IndexVocab.DateField.getURI().equals(uri)) return FieldType.DATE;
-        if (IndexVocab.DateTimeField.getURI().equals(uri)) return FieldType.DATETIME;
+        if (IndexVocab.TemporalField.getURI().equals(uri)) return FieldType.TEMPORAL;
+        // Deprecated aliases — both still map to FieldType.TEMPORAL for backwards compat.
+        if (IndexVocab.DateField.getURI().equals(uri)) return FieldType.TEMPORAL;
+        if (IndexVocab.DateTimeField.getURI().equals(uri)) return FieldType.TEMPORAL;
         if (IndexVocab.LatLonField.getURI().equals(uri)) return FieldType.LATLON;
         throw new TextIndexException("Unknown idx:fieldType: " + uri);
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/cmd/shacltextindexer.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/cmd/shacltextindexer.java
@@ -21,6 +21,9 @@
 
 package org.apache.jena.query.text.cmd;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.apache.jena.atlas.logging.LogCtlJUL;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdException;
@@ -48,8 +51,8 @@ public class shacltextindexer extends CmdARQ {
     public static final ArgDecl assemblerDescDecl = new ArgDecl(ArgDecl.HasValue, "desc", "dataset");
 
     protected DatasetGraphText dataset = null;
-    protected ShaclTextIndexLucene textIndex = null;
-    protected ShaclIndexMapping shaclMapping = null;
+    /** Ordered map of (registry id -> SHACL index). Always contains at least one entry. */
+    protected Map<String, ShaclTextIndexLucene> shaclIndexes = new LinkedHashMap<>();
 
     static public void main(String... argv) {
         LogCtlJUL.routeJULtoSLF4J();
@@ -93,15 +96,29 @@ public class shacltextindexer extends CmdARQ {
             throw new CmdException("No dataset description found");
 
         dataset = (DatasetGraphText)(ds.asDatasetGraph());
-        TextIndex idx = dataset.getTextIndex();
-        if (idx == null)
-            throw new CmdException("Dataset has no text index");
-        if (!(idx instanceof ShaclTextIndexLucene))
-            throw new CmdException("Text index is not a SHACL Lucene index. " +
-                "Use 'textindexer' for classic triple-per-document indexes.");
 
-        textIndex = (ShaclTextIndexLucene) idx;
-        shaclMapping = textIndex.getShaclMapping();
+        // Prefer the TextIndexRegistry stored in the dataset context (multi-index aware).
+        // Fall back to the single-index path for backwards compatibility.
+        Object regObj = dataset.getContext().get(TextQuery.textIndexRegistry);
+        if (regObj instanceof TextIndexRegistry registry) {
+            for (Map.Entry<String, TextIndexLucene> entry : registry.allWithIds().entrySet()) {
+                if (entry.getValue() instanceof ShaclTextIndexLucene shaclIdx) {
+                    shaclIndexes.put(entry.getKey(), shaclIdx);
+                }
+            }
+            if (shaclIndexes.isEmpty()) {
+                throw new CmdException("No SHACL Lucene indexes registered. " +
+                    "Use 'textindexer' for classic triple-per-document indexes.");
+            }
+        } else {
+            TextIndex idx = dataset.getTextIndex();
+            if (idx == null)
+                throw new CmdException("Dataset has no text index");
+            if (!(idx instanceof ShaclTextIndexLucene shaclIdx))
+                throw new CmdException("Text index is not a SHACL Lucene index. " +
+                    "Use 'textindexer' for classic triple-per-document indexes.");
+            shaclIndexes.put(TextIndexRegistry.DEFAULT_ID, shaclIdx);
+        }
     }
 
     @Override
@@ -116,33 +133,46 @@ public class shacltextindexer extends CmdARQ {
                 dataset.begin(ReadWrite.READ);
             }
 
-            log.info("Starting SHACL bulk indexing...");
-            log.info("  Profiles: {}", shaclMapping.getProfiles().size());
-            for (ShaclIndexMapping.IndexProfile profile : shaclMapping.getProfiles()) {
-                log.info("    {} -> {}", profile.getShapeNode(), profile.getTargetClasses());
-            }
-
-            long startTime = System.currentTimeMillis();
-
-            ShaclBulkIndexer indexer = new ShaclBulkIndexer(
-                dataset, textIndex, shaclMapping);
+            log.info("Starting SHACL bulk indexing across {} index(es)", shaclIndexes.size());
             String firstN = System.getenv(ENV_INDEX_FIRST_N);
+            long maxEntitiesPerProfile = -1;
             if (firstN != null && !firstN.isBlank()) {
-                long maxEntitiesPerProfile = Long.parseLong(firstN.trim());
-                if (maxEntitiesPerProfile > 0) {
-                    indexer.setMaxEntitiesPerProfile(maxEntitiesPerProfile);
+                long parsed = Long.parseLong(firstN.trim());
+                if (parsed > 0) {
+                    maxEntitiesPerProfile = parsed;
                     log.info("Dev mode: indexing first {} entities per SHACL profile from ${}",
                         maxEntitiesPerProfile, ENV_INDEX_FIRST_N);
                 }
             }
-            indexer.index();
 
-            textIndex.close();
+            long startTime = System.currentTimeMillis();
+            long totalEntities = 0;
+
+            for (Map.Entry<String, ShaclTextIndexLucene> entry : shaclIndexes.entrySet()) {
+                String id = entry.getKey();
+                ShaclTextIndexLucene shaclIdx = entry.getValue();
+                ShaclIndexMapping mapping = shaclIdx.getShaclMapping();
+
+                log.info("Indexing index '{}' ({} profile(s))", id, mapping.getProfiles().size());
+                for (ShaclIndexMapping.IndexProfile profile : mapping.getProfiles()) {
+                    log.info("    {} -> {}", profile.getShapeNode(), profile.getTargetClasses());
+                }
+
+                ShaclBulkIndexer indexer = new ShaclBulkIndexer(dataset, shaclIdx, mapping);
+                if (maxEntitiesPerProfile > 0) {
+                    indexer.setMaxEntitiesPerProfile(maxEntitiesPerProfile);
+                }
+                indexer.index();
+                totalEntities += indexer.getEntityCount();
+
+                shaclIdx.close();
+                log.info("  Index '{}' complete: {} entities", id, indexer.getEntityCount());
+            }
 
             long elapsed = System.currentTimeMillis() - startTime;
             long seconds = Math.max(elapsed / 1000, 1);
-            log.info("Indexing complete: {} entities in {} seconds ({} per second)",
-                indexer.getEntityCount(), seconds, indexer.getEntityCount() / seconds);
+            log.info("All indexes complete: {} entities total in {} seconds ({} per second)",
+                totalEntities, seconds, totalEntities / seconds);
 
             if (dataset.supportsTransactions()) {
                 dataset.commit();

--- a/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
@@ -429,7 +429,7 @@ public class CqlToLuceneCompiler {
             case INT -> IntPoint.newExactQuery(fieldName, toInt(value));
             case LONG -> LongPoint.newExactQuery(fieldName, toLong(value));
             case DOUBLE -> DoublePoint.newExactQuery(fieldName, toDouble(value));
-            case DATE, DATETIME -> LongPoint.newExactQuery(
+            case TEMPORAL -> LongPoint.newExactQuery(
                 LiteralFieldSupport.epochField(fieldName),
                 toEpochMillis(ft, value));
             case LATLON -> throw new TextIndexException("Equality queries not supported on LATLON field '" + fieldName + "'");
@@ -460,7 +460,7 @@ public class CqlToLuceneCompiler {
                     : Double.POSITIVE_INFINITY;
                 yield DoublePoint.newRangeQuery(fieldName, lo, hi);
             }
-            case DATE, DATETIME -> {
+            case TEMPORAL -> {
                 long lo = lower != null
                     ? (lowerInclusive ? toEpochMillis(ft, lower) : Math.addExact(toEpochMillis(ft, lower), 1L))
                     : Long.MIN_VALUE;

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -92,6 +92,7 @@ import org.junit.runners.Suite.SuiteClasses;
     , TestShaclPathSupport.class
     , TestTextQueryPFFilters.class
     , TestShaclBulkIndexer.class
+    , TestShaclBulkIndexerMultiIndex.class
 
     // CQL and multi-index tests
     , TestCqlParser.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java
@@ -65,9 +65,9 @@ public class TestDateLiteralRoundTrip {
     public void setUp() {
         FieldDef labelField = new FieldDef("label", FieldType.TEXT, null,
             true, true, false, false, false, true);
-        FieldDef dateField = new FieldDef("eventDate", FieldType.DATE, null, null,
+        FieldDef dateField = new FieldDef("eventDate", FieldType.TEMPORAL, null, null,
             true, true, false, true, false, false, true);
-        FieldDef tsField = new FieldDef("eventTimestamp", FieldType.DATETIME, null, null,
+        FieldDef tsField = new FieldDef("eventTimestamp", FieldType.TEMPORAL, null, null,
             true, true, false, true, false, false, true);
         FieldDef noteField = new FieldDef("note", FieldType.TEXT, null, null,
             true, true, false, false, false, false, true);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclBulkIndexer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclBulkIndexer.java
@@ -326,6 +326,39 @@ public class TestShaclBulkIndexer {
     }
 
     @Test
+    public void testBulkIndexSkipsBlankNodeEntities() {
+        Model model = baseDataset.getDefaultModel();
+
+        // URI-keyed book (should be indexed)
+        addBook(model, "book1", "Indexed URI Book", "Technology", "Smith");
+
+        // Blank-node book (should be skipped with a warning)
+        Resource bnodeBook = model.createResource();
+        bnodeBook.addProperty(RDF.type, ResourceFactory.createResource(NS + "Book"));
+        bnodeBook.addProperty(ResourceFactory.createProperty(NS + "title"), "Blank Node Book");
+        bnodeBook.addProperty(ResourceFactory.createProperty(NS + "category"), "Technology");
+        bnodeBook.addProperty(ResourceFactory.createProperty(NS + "author"), "Anonymous");
+
+        DatasetGraph dsg = baseDataset.asDatasetGraph();
+        ShaclBulkIndexer indexer = new ShaclBulkIndexer(dsg, textIndex, mapping);
+        indexer.index();
+
+        assertEquals("Blank-node entity must not count toward indexed entities",
+            1, indexer.getEntityCount());
+
+        List<TextHit> hits = textIndex.query(TITLE_PRED, "book", null, null);
+        Set<String> uris = new HashSet<>();
+        for (TextHit hit : hits) {
+            if (hit.getNode().isURI()) {
+                uris.add(hit.getNode().getURI());
+            } else {
+                fail("Blank-node subject should not have been indexed: " + hit.getNode());
+            }
+        }
+        assertTrue("URI book must still be indexed", uris.contains(NS + "book1"));
+    }
+
+    @Test
     public void testBulkIndexMultiValuedField() {
         Model model = baseDataset.getDefaultModel();
         Resource book = ResourceFactory.createResource(NS + "book1");

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclBulkIndexerMultiIndex.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclBulkIndexerMultiIndex.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.*;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ShaclBulkIndexer} when the dataset has multiple SHACL indexes
+ * registered via {@link TextIndexRegistry} (issue #68).
+ * <p>
+ * Mirrors what {@code shacltextindexer} does on the CLI: walks the registry,
+ * runs a {@code ShaclBulkIndexer} per registered SHACL index. Each index must
+ * receive its own documents.
+ */
+public class TestShaclBulkIndexerMultiIndex {
+
+    private static final String NS = "http://example.org/";
+    private static final Node BOOK_CLASS = NodeFactory.createURI(NS + "Book");
+    private static final Node ARTICLE_CLASS = NodeFactory.createURI(NS + "Article");
+    private static final Node TITLE_PRED = NodeFactory.createURI(NS + "title");
+    private static final Node CATEGORY_PRED = NodeFactory.createURI(NS + "category");
+    private static final Node TOPIC_PRED = NodeFactory.createURI(NS + "topic");
+
+    private Dataset baseDataset;
+    private ShaclTextIndexLucene bookIndex;
+    private ShaclTextIndexLucene articleIndex;
+    private TextIndexRegistry registry;
+
+    @Before
+    public void setUp() {
+        baseDataset = DatasetFactory.create();
+        bookIndex = makeShaclIndex("BookShape", BOOK_CLASS,
+            occurrence(textField("title"), TITLE_PRED),
+            occurrence(keywordField("category"), CATEGORY_PRED));
+        articleIndex = makeShaclIndex("ArticleShape", ARTICLE_CLASS,
+            occurrence(textField("title"), TITLE_PRED),
+            occurrence(keywordField("topic"), TOPIC_PRED));
+
+        registry = new TextIndexRegistry();
+        registry.register("books", bookIndex);
+        registry.register("articles", articleIndex);
+    }
+
+    @After
+    public void tearDown() {
+        if (registry != null) registry.close();
+        if (baseDataset != null) baseDataset.close();
+    }
+
+    @Test
+    public void testBulkIndexerProcessesEachRegisteredShaclIndex() {
+        // Load mixed data: books and articles in the same TDB (no live wrapper).
+        Model model = baseDataset.getDefaultModel();
+        addBook(model, "book1", "Machine Learning Basics", "Technology");
+        addBook(model, "book2", "Quantum Physics", "Science");
+        addArticle(model, "art1", "Deep Learning Article", "AI");
+        addArticle(model, "art2", "Cosmology Update", "Physics");
+
+        DatasetGraph dsg = baseDataset.asDatasetGraph();
+
+        // Mirror what shacltextindexer.exec() does post-PR-72: walk the registry and
+        // run ShaclBulkIndexer per registered SHACL index.
+        long total = 0;
+        for (Map.Entry<String, TextIndexLucene> entry : registry.allWithIds().entrySet()) {
+            assertTrue("Each registered index must be a SHACL Lucene index for this test",
+                entry.getValue() instanceof ShaclTextIndexLucene);
+            ShaclTextIndexLucene shaclIdx = (ShaclTextIndexLucene) entry.getValue();
+            ShaclBulkIndexer indexer = new ShaclBulkIndexer(
+                dsg, shaclIdx, shaclIdx.getShaclMapping());
+            indexer.index();
+            total += indexer.getEntityCount();
+        }
+        assertEquals("Total entities across both indexes must equal book + article count",
+            4, total);
+
+        // Each index must contain only its own docs.
+        List<TextHit> bookHits = bookIndex.query(TITLE_PRED, "machine OR quantum", null, null);
+        Set<String> bookUris = uris(bookHits);
+        assertTrue("Book index should contain book1", bookUris.contains(NS + "book1"));
+        assertTrue("Book index should contain book2", bookUris.contains(NS + "book2"));
+        assertFalse("Book index must NOT contain articles", bookUris.contains(NS + "art1"));
+
+        List<TextHit> articleHits = articleIndex.query(TITLE_PRED, "deep OR cosmology", null, null);
+        Set<String> articleUris = uris(articleHits);
+        assertTrue("Article index should contain art1", articleUris.contains(NS + "art1"));
+        assertTrue("Article index should contain art2", articleUris.contains(NS + "art2"));
+        assertFalse("Article index must NOT contain books", articleUris.contains(NS + "book1"));
+    }
+
+    // --- Helpers ---
+
+    private static FieldDef textField(String name) {
+        return new FieldDef(name, FieldType.TEXT, null,
+            true, true, false, false, false, true);
+    }
+
+    private static FieldDef keywordField(String name) {
+        return new FieldDef(name, FieldType.KEYWORD, null,
+            true, true, true, false, true, false);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Node predicate) {
+        Path path = PathFactory.pathLink(predicate);
+        return new FieldOccurrence(
+            field, path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            Collections.singleton(predicate),
+            null, null, null, null);
+    }
+
+    private static ShaclTextIndexLucene makeShaclIndex(String shapeLocalName, Node targetClass,
+                                                       FieldOccurrence... occurrences) {
+        List<FieldDef> fields = new ArrayList<>();
+        for (FieldOccurrence occ : occurrences) fields.add(occ.getField());
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + shapeLocalName),
+            Collections.singleton(targetClass),
+            "uri", "docType",
+            fields,
+            Arrays.asList(occurrences),
+            Collections.emptyList(),
+            Collections.emptyList());
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+        return new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+    }
+
+    private void addBook(Model model, String id, String title, String category) {
+        Resource r = ResourceFactory.createResource(NS + id);
+        model.add(r, RDF.type, ResourceFactory.createResource(NS + "Book"));
+        model.add(r, ResourceFactory.createProperty(NS + "title"), title);
+        model.add(r, ResourceFactory.createProperty(NS + "category"), category);
+    }
+
+    private void addArticle(Model model, String id, String title, String topic) {
+        Resource r = ResourceFactory.createResource(NS + id);
+        model.add(r, RDF.type, ResourceFactory.createResource(NS + "Article"));
+        model.add(r, ResourceFactory.createProperty(NS + "title"), title);
+        model.add(r, ResourceFactory.createProperty(NS + "topic"), topic);
+    }
+
+    private static Set<String> uris(List<TextHit> hits) {
+        Set<String> s = new HashSet<>();
+        for (TextHit h : hits) {
+            if (h.getNode().isURI()) s.add(h.getNode().getURI());
+        }
+        return s;
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclTextDocProducer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclTextDocProducer.java
@@ -229,6 +229,41 @@ public class TestShaclTextDocProducer {
     }
 
     @Test
+    public void testBlankNodeSubjectIsSkipped() {
+        // Blank-node subject with matching type and title — should not be indexed
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            Resource bnodeBook = model.createResource();
+            bnodeBook.addProperty(RDF.type, ResourceFactory.createResource(NS + "Book"));
+            bnodeBook.addProperty(ResourceFactory.createProperty(NS + "title"), "BlankNodeOnly");
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+
+        List<TextHit> hits = textIndex.query(TITLE_PRED, "BlankNodeOnly", null, null);
+        assertTrue("Blank-node entity must not be indexed", hits.isEmpty());
+
+        // URI-keyed entity in the same dataset should still index
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            Resource book = ResourceFactory.createResource(NS + "namedBook");
+            model.add(book, RDF.type, ResourceFactory.createResource(NS + "Book"));
+            model.add(book, ResourceFactory.createProperty(NS + "title"), "BlankNodeOnly Companion");
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+
+        List<TextHit> hits2 = textIndex.query(TITLE_PRED, "Companion", null, null);
+        assertEquals("URI subject must still be indexed alongside skipped blank node",
+            1, hits2.size());
+        assertEquals(NS + "namedBook", hits2.get(0).getNode().getURI());
+    }
+
+    @Test
     public void testMultipleBooks() {
         dataset.begin(ReadWrite.WRITE);
         try {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextFacetPF.java
@@ -78,7 +78,7 @@ public class TestTextFacetPF {
 
         FieldDef yearField = new FieldDef("year", FieldType.INT, null,
             true, true, true, true, true, false);
-        FieldDef publishedOnField = new FieldDef("publishedOn", FieldType.DATE, null, null,
+        FieldDef publishedOnField = new FieldDef("publishedOn", FieldType.TEMPORAL, null, null,
             true, true, true, true, false, false, true);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
@@ -219,6 +219,46 @@ public class TestShaclAssembler {
     }
 
     @Test
+    public void testTemporalFieldVocabResolvesToTemporal() {
+        // Issue #69: idx:TemporalField is the new canonical resource, idx:DateField and
+        // idx:DateTimeField are deprecated aliases — all three must produce TEMPORAL.
+        for (Resource fieldTypeRes : new Resource[]{
+                IndexVocab.TemporalField, IndexVocab.DateField, IndexVocab.DateTimeField }) {
+            Model model = createModel();
+
+            Resource tempField = model.createResource(EX + "eventDateField_" + fieldTypeRes.getLocalName())
+                .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "eventDate")
+                .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), fieldTypeRes)
+                .addProperty(model.createProperty(IndexVocab.NS, "storeLiteralMetadata"),
+                    model.createTypedLiteral(true));
+
+            Resource bookShape = model.createResource(EX + "BookShape_" + fieldTypeRes.getLocalName())
+                .addProperty(model.createProperty(SH, "targetClass"),
+                    model.createResource(EX + "Book_" + fieldTypeRes.getLocalName()))
+                .addProperty(model.createProperty(SH, "property"),
+                    occurrence(model, tempField, model.createResource(EX + "eventDate")));
+
+            RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
+            Resource indexSpec = model.createResource(EX + "index_" + fieldTypeRes.getLocalName())
+                .addProperty(RDF.type, TextVocab.textIndexShacl)
+                .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+                .addProperty(TextVocab.pShapes, shapesList);
+
+            ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
+            try {
+                FieldDef fd = index.getShaclMapping().findFieldByName("eventDate");
+                assertNotNull("Field eventDate must be parsed", fd);
+                assertEquals("All three vocab resources must produce FieldType.TEMPORAL ("
+                    + fieldTypeRes.getLocalName() + ")",
+                    org.apache.jena.query.text.ShaclIndexMapping.FieldType.TEMPORAL,
+                    fd.getFieldType());
+            } finally {
+                index.close();
+            }
+        }
+    }
+
+    @Test
     public void testSequencePathParsed() {
         Model model = createModel();
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
@@ -261,7 +261,7 @@ public class TestCqlToLuceneCompiler {
 
     @Test
     public void testDateEqualityUsesTemporalCompanionField() {
-        FieldDef eventDateField = new FieldDef("eventDate", FieldType.DATE, null, null,
+        FieldDef eventDateField = new FieldDef("eventDate", FieldType.TEMPORAL, null, null,
             true, true, false, true, false, false, true);
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/DateShape"),
@@ -285,7 +285,7 @@ public class TestCqlToLuceneCompiler {
 
     @Test
     public void testDateBetweenUsesTemporalCompanionField() {
-        FieldDef eventDateField = new FieldDef("eventDate", FieldType.DATE, null, null,
+        FieldDef eventDateField = new FieldDef("eventDate", FieldType.TEMPORAL, null, null,
             true, true, false, true, false, false, true);
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI("http://example.org/DateShape"),


### PR DESCRIPTION
Bundles three small SHACL-mode improvements.

## #66 — Skip blank-node entities

The live change-listener path (`ShaclTextDocProducer`) and bulk indexer (`ShaclBulkIndexer`) now skip subjects that are blank nodes, emitting a WARN log naming the matched shape(s) so misconfigurations producing unindexable keys are visible.

## #68 — Multi-index `shacltextindexer`

The CLI previously resolved the text index via `dataset.getTextIndex()`, which returns only the default (first-registered) index. With `text:indexes ( :a :b )`, the second index was silently ignored. Now iterates `TextIndexRegistry.allWithIds()` from the dataset context and runs `ShaclBulkIndexer` per registered SHACL index. Falls back to the single-index path when no registry is present.

## #69 — `FieldType.DATE` + `DATETIME` → `TEMPORAL`

Replaces the two enum values with a single `FieldType.TEMPORAL` backed by a single canonical `idx:TemporalField` vocabulary term. `idx:DateField` and `idx:DateTimeField` are kept as `@Deprecated` aliases that resolve to `TEMPORAL` — existing assembler configs continue to work. Round-trip fidelity preserved by inspecting the stored lexical form (contains `T` → `xsd:dateTime`, else `xsd:date`).

## Test plan
- `mvn test -pl jena-text` — 575 pass / 8 skipped (was 571 baseline; +4 new tests)
- `TestShaclBulkIndexer.testBulkIndexSkipsBlankNodeEntities`
- `TestShaclTextDocProducer.testBlankNodeSubjectIsSkipped`
- `TestShaclBulkIndexerMultiIndex.testBulkIndexerProcessesEachRegisteredShaclIndex`
- `TestShaclAssembler.testTemporalFieldVocabResolvesToTemporal` (covers all three vocab resources)
- Existing date round-trip tests pass with `TEMPORAL`

Closes #66, #68, #69.
