### PR TITLE
CI trivy scans: PR + main gate, nightly findings issue, GHCR auto-link

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@
 name: Build and push Docker images
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -32,6 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -44,7 +48,31 @@ jobs:
           VERSION=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push fuseki-ai image
+      # ─── fuseki-ai: build amd64 (load), scan, push multi-arch on main ───────
+
+      - name: Build fuseki-ai (amd64, load for scan)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build-files/docker/Dockerfile.runtime
+          platforms: linux/amd64
+          load: true
+          tags: fuseki-ai:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan fuseki-ai (HIGH, CRITICAL)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: fuseki-ai:scan
+          format: table
+          severity: HIGH,CRITICAL
+          scanners: vuln
+          exit-code: '1'
+          ignore-unfixed: false
+
+      - name: Push fuseki-ai (multi-arch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -57,7 +85,31 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and push fuseki-loader image
+      # ─── fuseki-loader: build amd64 (load), scan, push multi-arch on main ──
+
+      - name: Build fuseki-loader (amd64, load for scan)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build-files/docker/Dockerfile.loader
+          platforms: linux/amd64
+          load: true
+          tags: fuseki-loader:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan fuseki-loader (HIGH, CRITICAL)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: fuseki-loader:scan
+          format: table
+          severity: HIGH,CRITICAL
+          scanners: vuln
+          exit-code: '1'
+          ignore-unfixed: false
+
+      - name: Push fuseki-loader (multi-arch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -67,3 +119,5 @@ jobs:
           tags: |
             ${{ env.LOADER_IMAGE }}:${{ steps.version.outputs.version }}
             ${{ env.LOADER_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/scan-published.yml
+++ b/.github/workflows/scan-published.yml
@@ -1,0 +1,126 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+name: Nightly trivy scan of published images
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # daily at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  issues: write
+
+env:
+  FUSEKI_IMAGE: ghcr.io/${{ github.repository_owner }}/fuseki-ai
+  LOADER_IMAGE: ghcr.io/${{ github.repository_owner }}/fuseki-loader
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GHCR (read)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan fuseki-ai
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.FUSEKI_IMAGE }}:latest
+          format: table
+          severity: HIGH,CRITICAL
+          scanners: vuln
+          output: trivy-fuseki-ai.txt
+          exit-code: '0'
+
+      - name: Scan fuseki-loader
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.LOADER_IMAGE }}:latest
+          format: table
+          severity: HIGH,CRITICAL
+          scanners: vuln
+          output: trivy-fuseki-loader.txt
+          exit-code: '0'
+
+      - name: Detect findings
+        id: check
+        run: |
+          # trivy table format prints a "Total: N (...)" line per Result; N > 0 means
+          # there are HIGH/CRITICAL findings in that image. A clean image emits no
+          # table, so the file is empty / has no Total line.
+          ai_findings=0
+          loader_findings=0
+          if [ -s trivy-fuseki-ai.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-ai.txt; then
+            ai_findings=1
+          fi
+          if [ -s trivy-fuseki-loader.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-loader.txt; then
+            loader_findings=1
+          fi
+          if [ "$ai_findings" = "1" ] || [ "$loader_findings" = "1" ]; then
+            echo "has_findings=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build issue body
+        if: steps.check.outputs.has_findings == 'true'
+        run: |
+          {
+            echo "/cc @aiworkerjohns @recalcitrantsupplant @lalewis1"
+            echo ""
+            echo "Trivy found HIGH/CRITICAL findings in the published images. Reproduce with the \`scan-images\` skill or \`task scan\`."
+            echo ""
+            echo "- **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "- **Scanned at:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+            echo ""
+            echo "### \`${{ env.FUSEKI_IMAGE }}:latest\`"
+            if [ -s trivy-fuseki-ai.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-ai.txt; then
+              echo '```'
+              cat trivy-fuseki-ai.txt
+              echo '```'
+            else
+              echo "_clean — no HIGH/CRITICAL findings_"
+            fi
+            echo ""
+            echo "### \`${{ env.LOADER_IMAGE }}:latest\`"
+            if [ -s trivy-fuseki-loader.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-loader.txt; then
+              echo '```'
+              cat trivy-fuseki-loader.txt
+              echo '```'
+            else
+              echo "_clean — no HIGH/CRITICAL findings_"
+            fi
+          } > issue-body.md
+
+      - name: Create or update findings issue
+        if: steps.check.outputs.has_findings == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title="Nightly trivy scan: HIGH/CRITICAL findings"
+          # de-dupe: comment on the existing open issue with that exact title
+          existing=$(gh issue list -R "${{ github.repository }}" \
+                       --state open --limit 100 \
+                       --json number,title \
+                     | jq -r --arg t "$title" '.[] | select(.title==$t) | .number' \
+                     | head -1)
+          if [ -n "$existing" ]; then
+            echo "Adding comment to existing issue #$existing"
+            gh issue comment "$existing" -R "${{ github.repository }}" --body-file issue-body.md
+          else
+            echo "Creating new issue"
+            gh issue create -R "${{ github.repository }}" \
+              --title "$title" \
+              --body-file issue-body.md
+          fi
+
+      - name: Fail workflow if findings
+        if: steps.check.outputs.has_findings == 'true'
+        run: |
+          echo "::error::Trivy found HIGH/CRITICAL findings in published images. See created/updated issue."
+          exit 1

--- a/build-files/docker/Dockerfile.loader
+++ b/build-files/docker/Dockerfile.loader
@@ -49,6 +49,8 @@ COPY . .
 
 FROM eclipse-temurin:21-jre-ubi10-minimal
 
+LABEL org.opencontainers.image.source=https://github.com/aiworkerjohns/jena
+
 WORKDIR /fuseki
 
 COPY build-files/docker/loader-entrypoint.sh ./entrypoint.sh

--- a/build-files/docker/Dockerfile.runtime
+++ b/build-files/docker/Dockerfile.runtime
@@ -43,6 +43,8 @@ COPY . .
 
 FROM eclipse-temurin:21-jre-ubi10-minimal
 
+LABEL org.opencontainers.image.source=https://github.com/aiworkerjohns/jena
+
 WORKDIR /fuseki
 
 COPY --from=builder /build/jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-*.jar ./jena-fuseki-server.jar


### PR DESCRIPTION
## Summary
Three things that build on PR #82 (the libthrift fix + scan tooling):

1. **Trivy gates publish in `docker.yml`.** New `pull_request` trigger so every PR targeting `main` builds + scans both images **without pushing**. On merge to `main`, the scan runs again and the multi-arch push only happens if the scan is clean. Severity threshold `HIGH,CRITICAL` with `exit-code: 1`, so any finding fails the workflow (and, once the job is listed as a required check in branch protection, blocks merge).
2. **Nightly scan of published images** (`scan-published.yml`). Runs daily at **03:00 UTC** and on `workflow_dispatch`. Pulls `fuseki-ai:latest` and `fuseki-loader:latest` from GHCR and scans both. On findings it creates a single tracking issue *"Nightly trivy scan: HIGH/CRITICAL findings"* — or comments on the existing open one — with the trivy table per image, `/cc`'ing **@aiworkerjohns @recalcitrantsupplant @lalewis1**, then fails the workflow.
3. **`LABEL org.opencontainers.image.source`** added to both production Dockerfiles. GHCR uses this OCI label to auto-link a package to its source repo on first push, regardless of which token did the pushing — fixes the failure mode where a manual `task *-ghcr-push` from a PAT creates a user-owned, unlinked package that CI's `GITHUB_TOKEN` then can't write to.

## Why
- `docker.yml` previously pushed first and didn't scan at all — vulnerable images could (and did) reach GHCR.
- Even with PR scanning, *new* CVEs land in **already-published** images over time; nightly catches that drift and turns it into an actionable, de-duplicated issue.
- The PAT-created package problem isn't theoretical — we hit it post-merge of PR #82 and had to delete the existing packages to recover. The `LABEL` makes the link automatic.

## Build flow in `docker.yml` (new)
- Build amd64 with `load: true` → trivy scan locally → on `push`/`main` only, rebuild multi-arch and push (`linux/amd64,linux/arm64`). GitHub Actions layer cache keeps the second build mostly cache hits.
- PR runs perform no GHCR login and no push.

## Test plan
- [ ] This PR's `docker.yml` run scans both images and (assuming clean) reports success without pushing.
- [ ] After merge, `docker.yml` on `main` scans, pushes multi-arch, packages stay auto-linked to the repo.
- [ ] First nightly run (or manual `workflow_dispatch`) of `scan-published.yml` succeeds when GHCR images are clean; failures land in the tracking issue.

## Notes / follow-ups
- Once you're happy, mark the `build-and-push` job a **required check** in branch protection so PR scan failures actually block merges.
- The scan workflows still call `aquasecurity/trivy-action` directly rather than going through the Taskfile; aligns with the existing "CI calling the Taskfile" follow-up.
- Severity threshold and schedule are easy to tune in env/cron blocks if needed.
