### PR TITLE
CQL filter: reserved property urn:jena:lucene:index#entityIri

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -427,6 +427,13 @@ public class ShaclIndexMapping {
         public boolean isNestedScoped()          { return nestedDef != null; }
     }
 
+    /**
+     * Reserved CQL filter property URI that resolves to the doc-id field of the
+     * active index. See {@link #findDocIdFieldForEntityIriProperty(String)} and
+     * issue #73.
+     */
+    public static final String ENTITY_IRI_PROPERTY = "urn:jena:lucene:index#entityIri";
+
     private final List<IndexProfile> profiles;
     private final Map<Node, List<ProfileOccurrence>> predicateLookup;
     private final Map<Node, List<ProfileOccurrence>> classConstraintLookup;
@@ -442,6 +449,7 @@ public class ShaclIndexMapping {
         validateLiteralMetadataRequirements();
         validateFieldNameUniqueness();
         validateHierarchyScopeConsistency();
+        validateDocIdFieldUniformity();
 
         this.predicateLookup = Collections.unmodifiableMap(buildPredicateLookup(this.profiles));
         this.classConstraintLookup = Collections.unmodifiableMap(buildClassConstraintLookup(this.profiles));
@@ -483,6 +491,24 @@ public class ShaclIndexMapping {
 
     public List<IndexProfile> getProfilesForClass(Node cls) {
         return classLookup.getOrDefault(cls, Collections.emptyList());
+    }
+
+    /**
+     * If {@code property} is the reserved {@link #ENTITY_IRI_PROPERTY}, returns the
+     * Lucene field name where the entity IRI is stored (the {@code idx:docIdField}
+     * value, defaulting to {@code "uri"}). Otherwise returns {@code null}.
+     * <p>
+     * Multi-profile configs are guaranteed by {@code validateDocIdFieldUniformity}
+     * to share a single doc-id field, so the choice is unambiguous.
+     */
+    public String findDocIdFieldForEntityIriProperty(String property) {
+        if (!ENTITY_IRI_PROPERTY.equals(property)) {
+            return null;
+        }
+        if (profiles.isEmpty()) {
+            return null;
+        }
+        return profiles.get(0).getDocIdField();
     }
 
     public FieldDef findField(String fieldIRI) {
@@ -663,6 +689,23 @@ public class ShaclIndexMapping {
                         "Field name '" + field.getFieldName()
                         + "' has conflicting types: " + prev + " vs " + field.getFieldType());
                 }
+            }
+        }
+    }
+
+    private void validateDocIdFieldUniformity() {
+        if (profiles.isEmpty()) {
+            return;
+        }
+        String first = profiles.get(0).getDocIdField();
+        for (int i = 1; i < profiles.size(); i++) {
+            String other = profiles.get(i).getDocIdField();
+            if (!Objects.equals(first, other)) {
+                throw new TextIndexException(
+                    "All profiles must share the same idx:docIdField (profiles in one Lucene index "
+                    + "share doc storage). Profile " + profiles.get(0).getShapeNode() + " uses '"
+                    + first + "' but profile " + profiles.get(i).getShapeNode() + " uses '"
+                    + other + "'.");
             }
         }
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
@@ -241,6 +241,11 @@ public class CqlToLuceneCompiler {
     }
 
     private CompileResult compileComparison(CqlExpression.CqlComparison cmp) {
+        Query entityIriQuery = compileEntityIriComparison(cmp);
+        if (entityIriQuery != null) {
+            return new CompileResult(entityIriQuery, null);
+        }
+
         FieldDef field = findField(cmp.property());
         if (field == null || !field.isIndexed()) {
             return new CompileResult(null, cmp);
@@ -300,6 +305,11 @@ public class CqlToLuceneCompiler {
     }
 
     private CompileResult compileIn(CqlExpression.CqlIn in) {
+        Query entityIriQuery = compileEntityIriIn(in);
+        if (entityIriQuery != null) {
+            return new CompileResult(entityIriQuery, null);
+        }
+
         FieldDef field = findField(in.property());
         if (field == null || !field.isIndexed()) {
             return new CompileResult(null, in);
@@ -476,6 +486,46 @@ public class CqlToLuceneCompiler {
 
     private FieldDef findField(String fieldIRI) {
         return mapping.findField(fieldIRI);
+    }
+
+    /**
+     * Reserved-property handler for {@code urn:jena:lucene:index#entityIri}.
+     * Translates {@code =} and {@code <>} into a TermQuery against the doc-id field.
+     * Returns null for unsupported operators (range, etc) so they fall through to residual.
+     */
+    private Query compileEntityIriComparison(CqlExpression.CqlComparison cmp) {
+        String docIdField = mapping.findDocIdFieldForEntityIriProperty(cmp.property());
+        if (docIdField == null) {
+            return null;
+        }
+        Query term = new TermQuery(new Term(docIdField, String.valueOf(cmp.value())));
+        return switch (cmp.op()) {
+            case "=" -> term;
+            case "<>" -> new BooleanQuery.Builder()
+                .add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST)
+                .add(term, BooleanClause.Occur.MUST_NOT)
+                .build();
+            default -> null;
+        };
+    }
+
+    /**
+     * Reserved-property handler for {@code urn:jena:lucene:index#entityIri}.
+     * Translates {@code in [...]} into a TermInSetQuery against the doc-id field.
+     */
+    private Query compileEntityIriIn(CqlExpression.CqlIn in) {
+        String docIdField = mapping.findDocIdFieldForEntityIriProperty(in.property());
+        if (docIdField == null) {
+            return null;
+        }
+        if (in.values().isEmpty()) {
+            return new MatchNoDocsQuery();
+        }
+        List<BytesRef> refs = new ArrayList<>(in.values().size());
+        for (Object v : in.values()) {
+            refs.add(new BytesRef(String.valueOf(v)));
+        }
+        return new TermInSetQuery(docIdField, refs);
     }
 
     private static int toInt(Object v) {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -479,4 +479,112 @@ public class TestTextQueryPFFilters {
             dataset.end();
         }
     }
+
+    @Test
+    public void testLucQueryPinnedToEntityIriEqualsSingleHit() {
+        // Issue #73: reserved property urn:jena:lucene:index#entityIri pins luc:query
+        // to a specific document by IRI. With CQL filter '=' on entityIri, exactly one
+        // hit must come back regardless of how broad the text search is.
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:index#entityIri\"},\""
+            + NS + "doc3\"]}' \"\" 20 0)\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                Set<String> subjects = new HashSet<>();
+                while (rs.hasNext()) {
+                    subjects.add(rs.next().getResource("s").getURI());
+                }
+                assertEquals("Pinning to entityIri should return exactly one entity",
+                    Collections.singleton(NS + "doc3"), subjects);
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testLucQueryPinnedToEntityIriInSet() {
+        // Issue #73: 'in' on entityIri pins to a set of entities.
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
+            "    '{\"op\":\"in\",\"args\":[{\"property\":\"urn:jena:lucene:index#entityIri\"},"
+            + "[\"" + NS + "doc1\",\"" + NS + "doc5\"]]}' \"\" 20 0)\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                Set<String> subjects = new HashSet<>();
+                while (rs.hasNext()) {
+                    subjects.add(rs.next().getResource("s").getURI());
+                }
+                Set<String> expected = new HashSet<>(Arrays.asList(NS + "doc1", NS + "doc5"));
+                assertEquals("'in' on entityIri should return only the listed entities",
+                    expected, subjects);
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testLucQueryEntityIriCombinedWithFieldFilter() {
+        // Issue #73: reserved entityIri compose with other filters; AND should
+        // intersect to either zero or one hit (the pinned entity if its other
+        // attributes match the field filter).
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
+            "    '{\"op\":\"and\",\"args\":[" +
+            "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:index#entityIri\"},\""
+            + NS + "doc3\"]}," +
+            "      {\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:field#category\"},\""
+            + NS + "category/technology\"]}" +
+            "    ]}' \"\" 20 0)\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                Set<String> subjects = new HashSet<>();
+                while (rs.hasNext()) {
+                    subjects.add(rs.next().getResource("s").getURI());
+                }
+                // doc3 is in category/technology, so the AND matches.
+                assertEquals(Collections.singleton(NS + "doc3"), subjects);
+            }
+        } finally {
+            dataset.end();
+        }
+    }
+
+    @Test
+    public void testLucQueryEntityIriUnknownReturnsEmpty() {
+        // Pinning to a non-existent IRI returns no hits.
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"learning\" " +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"urn:jena:lucene:index#entityIri\"},"
+            + "\"http://example.org/nonexistent\"]}' \"\" 20 0)\n" +
+            "}";
+
+        dataset.begin(ReadWrite.READ);
+        try {
+            try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+                ResultSet rs = qe.execSelect();
+                assertFalse("Pinning to unknown IRI should yield zero hits", rs.hasNext());
+            }
+        } finally {
+            dataset.end();
+        }
+    }
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/cql/TestCqlToLuceneCompiler.java
@@ -368,6 +368,163 @@ public class TestCqlToLuceneCompiler {
         assertTrue(r.pushed() instanceof DrillDownQuery);
     }
 
+    // --- Reserved property: urn:jena:lucene:index#entityIri (issue #73) ---
+
+    private static final String ENTITY_IRI = ShaclIndexMapping.ENTITY_IRI_PROPERTY;
+    private static final String SAMPLE_IRI = "http://example.org/borehole/BH123456";
+
+    @Test
+    public void testEntityIriEqualityIsTermQueryOnDocIdField() {
+        CqlExpression expr = new CqlExpression.CqlComparison("=", ENTITY_IRI, SAMPLE_IRI);
+        CqlToLuceneCompiler.CompileResult r = compiler.compile(expr);
+
+        assertNotNull("=' on entityIri must push down", r.pushed());
+        assertNull("No residual for entityIri equality", r.residual());
+        assertTrue("Should be a TermQuery", r.pushed() instanceof TermQuery);
+        TermQuery tq = (TermQuery) r.pushed();
+        assertEquals("Field must be the configured docIdField (default 'uri')",
+            "uri", tq.getTerm().field());
+        assertEquals(SAMPLE_IRI, tq.getTerm().text());
+    }
+
+    @Test
+    public void testEntityIriNotEqualityIsMatchAllMinusTerm() {
+        CqlExpression expr = new CqlExpression.CqlComparison("<>", ENTITY_IRI, SAMPLE_IRI);
+        CqlToLuceneCompiler.CompileResult r = compiler.compile(expr);
+
+        assertNotNull(r.pushed());
+        assertNull(r.residual());
+        assertTrue(r.pushed() instanceof BooleanQuery);
+        BooleanQuery bq = (BooleanQuery) r.pushed();
+        boolean hasMatchAllMust = bq.clauses().stream()
+            .anyMatch(c -> c.occur() == BooleanClause.Occur.MUST
+                && c.query() instanceof MatchAllDocsQuery);
+        boolean hasTermMustNot = bq.clauses().stream()
+            .anyMatch(c -> c.occur() == BooleanClause.Occur.MUST_NOT
+                && c.query() instanceof TermQuery);
+        assertTrue("Should contain MatchAllDocsQuery as MUST", hasMatchAllMust);
+        assertTrue("Should contain TermQuery as MUST_NOT", hasTermMustNot);
+    }
+
+    @Test
+    public void testEntityIriInIsTermInSetQuery() {
+        CqlExpression in = new CqlExpression.CqlIn(ENTITY_IRI,
+            List.of("http://example.org/a", "http://example.org/b"));
+        CqlToLuceneCompiler.CompileResult r = compiler.compile(in);
+
+        assertNotNull(r.pushed());
+        assertNull(r.residual());
+        assertTrue(r.pushed() instanceof TermInSetQuery);
+    }
+
+    @Test
+    public void testEntityIriEmptyInIsMatchNoDocs() {
+        CqlExpression in = new CqlExpression.CqlIn(ENTITY_IRI, Collections.emptyList());
+        CqlToLuceneCompiler.CompileResult r = compiler.compile(in);
+
+        assertNotNull(r.pushed());
+        assertNull(r.residual());
+        assertTrue(r.pushed() instanceof MatchNoDocsQuery);
+    }
+
+    @Test
+    public void testEntityIriRangeFallsThroughToResidual() {
+        // Range operators don't make sense on IRIs; should not push down.
+        CqlExpression expr = new CqlExpression.CqlComparison(">", ENTITY_IRI, SAMPLE_IRI);
+        CqlToLuceneCompiler.CompileResult r = compiler.compile(expr);
+
+        assertNull("Range on entityIri must not push", r.pushed());
+        assertNotNull("Range on entityIri must remain residual", r.residual());
+    }
+
+    @Test
+    public void testEntityIriBetweenFallsThroughToResidual() {
+        CqlExpression btw = new CqlExpression.CqlBetween(ENTITY_IRI,
+            "http://example.org/a", "http://example.org/z");
+        CqlToLuceneCompiler.CompileResult r = compiler.compile(btw);
+
+        assertNull(r.pushed());
+        assertNotNull(r.residual());
+    }
+
+    @Test
+    public void testEntityIriLikeFallsThroughToResidual() {
+        CqlExpression like = new CqlExpression.CqlLike(ENTITY_IRI, "http://example.org/%");
+        CqlToLuceneCompiler.CompileResult r = compiler.compile(like);
+
+        assertNull(r.pushed());
+        assertNotNull(r.residual());
+    }
+
+    @Test
+    public void testEntityIriCombinedWithFieldFilter() {
+        CqlExpression entityFilter = new CqlExpression.CqlComparison("=", ENTITY_IRI, SAMPLE_IRI);
+        CqlExpression stateFilter = new CqlExpression.CqlComparison("=", FP + "state", "WA");
+        CqlExpression and = new CqlExpression.CqlAnd(List.of(entityFilter, stateFilter));
+
+        CqlToLuceneCompiler.CompileResult r = compiler.compile(and);
+
+        assertNotNull("AND of two pushable filters should push fully", r.pushed());
+        assertNull(r.residual());
+    }
+
+    @Test
+    public void testEntityIriHonoursCustomDocIdField() {
+        FieldDef nameField = new FieldDef("name", FieldType.KEYWORD, null,
+            true, true, false, false, false, false);
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI("http://example.org/Shape"),
+            Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
+            "entityUri", "docType",
+            Collections.singletonList(nameField),
+            Collections.singletonList(occurrence(nameField, "http://example.org/name")),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        CqlToLuceneCompiler customCompiler =
+            new CqlToLuceneCompiler(new ShaclIndexMapping(Collections.singletonList(profile)));
+
+        CqlExpression expr = new CqlExpression.CqlComparison("=", ENTITY_IRI, SAMPLE_IRI);
+        CqlToLuceneCompiler.CompileResult r = customCompiler.compile(expr);
+
+        assertNotNull(r.pushed());
+        TermQuery tq = (TermQuery) r.pushed();
+        assertEquals("Reserved entityIri must resolve to the configured docIdField",
+            "entityUri", tq.getTerm().field());
+    }
+
+    @Test
+    public void testMultiProfileMismatchedDocIdFieldRejectedAtConstruction() {
+        FieldDef nameA = new FieldDef("nameA", FieldType.KEYWORD, null,
+            true, true, false, false, false, false);
+        FieldDef nameB = new FieldDef("nameB", FieldType.KEYWORD, null,
+            true, true, false, false, false, false);
+        IndexProfile a = new IndexProfile(
+            NodeFactory.createURI("http://example.org/ShapeA"),
+            Collections.singleton(NodeFactory.createURI("http://example.org/A")),
+            "uri", "docType",
+            Collections.singletonList(nameA),
+            Collections.singletonList(occurrence(nameA, "http://example.org/nameA")),
+            Collections.emptyList(),
+            Collections.emptyList());
+        IndexProfile b = new IndexProfile(
+            NodeFactory.createURI("http://example.org/ShapeB"),
+            Collections.singleton(NodeFactory.createURI("http://example.org/B")),
+            "entityUri", "docType",
+            Collections.singletonList(nameB),
+            Collections.singletonList(occurrence(nameB, "http://example.org/nameB")),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        try {
+            new ShaclIndexMapping(Arrays.asList(a, b));
+            fail("Expected TextIndexException for mismatched docIdField across profiles");
+        } catch (org.apache.jena.query.text.TextIndexException e) {
+            assertTrue("Error message should mention idx:docIdField",
+                e.getMessage().contains("idx:docIdField") || e.getMessage().contains("docIdField"));
+        }
+    }
+
     private static FieldOccurrence occurrence(FieldDef field, String predicateUri) {
         Node predicate = NodeFactory.createURI(predicateUri);
         return new FieldOccurrence(


### PR DESCRIPTION
## Summary

Adds a reserved CQL filter property `urn:jena:lucene:index#entityIri` that resolves to the active index's `idx:docIdField` (default `"uri"`). Allows clients to pin `luc:query` to a specific entity — or a small set — by IRI, without declaring a duplicate KEYWORD field that would double-store the value.

Closes #73.

## Operators

| CQL operator | Lucene query |
|---|---|
| `=` | `TermQuery` |
| `<>` | `MatchAllDocsQuery` (MUST) + `TermQuery` (MUST_NOT) |
| `in` | `TermInSetQuery` (empty list → `MatchNoDocsQuery`) |
| `>`, `>=`, `<`, `<=`, `like`, `between` | residual (do not push down) |

## Files

| File | Change |
|---|---|
| `ShaclIndexMapping.java` | Adds `ENTITY_IRI_PROPERTY` constant, `findDocIdFieldForEntityIriProperty(property)` helper, and `validateDocIdFieldUniformity()` validator |
| `cql/CqlToLuceneCompiler.java` | New helpers `compileEntityIriComparison` and `compileEntityIriIn` consulted before the existing `findField == null → residual` early returns in `compileComparison` and `compileIn` |
| `cql/TestCqlToLuceneCompiler.java` | +10 unit tests |
| `TestTextQueryPFFilters.java` | +4 SPARQL-level integration tests |

## Test plan
- [x] `mvn test -pl jena-text` — 585 pass / 8 skipped (was 571 baseline; +14 new)
- [x] Unit tests cover `=`, `<>`, `in`, empty `in`, range/`between`/`like` fall-through, `AND` combination with another field filter, custom `docIdField`, multi-profile validation rejection
- [x] Integration tests cover SPARQL `luc:query` with the reserved property: pinning to one entity returns exactly one hit, `in` returns the listed set, `AND` with field filter intersects, unknown IRI returns zero hits

## Open questions / decisions to confirm

1. **Strict multi-profile validation.** Construction now rejects multiple profiles with different `docIdField` values. The issue explicitly recommended this; alternative was permissive `OR` query across distinct field names. **Strict was chosen.** If anyone has a config with divergent docIdField values, they will fail at startup. (Probably nobody does — the default is `"uri"` everywhere.)

2. **JSON RHS syntax in the issue example.** The issue's example uses `{"value":"..."}` for the right-hand side of `=`. The existing CQL JSON parser uses bare strings (`[{"property":"..."}, "literal"]`). I used the existing convention — flagging in case the issue author intended a parser change too.

3. **`luc:facet` interaction.** The issue's motivating example pairs the new `luc:query` filter with `luc:facet (?s)`. I have NOT touched `TextFacetPF`. The assumption is that since pinning produces a single-hit result, `luc:facet` already operates per-subject. If there's separate plumbing needed to scope facet counts to a single entity, that's a follow-up — happy to extend or file as a separate issue if needed.

Happy to revise any of the above based on review.