### PR TITLE
Tag ACR pushes with :latest; add task push_gswa convenience

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,7 +45,7 @@ tasks:
     cmds:
       - az account show > /dev/null 2>&1 || az login
       - az acr login --name {{.ACR_NAME}}
-      - docker buildx build --builder {{.BUILDX_BUILDER}} --platform {{.ACR_PLATFORMS}} -f build-files/docker/Dockerfile.runtime -t {{.ACR_NAME}}.azurecr.io/{{.RUNTIME_IMAGE_NAME}}:{{.IMAGE_TAG}} --push .
+      - docker buildx build --builder {{.BUILDX_BUILDER}} --platform {{.ACR_PLATFORMS}} -f build-files/docker/Dockerfile.runtime -t {{.ACR_NAME}}.azurecr.io/{{.RUNTIME_IMAGE_NAME}}:{{.IMAGE_TAG}} -t {{.ACR_NAME}}.azurecr.io/{{.RUNTIME_IMAGE_NAME}}:latest --push .
 
   loader-build:
     desc: Build the text-only SHACL indexer image from the repo root
@@ -67,7 +67,17 @@ tasks:
     cmds:
       - az account show > /dev/null 2>&1 || az login
       - az acr login --name {{.ACR_NAME}}
-      - docker buildx build --builder {{.BUILDX_BUILDER}} --platform {{.ACR_PLATFORMS}} -f build-files/docker/Dockerfile.loader -t {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:{{.IMAGE_TAG}} --push .
+      - docker buildx build --builder {{.BUILDX_BUILDER}} --platform {{.ACR_PLATFORMS}} -f build-files/docker/Dockerfile.loader -t {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:{{.IMAGE_TAG}} -t {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:latest --push .
+
+  push_gswa:
+    desc: Push both fuseki-ai and fuseki-loader to the GSWA ACR (gswareg.azurecr.io) with :IMAGE_TAG and :latest
+    cmds:
+      - task: runtime-acr-push
+        vars:
+          ACR_NAME: gswareg
+      - task: loader-acr-push
+        vars:
+          ACR_NAME: gswareg
 
   # ── Vulnerability scanning ──────────────────────────────
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,11 +70,14 @@ tasks:
       - docker buildx build --builder {{.BUILDX_BUILDER}} --platform {{.ACR_PLATFORMS}} -f build-files/docker/Dockerfile.loader -t {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:{{.IMAGE_TAG}} -t {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:latest --push .
 
   push_gswa:
-    desc: Push both fuseki-ai and fuseki-loader to the GSWA ACR (gswareg.azurecr.io) with :IMAGE_TAG and :latest
+    desc: Push runtime (as rdf-delta-server) and fuseki-loader to the GSWA ACR (gswareg.azurecr.io) with :IMAGE_TAG and :latest
     cmds:
+      # On gswareg the runtime is published under the GSWA naming convention
+      # (rdf-delta-server), not fuseki-ai. GHCR and gswadevacr keep fuseki-ai.
       - task: runtime-acr-push
         vars:
           ACR_NAME: gswareg
+          RUNTIME_IMAGE_NAME: rdf-delta-server
       - task: loader-acr-push
         vars:
           ACR_NAME: gswareg


### PR DESCRIPTION
## Summary
- The two ACR push tasks (`runtime-acr-push`, `loader-acr-push`) now tag the pushed image with **both** `:{{.IMAGE_TAG}}` and `:latest`, so consumers can pin either.
- Adds **`task push_gswa`** — convenience that runs `runtime-acr-push` then `loader-acr-push` against `ACR_NAME=gswareg` (the GSWA production registry).
- **On `gswareg` the runtime is published as `rdf-delta-server`**, not `fuseki-ai` — matches GSWA's naming convention for their deployment. `fuseki-loader` keeps its name. GHCR and `gswadevacr` are unchanged (`fuseki-ai` + `fuseki-loader`).

## Why
- ACR previously published only `:6.1.0-SNAPSHOT`; consumers had no `:latest` to pin. GHCR already publishes both via CI — this brings ACR to parity.
- `task push_gswa` removes the need to spell out `ACR_NAME=gswareg` twice for the standard "publish to GSWA prod" flow, and encodes the registry-specific `rdf-delta-server` naming so contributors don't have to remember it.

## Verified (mechanism)
- `:latest` push works against ACR: both `:6.1.0-SNAPSHOT` and `:latest` were pushed to `gswadevacr` and `gswareg` earlier, end up at the same digest.
- Dry-run of the updated `push_gswa`:
  ```
  docker buildx … -t gswareg.azurecr.io/rdf-delta-server:6.1.0-SNAPSHOT -t gswareg.azurecr.io/rdf-delta-server:latest --push .
  docker buildx … -t gswareg.azurecr.io/fuseki-loader:6.1.0-SNAPSHOT  -t gswareg.azurecr.io/fuseki-loader:latest  --push .
  ```

## Notes
- ACR pushes stay amd64-only (`ACR_PLATFORMS=linux/amd64`); GHCR stays multi-arch.
- Running `task push_gswa` after this merges will rebuild from current source (including the `org.opencontainers.image.source` label from #84) and overwrite the existing `rdf-delta-server:latest` in `gswareg`. Content is the same Fuseki runtime; only the OCI manifest wrapping + the source label differ from what's there now.
