### PR TITLE
Fix broken main: remove dangling TestBulkIndexerParallelism suite reference

### DIFF
--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -94,7 +94,6 @@ import org.junit.runners.Suite.SuiteClasses;
     , TestShaclBulkIndexer.class
     , TestShaclBulkIndexerMultiIndex.class
     , TestFacetCachingInvalidation.class
-    , TestBulkIndexerParallelism.class
 
     // CQL and multi-index tests
     , TestCqlParser.class


### PR DESCRIPTION
After #77 reverted the parallel bulk indexer and deleted `TestBulkIndexerParallelism.java`, #76's merge resolution inadvertently kept the now-dangling suite entry. Current `main` doesn't compile:

```
TS_Text.java:[97,7] cannot find symbol
  symbol: class TestBulkIndexerParallelism
```

This PR removes the stale line. One-line change.

## Test plan
- [x] `mvn test -pl jena-text -Drat.skip` — 594 pass / 8 skipped, BUILD SUCCESS

CI on `main` would have caught this if it ran on merge; the `pr.yml` workflow only triggers on `opened`/`reopened` so post-merge state went unverified.