### PR TITLE
KEYWORD idx:normalizer: case-/locale-aware sort & exact match (proposal + implementation)

### DIFF
--- a/build-files/rat-exclusions.txt
+++ b/build-files/rat-exclusions.txt
@@ -28,6 +28,9 @@ archive.md
 **/derby.log
 **/hs_err_pid*.log
 
+## demo test-case captured run outputs (pre/post-work snapshots)
+demo/test-cases/**/results/**
+
 ## jena-core exclusions
 **/src-examples/data/*
 

--- a/demo/test-cases/README.md
+++ b/demo/test-cases/README.md
@@ -1,0 +1,62 @@
+# Fuseki test-cases harness
+
+A small, reusable setup for spinning up a Fuseki server against a self-contained
+scenario so you can **see the behaviour in the browser** (and in the editor). Use it to
+reproduce/validate index behaviour live — the in-browser counterpart of the jena-text
+JUnit tests.
+
+Each subdirectory that contains a `config.ttl` is a **test case**. Pick one with
+`CASE=<dir>`. Every case is served under the dataset name **`ds`**.
+
+```
+test-cases/
+  Taskfile.yml            # this harness
+  README.md
+  keyword-sort-demo/      # a case
+    config.ttl            #   Fuseki + SHACL index config (in-memory)
+    data.ttl              #   sample data, loaded via GSP
+    queries/*.rq          #   one SPARQL file per thing being shown (with an #@ intent line)
+    README.md             #   what it shows + expected results
+```
+
+## Usage
+
+From this directory (`demo/test-cases/`):
+
+```bash
+task build                              # once — builds the Fuseki server jar
+task list                               # list available cases
+task run    CASE=keyword-sort-demo      # start (background) + load, prints the UI URL
+task verify CASE=keyword-sort-demo      # run every queries/*.rq, print results to eyeball
+task query  CASE=keyword-sort-demo Q=01-sort-raw-bytes   # run a single query
+task serve  CASE=keyword-sort-demo      # foreground instead (Ctrl-C to stop); load separately
+task stop                               # stop the server
+```
+
+UI for any case: `http://localhost:3032/#/dataset/ds/query`
+
+Override the port with `PORT=3033` on any command (if you change it, also update
+`idx:fusekiBase` in the case's `config.ttl` — it's only used for facet links, queries work
+regardless).
+
+## How it stays clean
+
+- Cases use an **in-memory** dataset (`ja:DatasetTxnMem`) and an in-memory Lucene
+  directory (`text:directory "mem"`), so nothing is written under the repo — data is fresh
+  on every `task run`.
+- Fuseki's working area (`FUSEKI_BASE`) and the server log are sent to `/tmp`, so they
+  never appear in the repo or trip the RAT license check during `task build`.
+
+## Adding a new case
+
+1. `mkdir mycase && cd mycase`
+2. Add `config.ttl` — copy `keyword-sort-demo/config.ttl`, keep `fuseki:name "ds"`, change the
+   shapes/fields. Keep it in-memory (`ja:DatasetTxnMem` + `text:directory "mem"`).
+3. Add `data.ttl` with sample triples.
+4. Add `queries/NN-name.rq` files. Start each with the license line and an `#@` line
+   describing intent / expected result (shown by `task verify`).
+5. Add a `README.md` with an Expected-results table.
+6. `task run CASE=mycase` then `task verify CASE=mycase`.
+
+> Turtle/SPARQL files need the first line `## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0`
+> (RAT license check). `README.md` files are exempt.

--- a/demo/test-cases/Taskfile.yml
+++ b/demo/test-cases/Taskfile.yml
@@ -1,0 +1,153 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# https://taskfile.dev
+#
+# Reusable harness for "see it in the browser" Fuseki test cases.
+# Each subdirectory that contains a config.ttl (+ data.ttl) is a case.
+# Pick one with CASE=<dir>; every case is served under dataset name "ds".
+#
+# Typical flow:
+#   task build                       # once: build the Fuseki server jar
+#   task run    CASE=keyword-sort-demo
+#   task verify CASE=keyword-sort-demo
+#   task stop
+version: '3'
+
+vars:
+  VERSION: 6.1.0-SNAPSHOT
+  FUSEKI_JAR: ../../jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-{{.VERSION}}.jar
+  PORT: '{{.PORT | default "3032"}}'
+  CASE: '{{.CASE | default "keyword-sort-demo"}}'
+  DATASET: ds
+  BASE: 'http://localhost:{{.PORT}}'
+  LOG: '/tmp/fuseki-test-cases-{{.CASE}}.log'
+
+env:
+  # Keep Fuseki's working area (run/) and logs out of the repo tree.
+  FUSEKI_BASE: '/tmp/fuseki-test-cases-base'
+
+tasks:
+  default:
+    cmds:
+      - task: list
+
+  list:
+    desc: List available test cases
+    silent: true
+    cmds:
+      - |
+        echo "Test cases (use CASE=<name>):"
+        for d in */ ; do [ -f "${d}config.ttl" ] && echo "  - ${d%/}" ; done
+        echo ""
+        echo "  task run    CASE=<name>   start (background) + load, print UI URL"
+        echo "  task verify CASE=<name>   run all queries, print results"
+        echo "  task serve  CASE=<name>   foreground (Ctrl-C to stop)"
+        echo "  task stop                 stop the harness server"
+
+  build:
+    desc: Build the Fuseki server jar (includes jena-text)
+    dir: ../..
+    cmds:
+      # 'clean' is required: an incremental install can leave the shaded uber jar
+      # bundling a stale jena-text (shade doesn't always re-run on unchanged inputs).
+      - mvn clean install -pl jena-fuseki2/jena-fuseki-server -am -DskipTests
+
+  check-jar:
+    internal: true
+    cmds:
+      - |
+        if [ ! -f "{{.FUSEKI_JAR}}" ]; then
+          echo "Fuseki jar not found at {{.FUSEKI_JAR}} — run 'task build' first."
+          exit 1
+        fi
+
+  stop:
+    desc: Stop a harness Fuseki running on PORT (default 3032)
+    cmds:
+      - |
+        pkill -f "jena-fuseki-server.*--port {{.PORT}}" && echo "stopped" || echo "nothing running on port {{.PORT}}"
+
+  serve:
+    desc: 'Foreground server (Ctrl-C to stop). Usage: task serve CASE=keyword-sort-demo'
+    deps: [check-jar]
+    cmds:
+      - |
+        echo "Serving {{.CASE}} on {{.BASE}}"
+        echo "UI         {{.BASE}}/#/dataset/{{.DATASET}}/query"
+        echo "Load data in another shell with  task load CASE={{.CASE}}"
+      - java -jar {{.FUSEKI_JAR}} --port {{.PORT}} --config {{.CASE}}/config.ttl
+
+  load:
+    desc: 'POST a case data.ttl into the running server. Usage: task load CASE=keyword-sort-demo'
+    cmds:
+      - |
+        curl -fsS -X POST -H 'Content-Type: text/turtle' --data-binary @{{.CASE}}/data.ttl '{{.BASE}}/{{.DATASET}}/data?default'
+        echo " <= loaded {{.CASE}}/data.ttl"
+
+  run:
+    desc: 'Start a case (background) + load + print URL/queries. Usage: task run CASE=keyword-sort-demo'
+    deps: [check-jar]
+    cmds:
+      - task: stop
+      - |
+        nohup java -jar {{.FUSEKI_JAR}} --port {{.PORT}} --config {{.CASE}}/config.ttl > {{.LOG}} 2>&1 &
+      - |
+        # Poll until the server actually answers 200 (retry on ANY error, incl. resets
+        # during the bind-but-not-ready startup window that --retry-connrefused misses).
+        ready=0
+        for i in $(seq 1 60); do
+          if curl -fsS -o /dev/null "{{.BASE}}/$/ping" 2>/dev/null; then ready=1; break; fi
+          sleep 1
+        done
+        [ "$ready" = 1 ] || { echo "Fuseki did not become ready on {{.BASE}} — see {{.LOG}}"; exit 1; }
+      - task: load
+      - |
+        echo ""
+        echo "▶ {{.CASE}} is up."
+        echo "  Query UI   {{.BASE}}/#/dataset/{{.DATASET}}/query"
+        echo "  Queries    {{.CASE}}/queries/*.rq   (run all: task verify CASE={{.CASE}})"
+        echo "  Expected   {{.CASE}}/README.md"
+        echo "  Log        {{.LOG}}    (stop with: task stop)"
+
+  query:
+    desc: 'Run ONE query file, print CSV. Usage: task query CASE=keyword-sort-demo Q=01-sort-raw-bytes'
+    requires:
+      vars: [Q]
+    cmds:
+      - |
+        curl -fsS -H 'Accept: text/csv' -H 'Content-Type: application/sparql-query' --data-binary @{{.CASE}}/queries/{{.Q}}.rq '{{.BASE}}/{{.DATASET}}/query'
+
+  verify:
+    desc: 'Run ALL of a case''s queries and print results. Usage: task verify CASE=keyword-sort-demo'
+    silent: true
+    cmds:
+      - |
+        for f in {{.CASE}}/queries/*.rq ; do
+          echo "=== $(basename "$f") ==="
+          grep '^#@' "$f" | sed 's/^#@ \{0,1\}//'
+          echo "--- result ---"
+          curl -fsS -H 'Accept: text/csv' -H 'Content-Type: application/sparql-query' \
+            --data-binary @"$f" '{{.BASE}}/{{.DATASET}}/query' \
+            || echo "(query failed — is the server up?  task run CASE={{.CASE}})"
+          echo ""
+        done
+        echo "Compare the above against {{.CASE}}/README.md (Expected results)."
+
+  snapshot:
+    desc: 'Capture verify output to results/<NAME>.md (server must be up). Usage: task snapshot CASE=keyword-sort-demo NAME=pre-work'
+    requires:
+      vars: [NAME]
+    silent: true
+    cmds:
+      - |
+        mkdir -p {{.CASE}}/results
+        out="{{.CASE}}/results/{{.NAME}}.md"
+        {
+          echo "# {{.CASE}} — {{.NAME}} results"
+          echo ""
+          echo "Captured $(date '+%Y-%m-%d %H:%M:%S')"
+          echo ""
+          echo '```'
+          task verify CASE={{.CASE}}
+          echo '```'
+        } > "$out"
+        echo "wrote $out"

--- a/demo/test-cases/keyword-sort-demo/README.md
+++ b/demo/test-cases/keyword-sort-demo/README.md
@@ -1,0 +1,59 @@
+# Test case: `keyword-sort-demo`
+
+Demonstrates the **current (pre-normalizer) behaviour** of sortable / exact-match
+`KEYWORD` fields, as described in
+[`docs/2026-06-25_keyword_normalizer_for_sortable_fields.md`](../../../docs/2026-06-25_keyword_normalizer_for_sortable_fields.md).
+It is the live, in-browser counterpart of the JUnit test
+`jena-text/.../TestKeywordRawSortAndExactMatch.java`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `config.ttl` | Fuseki server + SHACL Lucene index, **fully in-memory** (`ja:DatasetTxnMem` + `text:directory "mem"`). Service name `ds`. |
+| `data.ttl` | 6 `ex:Thing` entities, all `ex:label "thing"`, with `ex:name` values chosen to expose raw-byte sort. |
+| `queries/*.rq` | One SPARQL file per finding (each has an `#@` line describing intent + expected result). |
+
+## The index (`config.ttl`)
+
+- `field:label` — `TextField`, `defaultSearch` → lets the single query string `"thing"` match every entity.
+- `field:name` — `KeywordField`, `sortable` → the field under test (raw bytes, verbatim match).
+- `field:nameLC` — `KeywordField`, `sortable`, **with** `idx:analyzer [ a text:LowerCaseKeywordAnalyzer ]` → proves the analyzer slot is inert on KEYWORD.
+
+`field:name` and `field:nameLC` are populated from the **same** predicate (`ex:name`).
+
+## Run it
+
+From `demo/test-cases/`:
+
+```bash
+task run CASE=keyword-sort-demo          # build-if-needed not included; run `task build` once first
+# then open the printed UI URL, or:
+task verify CASE=keyword-sort-demo       # runs all queries, prints results to compare below
+task stop
+```
+
+UI: `http://localhost:3032/#/dataset/ds/query`
+
+## Expected results
+
+Queries 01–04 are **controls** — always raw/case-sensitive regardless of the feature.
+Queries 05–06 exercise `idx:normalizer` (`field:nameCI`) and **change** once the feature is
+implemented. Captured snapshots live in [`results/`](results/) (`pre-work.md`, `post-work.md`).
+
+| Query | Field | Demonstrates | Pre-work `?name` | Post-work `?name` |
+|-------|-------|--------------|------------------|-------------------|
+| `01-sort-raw-bytes`   | `name` (raw) | KEYWORD sort = raw UTF-8 bytes | `Apple, Smith, Zebra, apple, banana, Äpfel` | *(same)* |
+| `02-exact-match-miss` | `name` | `= "smith"` ≠ `"Smith"` | *(0 rows)* | *(same)* |
+| `03-exact-match-hit`  | `name` | `= "Smith"` matches | `Smith` | *(same)* |
+| `04-analyzer-inert`   | `nameLC` (`idx:analyzer`) | analyzer slot is inert on KEYWORD | same as 01 | *(same — still inert)* |
+| `05-normalizer-sort`  | `nameCI` (`idx:normalizer`) | normalizer → case-insensitive sort | same as 01 (feature off) | `apple, Apple, banana, Smith, Zebra, Äpfel` |
+| `06-normalizer-match` | `nameCI` | normalizer → case-insensitive `=` | *(0 rows)* | `Smith` |
+
+Raw-byte ordering (01): `A`=0x41 < `S`=0x53 < `Z`=0x5A < `a`=0x61 < `b`=0x62 < `Ä`=0xC3.
+Normalized (lower-cased) ordering (05): the sort key is the lower-cased value, so `Apple`/`apple`
+collate together and `Smith`/`Zebra` fall in alphabetical position; the stored/returned value
+stays the original casing.
+
+The controls staying raw while only `nameCI` changes proves the feature is **additive and
+opt-in** — plain KEYWORD fields (and the inert `idx:analyzer`) are untouched.

--- a/demo/test-cases/keyword-sort-demo/config.ttl
+++ b/demo/test-cases/keyword-sort-demo/config.ttl
@@ -1,0 +1,94 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+## Minimal, fully in-memory Fuseki + SHACL Lucene index used to *demonstrate* the
+## current (pre-normalizer) KEYWORD behaviour described in
+## docs/2026-06-25_keyword_normalizer_for_sortable_fields.md:
+##   - sortable KEYWORD = raw UTF-8 byte order (case-sensitive, not collated)
+##   - KEYWORD exact "=" match = verbatim (case-sensitive)
+##   - an analyzer on a KEYWORD field is inert (field:nameLC proves it)
+## In-memory dataset + "mem" Lucene dir => nothing is written to disk.
+
+PREFIX :        <#>
+PREFIX field:   <urn:jena:lucene:field#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX text:    <http://jena.apache.org/text#>
+PREFIX idx:     <urn:jena:lucene:index#>
+PREFIX sh:      <http://www.w3.org/ns/shacl#>
+PREFIX ex:      <http://example.org/>
+
+## --- Fuseki server ---
+
+[] rdf:type fuseki:Server ;
+   fuseki:services ( :service ) .
+
+:service rdf:type fuseki:Service ;
+    fuseki:name "ds" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query  ; fuseki:name "query"  ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update ; fuseki:name "update" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; fuseki:name "data"   ] ;
+    fuseki:dataset :text_dataset .
+
+## --- Text-indexed dataset (in-memory) ---
+
+:text_dataset rdf:type text:TextDataset ;
+    text:dataset :base_dataset ;
+    text:indexes ( :index ) .
+
+:base_dataset rdf:type ja:DatasetTxnMem .
+
+:index rdf:type text:TextIndexShacl ;
+    text:indexId "default" ;
+    text:directory "mem" ;
+    text:shapes ( :ThingShape ) ;
+    text:storeValues true ;
+    idx:fusekiBase "http://localhost:3032" .
+
+## --- Field definitions ---
+
+## TEXT default-search field: lets a single "thing" query match every entity.
+field:label
+    idx:fieldName "label" ;
+    idx:fieldType idx:TextField ;
+    idx:stored true ;
+    idx:defaultSearch true .
+
+## KEYWORD, sortable + exact-match: the field under test (raw bytes, verbatim).
+field:name
+    idx:fieldName "name" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored true ;
+    idx:sortable true .
+
+## Same predicate, but with a lower-casing analyzer attached via idx:analyzer. The
+## proposal's claim is that idx:analyzer is INERT on a KEYWORD field, so sorting by nameLC
+## is identical to sorting by name (still raw bytes, "Zebra" before "apple").
+field:nameLC
+    idx:fieldName "nameLC" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored true ;
+    idx:sortable true ;
+    idx:analyzer [ a text:LowerCaseKeywordAnalyzer ] .
+
+## The proposed feature: idx:normalizer applies the analyzer to the KEYWORD term + sort key.
+## PRE-WORK  (feature not implemented): idx:normalizer is an unknown property -> ignored,
+##           so nameCI behaves exactly like name (raw bytes, case-sensitive).
+## POST-WORK (feature implemented): sorting by nameCI is case-insensitive and an exact
+##           match on nameCI is case-insensitive.
+field:nameCI
+    idx:fieldName "nameCI" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored true ;
+    idx:sortable true ;
+    idx:normalizer [ a text:LowerCaseKeywordAnalyzer ] .
+
+## --- Shape ---
+
+:ThingShape
+    sh:targetClass ex:Thing ;
+    sh:property [ idx:field field:label  ; sh:path ex:label ] ;
+    sh:property [ idx:field field:name   ; sh:path ex:name ] ;
+    sh:property [ idx:field field:nameLC ; sh:path ex:name ] ;
+    sh:property [ idx:field field:nameCI ; sh:path ex:name ] .

--- a/demo/test-cases/keyword-sort-demo/data.ttl
+++ b/demo/test-cases/keyword-sort-demo/data.ttl
@@ -1,0 +1,16 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX ex:  <http://example.org/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+## Every entity shares ex:label "thing" so a single default-search query matches all.
+## The ex:name values are chosen to expose raw-byte (case-sensitive, non-collated) sort:
+##   raw ascending bytes -> Apple(0x41) Smith(0x53) Zebra(0x5A) apple(0x61) banana(0x62) Äpfel(0xC3)
+##   a locale/case-insensitive sort would instead group Apple/apple/Äpfel together.
+
+ex:e1 a ex:Thing ; ex:label "thing" ; ex:name "Zebra"  .
+ex:e2 a ex:Thing ; ex:label "thing" ; ex:name "apple"  .
+ex:e3 a ex:Thing ; ex:label "thing" ; ex:name "Äpfel"  .
+ex:e4 a ex:Thing ; ex:label "thing" ; ex:name "banana" .
+ex:e5 a ex:Thing ; ex:label "thing" ; ex:name "Apple"  .
+ex:e6 a ex:Thing ; ex:label "thing" ; ex:name "Smith"  .

--- a/demo/test-cases/keyword-sort-demo/queries/01-sort-raw-bytes.rq
+++ b/demo/test-cases/keyword-sort-demo/queries/01-sort-raw-bytes.rq
@@ -1,0 +1,11 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#@ Finding #1 - KEYWORD sort is raw UTF-8 byte order (case-sensitive, NOT locale-collated).
+#@ Expect: Apple, Smith, Zebra, apple, banana, Äpfel  (every uppercase before any lowercase; accent last).
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/>
+
+SELECT ?name WHERE {
+  (?hit ?s ?score) luc:query ("default" "default" "thing" "" '{"field":"urn:jena:lucene:field#name"}' 100 0) .
+  ?s ex:name ?name .
+}

--- a/demo/test-cases/keyword-sort-demo/queries/02-exact-match-miss.rq
+++ b/demo/test-cases/keyword-sort-demo/queries/02-exact-match-miss.rq
@@ -1,0 +1,12 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#@ Finding #2a - KEYWORD '=' is verbatim: lowercase "smith" does NOT match indexed "Smith".
+#@ Expect: 0 rows.
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/>
+
+SELECT ?name WHERE {
+  (?hit ?s ?score) luc:query ("default" "default" "thing"
+     '{"op":"=","args":[{"property":"urn:jena:lucene:field#name"},"smith"]}' "" 100 0) .
+  ?s ex:name ?name .
+}

--- a/demo/test-cases/keyword-sort-demo/queries/03-exact-match-hit.rq
+++ b/demo/test-cases/keyword-sort-demo/queries/03-exact-match-hit.rq
@@ -1,0 +1,12 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#@ Finding #2b - exact-case "Smith" DOES match (control for 02).
+#@ Expect: 1 row -> Smith.
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/>
+
+SELECT ?name WHERE {
+  (?hit ?s ?score) luc:query ("default" "default" "thing"
+     '{"op":"=","args":[{"property":"urn:jena:lucene:field#name"},"Smith"]}' "" 100 0) .
+  ?s ex:name ?name .
+}

--- a/demo/test-cases/keyword-sort-demo/queries/04-analyzer-inert.rq
+++ b/demo/test-cases/keyword-sort-demo/queries/04-analyzer-inert.rq
@@ -1,0 +1,12 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#@ Finding #4 - the analyzer slot on a KEYWORD field is inert. field:nameLC has a
+#@ LowerCaseKeywordAnalyzer attached, yet sorting by it is identical to field:name.
+#@ Expect: same order as 01 -> Apple, Smith, Zebra, apple, banana, Äpfel.
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/>
+
+SELECT ?name WHERE {
+  (?hit ?s ?score) luc:query ("default" "default" "thing" "" '{"field":"urn:jena:lucene:field#nameLC"}' 100 0) .
+  ?s ex:name ?name .
+}

--- a/demo/test-cases/keyword-sort-demo/queries/05-normalizer-sort.rq
+++ b/demo/test-cases/keyword-sort-demo/queries/05-normalizer-sort.rq
@@ -1,0 +1,12 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#@ FEATURE (idx:normalizer) - sort by field:nameCI, which declares idx:normalizer [LowerCaseKeywordAnalyzer].
+#@ PRE-WORK  expect: raw order (same as 01)  -> Apple, Smith, Zebra, apple, banana, Äpfel
+#@ POST-WORK expect: case-insensitive order  -> apple, Apple, banana, Smith, Zebra, Äpfel (the two apples adjacent)
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/>
+
+SELECT ?name WHERE {
+  (?hit ?s ?score) luc:query ("default" "default" "thing" "" '{"field":"urn:jena:lucene:field#nameCI"}' 100 0) .
+  ?s ex:name ?name .
+}

--- a/demo/test-cases/keyword-sort-demo/queries/06-normalizer-match.rq
+++ b/demo/test-cases/keyword-sort-demo/queries/06-normalizer-match.rq
@@ -1,0 +1,13 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#@ FEATURE (idx:normalizer) - exact '=' match on field:nameCI with lowercase "smith".
+#@ PRE-WORK  expect: 0 rows (normalizer ignored -> verbatim, case-sensitive)
+#@ POST-WORK expect: 1 row -> Smith (query value normalized to match indexed term)
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/>
+
+SELECT ?name WHERE {
+  (?hit ?s ?score) luc:query ("default" "default" "thing"
+     '{"op":"=","args":[{"property":"urn:jena:lucene:field#nameCI"},"smith"]}' "" 100 0) .
+  ?s ex:name ?name .
+}

--- a/demo/test-cases/keyword-sort-demo/results/post-work.md
+++ b/demo/test-cases/keyword-sort-demo/results/post-work.md
@@ -1,0 +1,66 @@
+# keyword-sort-demo — post-work results
+
+Captured 2026-07-01 14:55:11
+
+```
+=== 01-sort-raw-bytes.rq ===
+Finding #1 - KEYWORD sort is raw UTF-8 byte order (case-sensitive, NOT locale-collated).
+Expect: Apple, Smith, Zebra, apple, banana, Äpfel  (every uppercase before any lowercase; accent last).
+--- result ---
+name
+Apple
+Smith
+Zebra
+apple
+banana
+Äpfel
+
+=== 02-exact-match-miss.rq ===
+Finding #2a - KEYWORD '=' is verbatim: lowercase "smith" does NOT match indexed "Smith".
+Expect: 0 rows.
+--- result ---
+name
+
+=== 03-exact-match-hit.rq ===
+Finding #2b - exact-case "Smith" DOES match (control for 02).
+Expect: 1 row -> Smith.
+--- result ---
+name
+Smith
+
+=== 04-analyzer-inert.rq ===
+Finding #4 - the analyzer slot on a KEYWORD field is inert. field:nameLC has a
+LowerCaseKeywordAnalyzer attached, yet sorting by it is identical to field:name.
+Expect: same order as 01 -> Apple, Smith, Zebra, apple, banana, Äpfel.
+--- result ---
+name
+Apple
+Smith
+Zebra
+apple
+banana
+Äpfel
+
+=== 05-normalizer-sort.rq ===
+FEATURE (idx:normalizer) - sort by field:nameCI, which declares idx:normalizer [LowerCaseKeywordAnalyzer].
+PRE-WORK  expect: raw order (same as 01)  -> Apple, Smith, Zebra, apple, banana, Äpfel
+POST-WORK expect: case-insensitive order  -> apple, Apple, banana, Smith, Zebra, Äpfel (the two apples adjacent)
+--- result ---
+name
+apple
+Apple
+banana
+Smith
+Zebra
+Äpfel
+
+=== 06-normalizer-match.rq ===
+FEATURE (idx:normalizer) - exact '=' match on field:nameCI with lowercase "smith".
+PRE-WORK  expect: 0 rows (normalizer ignored -> verbatim, case-sensitive)
+POST-WORK expect: 1 row -> Smith (query value normalized to match indexed term)
+--- result ---
+name
+Smith
+
+Compare the above against keyword-sort-demo/README.md (Expected results).
+```

--- a/demo/test-cases/keyword-sort-demo/results/pre-work.md
+++ b/demo/test-cases/keyword-sort-demo/results/pre-work.md
@@ -1,0 +1,65 @@
+# keyword-sort-demo — pre-work results
+
+Captured 2026-07-01 14:42:26
+
+```
+=== 01-sort-raw-bytes.rq ===
+Finding #1 - KEYWORD sort is raw UTF-8 byte order (case-sensitive, NOT locale-collated).
+Expect: Apple, Smith, Zebra, apple, banana, Äpfel  (every uppercase before any lowercase; accent last).
+--- result ---
+name
+Apple
+Smith
+Zebra
+apple
+banana
+Äpfel
+
+=== 02-exact-match-miss.rq ===
+Finding #2a - KEYWORD '=' is verbatim: lowercase "smith" does NOT match indexed "Smith".
+Expect: 0 rows.
+--- result ---
+name
+
+=== 03-exact-match-hit.rq ===
+Finding #2b - exact-case "Smith" DOES match (control for 02).
+Expect: 1 row -> Smith.
+--- result ---
+name
+Smith
+
+=== 04-analyzer-inert.rq ===
+Finding #4 - the analyzer slot on a KEYWORD field is inert. field:nameLC has a
+LowerCaseKeywordAnalyzer attached, yet sorting by it is identical to field:name.
+Expect: same order as 01 -> Apple, Smith, Zebra, apple, banana, Äpfel.
+--- result ---
+name
+Apple
+Smith
+Zebra
+apple
+banana
+Äpfel
+
+=== 05-normalizer-sort.rq ===
+FEATURE (idx:normalizer) - sort by field:nameCI, which declares idx:normalizer [LowerCaseKeywordAnalyzer].
+PRE-WORK  expect: raw order (same as 01)  -> Apple, Smith, Zebra, apple, banana, Äpfel
+POST-WORK expect: case-insensitive order  -> apple, Apple, banana, Smith, Zebra, Äpfel (the two apples adjacent)
+--- result ---
+name
+Apple
+Smith
+Zebra
+apple
+banana
+Äpfel
+
+=== 06-normalizer-match.rq ===
+FEATURE (idx:normalizer) - exact '=' match on field:nameCI with lowercase "smith".
+PRE-WORK  expect: 0 rows (normalizer ignored -> verbatim, case-sensitive)
+POST-WORK expect: 1 row -> Smith (query value normalized to match indexed term)
+--- result ---
+name
+
+Compare the above against keyword-sort-demo/README.md (Expected results).
+```

--- a/docs/2026-06-25_keyword_normalizer_for_sortable_fields.md
+++ b/docs/2026-06-25_keyword_normalizer_for_sortable_fields.md
@@ -92,8 +92,19 @@ call Lucene uses to normalize wildcard/range query terms.
 
 ## Proposed configuration surface
 
-A new optional field-level property, `idx:normalizer`, pointing at an `Analyzer` resource
-(reusing the existing analyzer-assembler machinery). Only valid on `KEYWORD` fields.
+A new optional field-level property, `idx:normalizer`, pointing at an `Analyzer` resource.
+Only valid on `KEYWORD` fields. It reuses the **existing** analyzer-assembler machinery
+(`a.open(resource)`, exactly as `idx:analyzer` / `idx:queryAnalyzer` already do at
+[ShaclIndexAssembler.java:354,363](../jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java)),
+so it inherits everything that machinery already supports.
+
+### The common case needs no custom analyzer
+
+jena-text already ships a built-in lowercase keyword analyzer
+(`text:lowerCaseKeywordAnalyzer` → `LowerCaseKeywordAnalyzerAssembler`, registered at
+[TextAssembler.java:40](../jena-text/src/main/java/org/apache/jena/query/text/assembler/TextAssembler.java)) —
+a keyword tokenizer + lowercase, i.e. the canonical case-insensitive normalizer. So the
+90% case is just:
 
 ```turtle
 ## Searchable label — analyzed, for luc:query full-text
@@ -102,23 +113,55 @@ A new optional field-level property, `idx:normalizer`, pointing at an `Analyzer`
   idx:path schema:name ;
   idx:defaultSearch true ] .
 
-## Sortable / exact-match twin — KEYWORD with a lowercase normalizer
+## Sortable / exact-match twin — KEYWORD, case-insensitive via a built-in normalizer
 [ idx:fieldName "labelSort" ;
   idx:fieldType idx:KeywordField ;
   idx:path schema:name ;
   idx:sortable true ;
-  idx:normalizer [ a text:DefinedAnalyzer ;          # or a custom keyword+lowercase analyzer
-                   text:tokenizer ... ;
-                   text:filters ( ... ) ] ] .
+  idx:normalizer [ a text:lowerCaseKeywordAnalyzer ] ] .
 ```
 
-(Exact analyzer-config syntax follows whatever the existing `idx:analyzer` /
-`text:DefinedAnalyzer` assembler already supports — the normalizer reuses it. The only new
-constraint is that the configured analyzer is expected to be single-token; we apply it via
-`Analyzer.normalize()` regardless, which ignores any tokenizer split.)
+### Reuse: point `idx:normalizer` at an IRI
 
-Naming alternatives considered: `idx:caseInsensitive true` (a shorthand that maps to a
-built-in lowercase normalizer) could be added later as sugar over `idx:normalizer`.
+`a.open()` resolves **any** resource — named IRI or blank node — so a normalizer can be
+defined once and referenced from many fields by IRI. Two idioms, both already supported
+with **no extra code**:
+
+**(a) Named analyzer resource** — define once, reference by IRI:
+
+```turtle
+<#nameNormalizer> a text:lowerCaseKeywordAnalyzer .
+
+[ idx:fieldName "labelSort" ; idx:fieldType idx:KeywordField ;
+  idx:sortable true ; idx:normalizer <#nameNormalizer> ] .
+
+[ idx:fieldName "orgNameSort" ; idx:fieldType idx:KeywordField ;
+  idx:sortable true ; idx:normalizer <#nameNormalizer> ] .
+```
+
+**(b) The existing `text:defineAnalyzers` registry** — jena-text already has a global
+named-analyzer registry (`text:defineAnalyzers (...)` + `text:DefinedAnalyzer` /
+`text:useAnalyzer`, backed by `Util.getDefinedAnalyzer(key)` in
+[DefinedAnalyzerAssembler.java:48](../jena-text/src/main/java/org/apache/jena/query/text/assembler/DefinedAnalyzerAssembler.java)).
+Define an analyzer once at the top of config, then reference it by key:
+
+```turtle
+text:defineAnalyzers (
+  [ text:defineAnalyzer <#ciNorm> ; text:analyzer [ a text:lowerCaseKeywordAnalyzer ] ]
+) .
+
+[ idx:fieldName "labelSort" ; idx:fieldType idx:KeywordField ; idx:sortable true ;
+  idx:normalizer [ a text:DefinedAnalyzer ; text:useAnalyzer <#ciNorm> ] ] .
+```
+
+For a fully custom normalizer (e.g. keyword tokenizer + lowercase + ASCII folding), use
+`text:configurableAnalyzer` / `text:genericAnalyzer` as the referenced resource — same as
+custom `idx:analyzer` definitions today. The only new expectation is that the analyzer is
+single-token; we apply it via `Analyzer.normalize()` regardless, which ignores any
+tokenizer split.
+
+Naming alternatives considered: `idx:caseInsensitive true` (a shorthand mapping to
+`text:lowerCaseKeywordAnalyzer`) could be added later as sugar over `idx:normalizer`.
 
 ## Touch points (implementation map)
 
@@ -160,8 +203,9 @@ the desired behaviour, but worth a test.
 
 ## Open questions
 
-1. Ship only the generic `idx:normalizer` (analyzer resource), or also a built-in
-   `idx:caseInsensitive true` shorthand for the 90% case?
+1. The 90% case is already covered by the built-in `text:lowerCaseKeywordAnalyzer`, so
+   `idx:normalizer` alone may be enough — is the extra `idx:caseInsensitive true` sugar
+   worth it, or just document the built-in?
 2. Do we want true locale collation (`ICUCollationKeyAnalyzer`) in v1, or just
    lowercase + ASCII folding? ICU pulls in `lucene-analysis-icu` as a dependency.
 3. Should `idx:normalizer` be allowed on numeric/temporal types as a no-op error, or a hard

--- a/docs/2026-06-25_keyword_normalizer_for_sortable_fields.md
+++ b/docs/2026-06-25_keyword_normalizer_for_sortable_fields.md
@@ -93,33 +93,63 @@ call Lucene uses to normalize wildcard/range query terms.
 ## Proposed configuration surface
 
 A new optional field-level property, `idx:normalizer`, pointing at an `Analyzer` resource.
-Only valid on `KEYWORD` fields. It reuses the **existing** analyzer-assembler machinery
-(`a.open(resource)`, exactly as `idx:analyzer` / `idx:queryAnalyzer` already do at
+**Only valid on `KEYWORD` fields — a hard build failure on any other field type** (it
+signals a config mistake; see touch point #3). It reuses the **existing** analyzer-assembler
+machinery (`a.open(resource)`, exactly as `idx:analyzer` / `idx:queryAnalyzer` already do at
 [ShaclIndexAssembler.java:354,363](../jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java)),
 so it inherits everything that machinery already supports.
 
-### The common case needs no custom analyzer
+### What you can do today vs what this adds
 
-jena-text already ships a built-in lowercase keyword analyzer
-(`text:lowerCaseKeywordAnalyzer` → `LowerCaseKeywordAnalyzerAssembler`, registered at
-[TextAssembler.java:40](../jena-text/src/main/java/org/apache/jena/query/text/assembler/TextAssembler.java)) —
-a keyword tokenizer + lowercase, i.e. the canonical case-insensitive normalizer. So the
-90% case is just:
+To sort on a name today you already use the twin pattern — a `TEXT` field for search plus a
+`KEYWORD` field with `idx:sortable true` for the sort:
 
 ```turtle
-## Searchable label — analyzed, for luc:query full-text
-[ idx:fieldName "label" ;
-  idx:fieldType idx:TextField ;
-  idx:path schema:name ;
-  idx:defaultSearch true ] .
+@prefix field: <urn:jena:lucene:field#> .
+@prefix idx:   <urn:jena:lucene:index#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
 
-## Sortable / exact-match twin — KEYWORD, case-insensitive via a built-in normalizer
-[ idx:fieldName "labelSort" ;
-  idx:fieldType idx:KeywordField ;
-  idx:path schema:name ;
-  idx:sortable true ;
-  idx:normalizer [ a text:lowerCaseKeywordAnalyzer ] ] .
+## Searchable name — TEXT, analyzed, used by luc:query
+field:personName
+    idx:fieldName "personName" ;
+    idx:fieldType idx:TextField ;
+    idx:defaultSearch true ;
+    sh:path schema:name .
+
+## Sortable twin — KEYWORD, used by the sortSpec and exact `in` filters
+field:personNameSort
+    idx:fieldName "personNameSort" ;
+    idx:fieldType idx:KeywordField ;
+    idx:sortable true ;
+    sh:path schema:name .          # SAME predicate populates both fields
 ```
+
+The catch: this sort is **raw UTF-8 byte order** — case-sensitive (`"Zebra"` before
+`"apple"`), no locale. There is no config knob to change that today. **Putting an analyzer
+on the KEYWORD field does nothing**, because the KEYWORD index path uses `StringField`
+(analyzer bypassed) and DocValues are never analyzed.
+
+### What `idx:normalizer` adds
+
+`idx:normalizer` is the new wiring that makes an analyzer actually take effect on a KEYWORD
+field (applied via `Analyzer.normalize()` to the term + sort key). For the case-insensitive
+common case you reuse the **upstream** built-in `text:LowerCaseKeywordAnalyzer`
+(`LowerCaseKeywordAnalyzerAssembler`, stock Apache Jena, registered at
+[TextAssembler.java:40](../jena-text/src/main/java/org/apache/jena/query/text/assembler/TextAssembler.java)) —
+a keyword tokenizer + lowercase. So you don't have to *define* the analyzer, only point at
+it:
+
+```turtle
+field:personNameSort
+    idx:fieldName "personNameSort" ;
+    idx:fieldType idx:KeywordField ;
+    idx:sortable true ;
+    idx:normalizer [ a text:LowerCaseKeywordAnalyzer ] ;
+    sh:path schema:name .
+```
+
+To be explicit: the analyzer *class* is upstream, but it is **inert on KEYWORD today** — the
+new code in this proposal is what applies it.
 
 ### Reuse: point `idx:normalizer` at an IRI
 
@@ -130,13 +160,15 @@ with **no extra code**:
 **(a) Named analyzer resource** — define once, reference by IRI:
 
 ```turtle
-<#nameNormalizer> a text:lowerCaseKeywordAnalyzer .
+<#nameNormalizer> a text:LowerCaseKeywordAnalyzer .
 
-[ idx:fieldName "labelSort" ; idx:fieldType idx:KeywordField ;
-  idx:sortable true ; idx:normalizer <#nameNormalizer> ] .
+field:personNameSort
+    idx:fieldName "personNameSort" ; idx:fieldType idx:KeywordField ;
+    idx:sortable true ; idx:normalizer <#nameNormalizer> ; sh:path schema:name .
 
-[ idx:fieldName "orgNameSort" ; idx:fieldType idx:KeywordField ;
-  idx:sortable true ; idx:normalizer <#nameNormalizer> ] .
+field:orgNameSort
+    idx:fieldName "orgNameSort" ; idx:fieldType idx:KeywordField ;
+    idx:sortable true ; idx:normalizer <#nameNormalizer> ; sh:path schema:legalName .
 ```
 
 **(b) The existing `text:defineAnalyzers` registry** — jena-text already has a global
@@ -147,11 +179,13 @@ Define an analyzer once at the top of config, then reference it by key:
 
 ```turtle
 text:defineAnalyzers (
-  [ text:defineAnalyzer <#ciNorm> ; text:analyzer [ a text:lowerCaseKeywordAnalyzer ] ]
+  [ text:defineAnalyzer <#ciNorm> ; text:analyzer [ a text:LowerCaseKeywordAnalyzer ] ]
 ) .
 
-[ idx:fieldName "labelSort" ; idx:fieldType idx:KeywordField ; idx:sortable true ;
-  idx:normalizer [ a text:DefinedAnalyzer ; text:useAnalyzer <#ciNorm> ] ] .
+field:personNameSort
+    idx:fieldName "personNameSort" ; idx:fieldType idx:KeywordField ; idx:sortable true ;
+    idx:normalizer [ a text:DefinedAnalyzer ; text:useAnalyzer <#ciNorm> ] ;
+    sh:path schema:name .
 ```
 
 For a fully custom normalizer (e.g. keyword tokenizer + lowercase + ASCII folding), use
@@ -161,7 +195,7 @@ single-token; we apply it via `Analyzer.normalize()` regardless, which ignores a
 tokenizer split.
 
 Naming alternatives considered: `idx:caseInsensitive true` (a shorthand mapping to
-`text:lowerCaseKeywordAnalyzer`) could be added later as sugar over `idx:normalizer`.
+`text:LowerCaseKeywordAnalyzer`) — **deferred** (see open questions).
 
 ## Touch points (implementation map)
 
@@ -201,17 +235,20 @@ the desired behaviour, but worth a test.
   different normalizers.
 - Add the new test class to `TS_Text.java` (Surefire only discovers `TS_*` suites).
 
-## Open questions
+## Decisions
 
-1. The 90% case is already covered by the built-in `text:lowerCaseKeywordAnalyzer`, so
-   `idx:normalizer` alone may be enough — is the extra `idx:caseInsensitive true` sugar
-   worth it, or just document the built-in?
-2. Do we want true locale collation (`ICUCollationKeyAnalyzer`) in v1, or just
-   lowercase + ASCII folding? ICU pulls in `lucene-analysis-icu` as a dependency.
-3. Should `idx:normalizer` be allowed on numeric/temporal types as a no-op error, or a hard
-   build failure? (Recommend hard failure — it signals a config mistake.)
-4. Multi-valued normalized KEYWORD: each value is normalized independently into the
-   `SortedSetDocValues`; sort uses min/max selector as today — confirm that is acceptable.
+1. **`idx:caseInsensitive true` sugar — deferred.** Ship only the generic `idx:normalizer`
+   for now; users point it at the upstream `text:LowerCaseKeywordAnalyzer` for the common
+   case. A `caseInsensitive` shorthand can be layered on later if the boilerplate proves
+   annoying.
+2. **Locale collation (`ICUCollationKeyAnalyzer`) — out of scope for v1.** Lowercase
+   (+ optional ASCII folding) only, via the existing analyzer machinery. Revisit if true
+   linguistic ordering is needed; it would add the `lucene-analysis-icu` dependency.
+3. **`idx:normalizer` on a non-KEYWORD field — hard build failure.** It is a config error,
+   so fail fast in the assembler rather than silently ignoring it.
+4. **Multi-valued normalized KEYWORD — accepted as-is.** Each value is normalized
+   independently into `SortedSetDocValues`; sort uses the min/max selector exactly as today.
+   There is no better option, and it matches existing multi-valued sort behaviour.
 
 ## Recommendation
 

--- a/docs/2026-06-25_keyword_normalizer_for_sortable_fields.md
+++ b/docs/2026-06-25_keyword_normalizer_for_sortable_fields.md
@@ -1,0 +1,181 @@
+# Proposal: Normalizer support for KEYWORD fields (case-/locale-aware sort & exact match)
+
+## Problem
+
+A very common requirement — sort search results by a **name or label** — is awkward
+today, and the only available answer produces surprising ordering.
+
+### Why you can't just sort a TEXT field
+
+Sorting in Lucene is driven entirely by **DocValues** (a per-document columnar value),
+not by the inverted index. A `TEXT` field is analyzed/tokenized (`"Napoleon Bonaparte"`
+→ `napoleon`, `bonaparte`), so there is no single value to order by, and Lucene refuses
+to attach `SortedDocValues` to a tokenized field. Our code makes this explicit:
+
+- `ShaclTextIndexLucene.buildLuceneSort()` throws
+  `"Cannot sort on TEXT field '…'. Use KEYWORD for sortable fields."`
+  ([ShaclTextIndexLucene.java:2362](../jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java)).
+
+This is **not** a fork limitation — it is how every Lucene-based system works
+(Elasticsearch makes you sort on `name.keyword`, not `name`). The correct model is the
+"multi-field" pattern: index the label once as `TEXT` (for full-text search via
+`luc:query`) and once as `KEYWORD` (for sorting / exact `in` filters).
+
+### The remaining gap: KEYWORD sort is raw byte order
+
+Today a sortable `KEYWORD` field writes the **raw lexical value** into DocValues:
+
+```java
+// ShaclTextIndexLucene.java:1000-1002 (and the node path at :1097-1099)
+if (fieldDef.isSortable()) {
+    doc.add(new SortedDocValuesField(fieldName, new BytesRef(strVal)));
+}
+```
+
+`SortedDocValuesField` compares by **raw UTF-8 bytes**, so:
+
+- `"Zebra"` sorts **before** `"apple"` (uppercase `Z` = 0x5A < lowercase `a` = 0x61)
+- accents / locale are ignored (`"Zoë"` does not collate where a reader expects)
+
+So sorting names "works" but is case-sensitive and not locale-aware — rarely what a user
+wants for a person/organisation/title field.
+
+The same problem affects exact match: `in` / `=` on a KEYWORD field compiles to a
+`TermInSetQuery` / `TermQuery` over the **verbatim** indexed term
+([CqlToLuceneCompiler.java:542-547](../jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java)),
+so a filter for `"Smith"` will not match an indexed `"smith"`.
+
+## What the fix is — and what it is *not*
+
+### Rejected: magic sidecar on TEXT (`sortable true` on a TEXT field)
+
+An earlier idea was: when a `TEXT` field is marked `sortable`, silently emit a normalized
+`SortedDocValuesField` under a derived sidecar name and have `buildLuceneSort` redirect to
+it. **We are not doing this.** It bundles three hidden decisions into one boolean:
+
+1. a field that exists in the index but appears in no config (mangled name),
+2. an implicit normalization policy (lowercase? fold? locale?) buried in code,
+3. an implicit multi-value tiebreak (which token becomes the sort key).
+
+One flag, three invisible policies — too clever, and hard to debug.
+
+### Chosen: an explicit **normalizer** on KEYWORD fields
+
+This is exactly Elasticsearch's `keyword` + `normalizer` model. A *normalizer* is just an
+`Analyzer` constrained to emit **one token, no tokenization** — e.g. a "lowercase keyword
+analyzer":
+
+```text
+KeywordTokenizer  →  LowerCaseFilter  →  (optional ASCIIFoldingFilter / ICU folding)
+```
+
+The normalizer is a real, declared property. The field it applies to stays explicit; the
+IRI you sort on is the field you declared. No sidecar, no redirect.
+
+### The key Lucene fact: we must apply it ourselves
+
+A normalizer **is** an analyzer, but Lucene will **not** apply it automatically on our
+paths, for two independent reasons:
+
+1. **DocValues are never analyzed.** `SortedDocValuesField` takes the `BytesRef` we hand
+   it; the `IndexWriter` analyzer is never consulted for DocValues.
+2. **`StringField` is `tokenized=false`,** so even the *indexed term* bypasses the writer
+   analyzer. Our KEYWORD path uses `StringField` + `SortedDocValuesField`, and the
+   `analyzer` slot on a KEYWORD `FieldDef` is currently **inert**
+   (only `TextField` paths consult the per-field analyzer; the writer is built with a
+   single `getAnalyzer()` at [ShaclTextIndexLucene.java:1942](../jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java)).
+
+The right primitive is **`Analyzer.normalize(field, text)`** — purpose-built to turn a
+string into a single normalized `BytesRef` by running char filters + multi-term-aware
+token filters (lowercase, folding, ICU collation) **without** tokenizing. It is the same
+call Lucene uses to normalize wildcard/range query terms.
+
+## Proposed configuration surface
+
+A new optional field-level property, `idx:normalizer`, pointing at an `Analyzer` resource
+(reusing the existing analyzer-assembler machinery). Only valid on `KEYWORD` fields.
+
+```turtle
+## Searchable label — analyzed, for luc:query full-text
+[ idx:fieldName "label" ;
+  idx:fieldType idx:TextField ;
+  idx:path schema:name ;
+  idx:defaultSearch true ] .
+
+## Sortable / exact-match twin — KEYWORD with a lowercase normalizer
+[ idx:fieldName "labelSort" ;
+  idx:fieldType idx:KeywordField ;
+  idx:path schema:name ;
+  idx:sortable true ;
+  idx:normalizer [ a text:DefinedAnalyzer ;          # or a custom keyword+lowercase analyzer
+                   text:tokenizer ... ;
+                   text:filters ( ... ) ] ] .
+```
+
+(Exact analyzer-config syntax follows whatever the existing `idx:analyzer` /
+`text:DefinedAnalyzer` assembler already supports — the normalizer reuses it. The only new
+constraint is that the configured analyzer is expected to be single-token; we apply it via
+`Analyzer.normalize()` regardless, which ignores any tokenizer split.)
+
+Naming alternatives considered: `idx:caseInsensitive true` (a shorthand that maps to a
+built-in lowercase normalizer) could be added later as sugar over `idx:normalizer`.
+
+## Touch points (implementation map)
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `assembler/IndexVocab.java:67-75` | Add `public static final Property pNormalizer = Vocab.property(NS, "normalizer");` |
+| 2 | `ShaclIndexMapping.FieldDef` (`ShaclIndexMapping.java:65-188`) | Add a `normalizer` (`Analyzer`) field + `getNormalizer()`. Thread through the canonical constructor. (Many overloaded ctors exist — add to the widest one and default the rest to `null`.) |
+| 3 | `assembler/ShaclIndexAssembler.parseCanonicalField` (`:339-383`) | Parse `idx:normalizer` like `idx:analyzer` (resolve via `a.open(...)`). Reject it on non-KEYWORD types. Add the resolved node to `CanonicalFieldSpec` so `validateSameCanonicalField` (`:319-337`) checks it for consistency across occurrences. |
+| 4 | `ShaclTextIndexLucene.addFieldToDoc` KEYWORD branch (`:990-1003`) **and** `addNodeFieldToDoc` KEYWORD branch (`:1087-1100`) | When a normalizer is present, compute `BytesRef key = normalizer.normalize(fieldName, value)` once and use it for **both** the `StringField` term and the `SortedDocValuesField`. When absent, behaviour is unchanged (raw value). |
+| 5 | `cql/CqlToLuceneCompiler.compileIn` (`:542-547`) and `buildEqualQuery` KEYWORD case (`:721-723`) | When the field has a normalizer, normalize each comparison value with `normalizer.normalize(...)` before building the `TermInSetQuery` / `TermQuery`, so index-time and query-time terms match. (Mirror of how range/term queries already normalize.) |
+| 6 | `ShaclTextIndexLucene.buildLuceneSort` (`:2342-2379`) | No change needed for KEYWORD — it already targets `queryFieldName(fd)` (= `fieldName`) and the normalized DocValues live there. Just remove/keep the TEXT guard (TEXT still throws; users use the KEYWORD twin). |
+
+Note the facet interaction: `SortedSetDocValuesFacetField` is written under the raw value
+today (`:997-999`, `:1094-1096`). If a normalized KEYWORD field is also `facetable`, decide
+whether facet values should be normalized too (probably **no** — facet labels should stay
+human-readable). Keep facet values raw and only normalize the term + sort DocValues. This
+means a single field can show raw facet labels while sorting case-insensitively — which is
+the desired behaviour, but worth a test.
+
+## Backward compatibility
+
+- Within SHACL mode no backward compatibility is required (per CLAUDE.md), but this change
+  is additive: fields **without** `idx:normalizer` behave exactly as today (raw bytes).
+- Adding or changing a normalizer changes the indexed term and sort key, so it requires a
+  **reindex** of affected entities. Document this.
+
+## Testing
+
+- Sort: index `["Zebra","apple","Äpfel"]` on a normalized KEYWORD field; assert
+  case-insensitive (and, with folding, accent-insensitive) order, vs raw byte order without
+  the normalizer.
+- Exact match: index `"Smith"`, filter `in ["smith"]` → matches with normalizer, does not
+  without.
+- Facet labels remain raw while sort is normalized (combined `facetable + sortable +
+  normalizer` field).
+- `validateSameCanonicalField` rejects two occurrences declaring the same field IRI with
+  different normalizers.
+- Add the new test class to `TS_Text.java` (Surefire only discovers `TS_*` suites).
+
+## Open questions
+
+1. Ship only the generic `idx:normalizer` (analyzer resource), or also a built-in
+   `idx:caseInsensitive true` shorthand for the 90% case?
+2. Do we want true locale collation (`ICUCollationKeyAnalyzer`) in v1, or just
+   lowercase + ASCII folding? ICU pulls in `lucene-analysis-icu` as a dependency.
+3. Should `idx:normalizer` be allowed on numeric/temporal types as a no-op error, or a hard
+   build failure? (Recommend hard failure — it signals a config mistake.)
+4. Multi-valued normalized KEYWORD: each value is normalized independently into the
+   `SortedSetDocValues`; sort uses min/max selector as today — confirm that is acceptable.
+
+## Recommendation
+
+- Add `idx:normalizer` on KEYWORD fields, applied via `Analyzer.normalize()` to the term +
+  sort DocValues at index time and to comparison values at query time.
+- Keep the twin-field pattern (TEXT for search, KEYWORD for sort/exact) as the documented
+  approach; this proposal just makes the KEYWORD side collate correctly.
+- Do **not** add magic sortable-TEXT sidecar fields.
+- Immediately (independent of code): document the twin-field pattern in `01-user-guide.md`
+  so users can sort on names *today* (case-sensitively), with normalizer support landing as
+  the follow-up that fixes collation.

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -75,6 +75,9 @@ public class ShaclIndexMapping {
         private final boolean multiValued;
         private final boolean defaultSearch;
         private final boolean storeLiteralMetadata;
+        /** Optional analyzer applied (via {@link Analyzer#normalize}) to a KEYWORD field's
+         *  indexed term and sort key. Null = raw value (unchanged behaviour). */
+        private final Analyzer normalizer;
 
         public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
                         boolean stored, boolean indexed, boolean facetable,
@@ -138,6 +141,17 @@ public class ShaclIndexMapping {
                         boolean stored, boolean indexed, boolean facetable,
                         boolean sortable, boolean multiValued, boolean defaultSearch,
                         boolean storeLiteralMetadata, Node fieldIRI) {
+            this(fieldName, fieldType, analyzer, queryAnalyzer, stored, indexed, facetable,
+                sortable, multiValued, defaultSearch, storeLiteralMetadata, fieldIRI, null);
+        }
+
+        /** Canonical (widest) constructor. {@code normalizer} is the KEYWORD normalizer
+         *  (null for all other cases and for the many delegating constructors above). */
+        public FieldDef(String fieldName, FieldType fieldType, Analyzer analyzer,
+                        Analyzer queryAnalyzer,
+                        boolean stored, boolean indexed, boolean facetable,
+                        boolean sortable, boolean multiValued, boolean defaultSearch,
+                        boolean storeLiteralMetadata, Node fieldIRI, Analyzer normalizer) {
             this.fieldName = Objects.requireNonNull(fieldName);
             this.fieldType = fieldType != null ? fieldType : FieldType.TEXT;
             this.analyzer = analyzer;
@@ -149,6 +163,7 @@ public class ShaclIndexMapping {
             this.multiValued = multiValued;
             this.defaultSearch = defaultSearch;
             this.storeLiteralMetadata = storeLiteralMetadata;
+            this.normalizer = normalizer;
             this.fieldIRI = fieldIRI != null ? fieldIRI : NodeFactory.createURI(FIELD_IRI_PREFIX + fieldName);
         }
 
@@ -157,6 +172,7 @@ public class ShaclIndexMapping {
         public FieldType getFieldType()      { return fieldType; }
         public Analyzer getAnalyzer()        { return analyzer; }
         public Analyzer getQueryAnalyzer()   { return queryAnalyzer; }
+        public Analyzer getNormalizer()      { return normalizer; }
         public boolean isStored()            { return stored; }
         public boolean isIndexed()           { return indexed; }
         public boolean isFacetable()         { return facetable; }

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -77,6 +77,7 @@ import org.apache.lucene.search.*;
 import org.apache.lucene.search.NamedMatches;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.locationtech.jts.geom.*;
@@ -989,8 +990,19 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
 
             case KEYWORD:
                 String strVal = value.toString();
+                // If a normalizer is declared, the indexed term + sort key use the
+                // normalized bytes; the stored value and facet label stay raw (human-readable).
+                Analyzer kwNorm = fieldDef.getNormalizer();
+                BytesRef kwKey = kwNorm != null ? kwNorm.normalize(fieldName, strVal) : null;
                 if (fieldDef.isIndexed()) {
-                    doc.add(new StringField(fieldName, strVal, store));
+                    if (kwKey != null) {
+                        doc.add(new StringField(fieldName, kwKey.utf8ToString(), Field.Store.NO));
+                        if (fieldDef.isStored()) {
+                            doc.add(new StoredField(fieldName, strVal));
+                        }
+                    } else {
+                        doc.add(new StringField(fieldName, strVal, store));
+                    }
                 } else if (fieldDef.isStored()) {
                     doc.add(new StoredField(fieldName, strVal));
                 }
@@ -998,7 +1010,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                     doc.add(new SortedSetDocValuesFacetField(fieldName, strVal));
                 }
                 if (fieldDef.isSortable()) {
-                    doc.add(new SortedDocValuesField(fieldName, new BytesRef(strVal)));
+                    doc.add(new SortedDocValuesField(fieldName, kwKey != null ? kwKey : new BytesRef(strVal)));
                 }
                 break;
 
@@ -1086,8 +1098,18 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
             }
             case KEYWORD -> {
                 Field.Store store = fieldDef.isStored() ? Field.Store.YES : Field.Store.NO;
+                // Normalizer (if any) drives the indexed term + sort key; stored/facet stay raw.
+                Analyzer kwNorm = fieldDef.getNormalizer();
+                BytesRef kwKey = kwNorm != null ? kwNorm.normalize(fieldName, lexical) : null;
                 if (fieldDef.isIndexed()) {
-                    doc.add(new StringField(fieldName, lexical, store));
+                    if (kwKey != null) {
+                        doc.add(new StringField(fieldName, kwKey.utf8ToString(), Field.Store.NO));
+                        if (fieldDef.isStored()) {
+                            doc.add(new StoredField(fieldName, lexical));
+                        }
+                    } else {
+                        doc.add(new StringField(fieldName, lexical, store));
+                    }
                 } else if (fieldDef.isStored()) {
                     doc.add(new StoredField(fieldName, lexical));
                 }
@@ -1095,7 +1117,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                     doc.add(new SortedSetDocValuesFacetField(fieldName, lexical));
                 }
                 if (fieldDef.isSortable()) {
-                    doc.add(new SortedDocValuesField(fieldName, new BytesRef(lexical)));
+                    doc.add(new SortedDocValuesField(fieldName, kwKey != null ? kwKey : new BytesRef(lexical)));
                 }
             }
             case INT -> addIntegerLiteralField(doc, fieldDef, lexical);

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
@@ -66,6 +66,7 @@ public class IndexVocab {
     public static final Property pFieldType     = Vocab.property(NS, "fieldType");
     public static final Property pAnalyzer      = Vocab.property(NS, "analyzer");
     public static final Property pQueryAnalyzer = Vocab.property(NS, "queryAnalyzer");
+    public static final Property pNormalizer    = Vocab.property(NS, "normalizer");
     public static final Property pStored        = Vocab.property(NS, "stored");
     public static final Property pIndexed       = Vocab.property(NS, "indexed");
     public static final Property pFacetable     = Vocab.property(NS, "facetable");

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
@@ -65,7 +65,8 @@ public class ShaclIndexAssembler {
 
     private ShaclIndexAssembler() {}
 
-    private record CanonicalFieldSpec(FieldDef field, Node analyzerNode, Node queryAnalyzerNode) {}
+    private record CanonicalFieldSpec(FieldDef field, Node analyzerNode, Node queryAnalyzerNode,
+                                      Node normalizerNode) {}
 
     public static ShaclIndexMapping parseShapes(Assembler a, Resource shapesList) {
         List<IndexProfile> profiles = new ArrayList<>();
@@ -329,7 +330,8 @@ public class ShaclIndexAssembler {
                 || existingField.isDefaultSearch() != parsedField.isDefaultSearch()
                 || existingField.isStoreLiteralMetadata() != parsedField.isStoreLiteralMetadata()
                 || !Objects.equals(existing.analyzerNode(), parsed.analyzerNode())
-                || !Objects.equals(existing.queryAnalyzerNode(), parsed.queryAnalyzerNode())) {
+                || !Objects.equals(existing.queryAnalyzerNode(), parsed.queryAnalyzerNode())
+                || !Objects.equals(existing.normalizerNode(), parsed.normalizerNode())) {
             throw new TextIndexException(
                 "Canonical field " + existingField.getFieldIRI().getURI()
                 + " is defined inconsistently across occurrences");
@@ -366,6 +368,25 @@ public class ShaclIndexAssembler {
             ? queryAnalyzerStmt.getObject().asNode()
             : null;
 
+        // idx:normalizer — an analyzer applied to a KEYWORD field's indexed term + sort key.
+        // Only valid on KEYWORD fields; a config error on anything else (fail fast).
+        Analyzer normalizer = null;
+        Node normalizerNode = null;
+        Statement normalizerStmt = fieldRes.getProperty(IndexVocab.pNormalizer);
+        if (normalizerStmt != null) {
+            if (fieldType != FieldType.KEYWORD) {
+                throw new TextIndexException(
+                    "idx:normalizer is only valid on KEYWORD fields; field '" + fieldName
+                    + "' has type " + fieldType + ".");
+            }
+            if (!normalizerStmt.getObject().isResource()) {
+                throw new TextIndexException(
+                    "idx:normalizer on field '" + fieldName + "' must reference an analyzer resource.");
+            }
+            normalizer = (Analyzer) a.open(normalizerStmt.getObject().asResource());
+            normalizerNode = normalizerStmt.getObject().asNode();
+        }
+
         boolean stored = getOptionalBoolean(fieldRes, IndexVocab.pStored, true);
         boolean indexed = getOptionalBoolean(fieldRes, IndexVocab.pIndexed, true);
         boolean facetable = getOptionalBoolean(fieldRes, IndexVocab.pFacetable, false);
@@ -377,10 +398,10 @@ public class ShaclIndexAssembler {
         Node fieldIRI = fieldRes.isURIResource() ? fieldRes.asNode() : null;
         FieldDef fieldDef = new FieldDef(fieldName, fieldType, analyzer, queryAnalyzer,
             stored, indexed, facetable, sortable, multiValued, defaultSearch,
-            storeLiteralMetadata, fieldIRI);
+            storeLiteralMetadata, fieldIRI, normalizer);
         log.debug("Parsed canonical field: {} type={} facetable={}", fieldDef.getFieldName(),
             fieldDef.getFieldType(), fieldDef.isFacetable());
-        return new CanonicalFieldSpec(fieldDef, analyzerNode, queryAnalyzerNode);
+        return new CanonicalFieldSpec(fieldDef, analyzerNode, queryAnalyzerNode, normalizerNode);
     }
 
     private static void rejectOccurrencePropertiesOnCanonicalField(Resource fieldRes) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
@@ -49,6 +49,7 @@ import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.geo.Polygon;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.*;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -542,7 +543,8 @@ public class CqlToLuceneCompiler {
         if (ft == FieldType.KEYWORD || ft == FieldType.TEXT) {
             List<BytesRef> refs = new ArrayList<>();
             for (Object v : in.values()) {
-                refs.add(new BytesRef(String.valueOf(v)));
+                // KEYWORD with a normalizer: normalize each value so it matches the indexed term.
+                refs.add(keywordBytes(field, String.valueOf(v)));
             }
             return new CompileResult(maybeLiftToParent(field, new TermInSetQuery(fieldName, refs)), null);
         }
@@ -714,13 +716,26 @@ public class CqlToLuceneCompiler {
         return pq.build();
     }
 
+    /** Normalized bytes for a comparison value: applies the field's normalizer (KEYWORD only)
+     *  so query-time terms match index-time terms; raw bytes when there is no normalizer. */
+    private static BytesRef keywordBytes(FieldDef field, String value) {
+        Analyzer norm = field.getNormalizer();
+        return norm != null ? norm.normalize(field.getFieldName(), value) : new BytesRef(value);
+    }
+
+    /** String form of {@link #keywordBytes} for building a {@link Term}. */
+    private static String keywordTerm(FieldDef field, Object value) {
+        return keywordBytes(field, String.valueOf(value)).utf8ToString();
+    }
+
     private Query buildEqualQuery(FieldDef field, Object value) {
         String fieldName = field.getFieldName();
         FieldType ft = field.getFieldType();
         return switch (ft) {
-            // KEYWORD and TEXT both go to raw TermQuery — exact-term semantics.
+            // KEYWORD and TEXT go to a TermQuery — exact-term semantics. A KEYWORD field
+            // with a normalizer normalizes the comparison value first (TEXT never has one).
             // Analyzer-aware text matching uses the explicit text_query operator instead.
-            case KEYWORD, TEXT -> new TermQuery(new Term(fieldName, String.valueOf(value)));
+            case KEYWORD, TEXT -> new TermQuery(new Term(fieldName, keywordTerm(field, value)));
             case INT -> IntPoint.newExactQuery(fieldName, toInt(value));
             case LONG -> LongPoint.newExactQuery(fieldName, toLong(value));
             case DOUBLE -> DoublePoint.newExactQuery(fieldName, toDouble(value));

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -109,6 +109,11 @@ import org.junit.runners.Suite.SuiteClasses;
     // Multi-valued field support
     , TestShaclLucQueryRawValueOnMultiValuedField.class
 
+    // KEYWORD raw-byte sort + verbatim exact-match baseline (keyword-normalizer proposal)
+    , TestKeywordRawSortAndExactMatch.class
+    // idx:normalizer feature: case-insensitive KEYWORD sort + exact match
+    , TestKeywordNormalizer.class
+
     // luc:match property function
     , TestTextMatchPF.class
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizer.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.analyzer.LowerCaseKeywordAnalyzer;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Feature test for {@code idx:normalizer} on a KEYWORD field. The counterpart baseline
+ * {@link TestKeywordRawSortAndExactMatch} asserts that a KEYWORD field WITHOUT a normalizer
+ * is raw/case-sensitive; this asserts that adding a lower-casing normalizer makes both
+ * the sort key and exact match case-insensitive, per
+ * {@code docs/2026-06-25_keyword_normalizer_for_sortable_fields.md}.
+ */
+public class TestKeywordNormalizer {
+
+    private static final String NS = "http://example.org/";
+    private static final String FP = "urn:jena:lucene:field#";
+    private static final Node THING_CLASS = NodeFactory.createURI(NS + "Thing");
+    private static final Node TITLE_PRED = NodeFactory.createURI(NS + "title");
+    private static final Node NAME_PRED = NodeFactory.createURI(NS + "name");
+
+    private static final String AEPFEL = "Äpfel";
+
+    private Dataset dataset;
+    private final Map<String, String> uriToName = new LinkedHashMap<>();
+
+    @Before
+    public void setUp() {
+        TextQuery.init();
+
+        FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, false, true);
+        // KEYWORD, sortable, WITH a lower-casing normalizer (the feature under test).
+        FieldDef nameField = new FieldDef("name", FieldType.KEYWORD, null, null,
+            true, true, false, true, false, false, false, null, new LowerCaseKeywordAnalyzer());
+
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(nameField, PathFactory.pathLink(NAME_PRED), Collections.singleton(NAME_PRED)));
+
+        IndexProfile thingProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "ThingShape"),
+            Collections.singleton(THING_CLASS),
+            "uri", "docType",
+            Arrays.asList(titleField, nameField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(thingProfile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setValueStored(true);
+
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), textIndex, mapping);
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+    }
+
+    private void addThing(String localName, String name) {
+        String uri = NS + localName;
+        uriToName.put(uri, name);
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            Resource r = ResourceFactory.createResource(uri);
+            model.add(r, RDF.type, ResourceFactory.createResource(NS + "Thing"));
+            model.add(r, ResourceFactory.createProperty(NS + "title"), "thing");
+            model.add(r, ResourceFactory.createProperty(NS + "name"), name);
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    /** With a lower-casing normalizer the KEYWORD sort key is case-insensitive. */
+    @Test
+    public void testNormalizedSortIsCaseInsensitive() {
+        addThing("rZebra", "Zebra");
+        addThing("rApple", "apple");
+        addThing("rAepfel", AEPFEL);
+
+        List<String> orderedNames = querySortedNames();
+
+        // Lower-cased sort keys: zebra, apple, äpfel -> ascending bytes a(0x61) < z(0x7A) < ä(0xC3).
+        List<String> collated = Arrays.asList("apple", "Zebra", AEPFEL);
+        assertEquals("Normalizer must make KEYWORD sort case-insensitive", collated, orderedNames);
+
+        // And it differs from the raw-byte order the baseline (no normalizer) produces.
+        List<String> rawByteOrder = Arrays.asList("Zebra", "apple", AEPFEL);
+        assertNotEquals("Sort must no longer be raw-byte order", rawByteOrder, orderedNames);
+    }
+
+    /** With a normalizer, an exact '=' match on the KEYWORD field is case-insensitive. */
+    @Test
+    public void testNormalizedExactMatchIsCaseInsensitive() {
+        addThing("rSmith", "Smith");
+
+        assertEquals("lower-case value must match indexed \"Smith\"", 1, countEqualsFilter("smith"));
+        assertEquals("upper-case value must match indexed \"Smith\"", 1, countEqualsFilter("SMITH"));
+        assertEquals("exact-case value must still match", 1, countEqualsFilter("Smith"));
+    }
+
+    private List<String> querySortedNames() {
+        String sparql =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"thing\" \"\" " +
+            "    '{\"field\":\"" + FP + "name\"}' 100 0) .\n" +
+            "}";
+
+        List<String> orderedNames = new ArrayList<>();
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                orderedNames.add(uriToName.get(sol.getResource("s").getURI()));
+            }
+        } finally {
+            dataset.end();
+        }
+        return orderedNames;
+    }
+
+    private int countEqualsFilter(String value) {
+        String sparql =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"thing\" " +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "name\"},\"" + value + "\"]}' " +
+            "    \"\" 100 0) .\n" +
+            "}";
+
+        int count = 0;
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                rs.next();
+                count++;
+            }
+        } finally {
+            dataset.end();
+        }
+        return count;
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestKeywordRawSortAndExactMatch.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestKeywordRawSortAndExactMatch.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.query.text.analyzer.LowerCaseKeywordAnalyzer;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Confirms the current (pre-normalizer) runtime behaviour of sortable / exact-match
+ * KEYWORD fields, as described in
+ * {@code docs/2026-06-25_keyword_normalizer_for_sortable_fields.md}:
+ *
+ * <ol>
+ *   <li><b>KEYWORD sort is raw UTF-8 byte order</b> — case-sensitive and not locale
+ *       collated. {@code "Zebra"} (Z = 0x5A) sorts before {@code "apple"} (a = 0x61),
+ *       and an accented value collates by its raw bytes, not linguistically. This is
+ *       because the KEYWORD path writes the verbatim value into {@code SortedDocValues}
+ *       ({@code ShaclTextIndexLucene} ~:1001 / :1098) and never analyses it.</li>
+ *   <li><b>KEYWORD exact match is verbatim</b> — a {@code =} filter for {@code "smith"}
+ *       does NOT match an indexed {@code "Smith"}, because the KEYWORD case compiles to a
+ *       raw {@code TermQuery} ({@code CqlToLuceneCompiler.buildEqualQuery} ~:723).</li>
+ * </ol>
+ *
+ * (The third finding — TEXT fields cannot be sorted at all — is already covered by
+ * {@code TestSortSpec#testBuildLuceneSortTextFieldThrows}.)
+ *
+ * These are the findings the proposed {@code idx:normalizer} feature would change; this
+ * test pins the baseline so a future normalizer change is demonstrably observable.
+ */
+public class TestKeywordRawSortAndExactMatch {
+
+    private static final String NS = "http://example.org/";
+    private static final String FP = "urn:jena:lucene:field#";
+    private static final Node THING_CLASS = NodeFactory.createURI(NS + "Thing");
+    private static final Node TITLE_PRED = NodeFactory.createURI(NS + "title");
+    private static final Node NAME_PRED = NodeFactory.createURI(NS + "name");
+
+    // Accented value (UTF-8 source, per project.build.sourceEncoding) used to show that
+    // accents collate by raw bytes, not linguistically.
+    private static final String AEPFEL = "Äpfel";
+
+    private Dataset dataset;
+    private final Map<String, String> uriToName = new LinkedHashMap<>();
+
+    @Before
+    public void setUp() {
+        // Default harness: KEYWORD name field with no analyzer.
+        buildDataset(null);
+    }
+
+    /**
+     * Build a fresh wired dataset whose KEYWORD {@code name} field optionally carries a
+     * per-field analyzer. {@code nameAnalyzer} is the analyzer slot the proposal calls
+     * "inert on KEYWORD today" — passing one here lets a test prove it has no effect.
+     */
+    private void buildDataset(Analyzer nameAnalyzer) {
+        TextQuery.init();
+        uriToName.clear();
+
+        // TEXT default-search field — lets a single "thing" query match every entity.
+        FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, false, true);
+        // KEYWORD field, sortable + indexed — the field under test.
+        FieldDef nameField = new FieldDef("name", FieldType.KEYWORD, nameAnalyzer,
+            true, true, false, true, false, false);
+
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(nameField, PathFactory.pathLink(NAME_PRED), Collections.singleton(NAME_PRED)));
+
+        IndexProfile thingProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "ThingShape"),
+            Collections.singleton(THING_CLASS),
+            "uri", "docType",
+            Arrays.asList(titleField, nameField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(thingProfile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setValueStored(true);
+
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), textIndex, mapping);
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+    }
+
+    private void addThing(String localName, String name) {
+        String uri = NS + localName;
+        uriToName.put(uri, name);
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            Resource r = ResourceFactory.createResource(uri);
+            model.add(r, RDF.type, ResourceFactory.createResource(NS + "Thing"));
+            model.add(r, ResourceFactory.createProperty(NS + "title"), "thing");
+            model.add(r, ResourceFactory.createProperty(NS + "name"), name);
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    /** Finding #1: a sortable KEYWORD field sorts by raw UTF-8 bytes, not by locale/case. */
+    @Test
+    public void testKeywordSortIsRawByteOrderNotCollated() {
+        addThing("rZebra", "Zebra");
+        addThing("rApple", "apple");
+        addThing("rAepfel", AEPFEL);
+
+        List<String> orderedNames = querySortedNames();
+
+        // Raw UTF-8 byte order: 'Z'=0x5A < 'a'=0x61 < 'Ä' first byte 0xC3.
+        List<String> rawByteOrder = Arrays.asList("Zebra", "apple", AEPFEL);
+        assertEquals("KEYWORD sort must follow raw UTF-8 byte order (case-sensitive)",
+            rawByteOrder, orderedNames);
+
+        // A locale/case-insensitive collation would instead give apple, Äpfel, Zebra.
+        List<String> collatedOrder = Arrays.asList("apple", AEPFEL, "Zebra");
+        assertNotEquals("Sort is NOT locale-collated today (would change with idx:normalizer)",
+            collatedOrder, orderedNames);
+    }
+
+    /** Finding #2: a KEYWORD {@code =} filter is verbatim — case-sensitive exact match. */
+    @Test
+    public void testKeywordExactMatchIsCaseSensitive() {
+        addThing("rSmith", "Smith");
+
+        // Lower-case filter must NOT match the indexed "Smith".
+        assertEquals("Case-mismatched KEYWORD '=' filter must not match",
+            0, countEqualsFilter("smith"));
+
+        // Exact-case filter matches.
+        assertEquals("Exact-case KEYWORD '=' filter must match",
+            1, countEqualsFilter("Smith"));
+    }
+
+    /**
+     * Finding #4 (the proposal's crux): the analyzer slot on a KEYWORD {@code FieldDef} is
+     * inert. Attaching a lower-casing analyzer changes neither the sort key nor exact match,
+     * because the KEYWORD path uses {@code StringField} + raw {@code SortedDocValues}
+     * (analyzer never consulted). If the slot were active, "Zebra" would lower-case to
+     * "zebra" (sorting last) and a "smith" filter would match — so this is exactly the gap
+     * {@code idx:normalizer} exists to close.
+     */
+    @Test
+    public void testKeywordAnalyzerSlotIsInert() {
+        dataset.close();
+        buildDataset(new LowerCaseKeywordAnalyzer()); // lower-casing analyzer on the KEYWORD field
+
+        addThing("rZebra", "Zebra");
+        addThing("rApple", "apple");
+        addThing("rAepfel", AEPFEL);
+        addThing("rSmith", "Smith");
+
+        // Sort key still raw bytes — analyzer did NOT lower-case it.
+        // Raw ascending: 'S'=0x53 < 'Z'=0x5A < 'a'=0x61 < 'Ä'=0xC3.
+        List<String> orderedNames = querySortedNames();
+        assertEquals("Analyzer on KEYWORD must NOT change the raw-byte sort key",
+            Arrays.asList("Smith", "Zebra", "apple", AEPFEL), orderedNames);
+
+        // Exact match still case-sensitive — analyzer did NOT lower-case the indexed term.
+        assertEquals("Analyzer on KEYWORD must NOT make exact match case-insensitive",
+            0, countEqualsFilter("smith"));
+        assertEquals("Exact-case match still works with an (inert) analyzer present",
+            1, countEqualsFilter("Smith"));
+    }
+
+    /**
+     * Run the sort query (ascending on the KEYWORD {@code name} field) and return the
+     * indexed names in result order. The luc:query PF emits hits in Lucene sort order and
+     * there is no BGP join, so the result iteration order is the PF's sort order.
+     */
+    private List<String> querySortedNames() {
+        String sparql =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"thing\" \"\" " +
+            "    '{\"field\":\"" + FP + "name\"}' 100 0) .\n" +
+            "}";
+
+        List<String> orderedNames = new ArrayList<>();
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                orderedNames.add(uriToName.get(sol.getResource("s").getURI()));
+            }
+        } finally {
+            dataset.end();
+        }
+        return orderedNames;
+    }
+
+    private int countEqualsFilter(String value) {
+        String sparql =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"thing\" " +
+            "    '{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "name\"},\"" + value + "\"]}' " +
+            "    \"\" 100 0) .\n" +
+            "}";
+
+        int count = 0;
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                rs.next();
+                count++;
+            }
+        } finally {
+            dataset.end();
+        }
+        return count;
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestShaclAssembler.java
@@ -219,6 +219,71 @@ public class TestShaclAssembler {
     }
 
     @Test
+    public void testNormalizerOnKeywordFieldParsed() {
+        Model model = createModel();
+
+        Resource labelField = model.createResource(EX + "labelField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "label")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
+            .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true));
+        Resource nameField = model.createResource(EX + "nameField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "name")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
+            .addProperty(model.createProperty(IndexVocab.NS, "sortable"), model.createTypedLiteral(true))
+            .addProperty(model.createProperty(IndexVocab.NS, "normalizer"),
+                model.createResource().addProperty(RDF.type, TextVocab.lowerCaseKeywordAnalyzer));
+
+        Resource bookShape = model.createResource(EX + "BookShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, labelField, RDFS.label))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, nameField, model.createResource(EX + "name")));
+
+        RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, shapesList);
+
+        ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
+        try {
+            FieldDef fd = index.getShaclMapping().findFieldByName("name");
+            assertNotNull("name field must be parsed", fd);
+            assertNotNull("idx:normalizer must be resolved to an analyzer", fd.getNormalizer());
+        } finally {
+            index.close();
+        }
+    }
+
+    @Test
+    public void testNormalizerOnNonKeywordFieldRejected() {
+        Model model = createModel();
+
+        // idx:normalizer on a TEXT field is a configuration error (fail fast).
+        Resource labelField = model.createResource(EX + "labelField")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), "label")
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.TextField)
+            .addProperty(model.createProperty(IndexVocab.NS, "defaultSearch"), model.createTypedLiteral(true))
+            .addProperty(model.createProperty(IndexVocab.NS, "normalizer"),
+                model.createResource().addProperty(RDF.type, TextVocab.lowerCaseKeywordAnalyzer));
+
+        Resource bookShape = model.createResource(EX + "BookShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Book"))
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, labelField, RDFS.label));
+
+        RDFNode shapesList = model.createList(new RDFNode[]{ bookShape });
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, shapesList);
+
+        AssemblerException ex = assertThrows(AssemblerException.class,
+            () -> Assembler.general().open(indexSpec));
+        assertTrue(ex.getCause() instanceof TextIndexException);
+        assertTrue(ex.getCause().getMessage().contains("only valid on KEYWORD"));
+    }
+
+    @Test
     public void testTemporalFieldVocabResolvesToTemporal() {
         // Issue #69: idx:TemporalField is the new canonical resource, idx:DateField and
         // idx:DateTimeField are deprecated aliases — all three must produce TEMPORAL.

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
          These two go together
          See jena-fuseki-webapp and https://shiro.apache.org/jakarta-ee.html
     -->
-    <ver.shiro>2.1.0</ver.shiro>
+    <ver.shiro>2.2.1</ver.shiro>
 
     <ver.protobuf>4.34.0</ver.protobuf>
     <ver.libthrift>0.23.0</ver.libthrift>


### PR DESCRIPTION
## Summary

Adds the **`idx:normalizer`** feature for KEYWORD fields — the proposal in
`docs/2026-06-25_keyword_normalizer_for_sortable_fields.md` **plus its implementation, tests,
and a live demo**.

An analyzer declared on a KEYWORD field via `idx:normalizer` is applied (through
`Analyzer.normalize`) to the indexed term and the sort DocValues at index time, and to `=` / `in`
comparison values at query time. Sorting and exact match on that field become case-/locale-normalized
(e.g. case-insensitive with the built-in `text:LowerCaseKeywordAnalyzer`). Stored values and facet
labels stay raw.

The feature is **additive and opt-in**: a plain KEYWORD field — and the pre-existing (inert)
`idx:analyzer` slot — keep their raw-byte, case-sensitive behaviour.

## Behaviour (from the `keyword-sort-demo` test case)

Data indexed: `Zebra, apple, Äpfel, banana, Apple, Smith`.

| Query | Field | Before | After |
|-------|-------|--------|-------|
| sort | `name` (plain KEYWORD) | `Apple, Smith, Zebra, apple, banana, Äpfel` | *(unchanged)* |
| sort | `nameLC` (`idx:analyzer`) | raw (inert) | *(unchanged — still inert)* |
| **sort** | `nameCI` (`idx:normalizer`) | raw | **`apple, Apple, banana, Smith, Zebra, Äpfel`** |
| **`= "smith"`** | `nameCI` | 0 rows | **`Smith`** |

## Implementation (touch points)

- `IndexVocab` — `idx:normalizer` property.
- `ShaclIndexMapping.FieldDef` — `normalizer` field + `getNormalizer()`, threaded through a new
  canonical constructor (others delegate `null`).
- `ShaclIndexAssembler` — parse `idx:normalizer` via `a.open()`; **hard-fail on a non-KEYWORD field**;
  consistency-checked across occurrences of the same field.
- `ShaclTextIndexLucene` — normalize the term + sort key in both KEYWORD index paths
  (`addFieldToDoc` / `addNodeFieldToDoc`); stored values and facet labels stay raw.
- `CqlToLuceneCompiler` — normalize `=` / `in` comparison values so query-time terms match
  index-time terms.
- `buildLuceneSort` — unchanged (already targets the field's DocValues).

## Tests (full `TS_Text` suite green)

- `TestKeywordRawSortAndExactMatch` — baseline: raw-byte sort, verbatim exact match, and the
  `idx:analyzer` slot being inert on KEYWORD (all unchanged by this feature).
- `TestKeywordNormalizer` — case-insensitive sort + exact match with a normalizer.
- `TestShaclAssembler` — `idx:normalizer` parses on KEYWORD, rejected on non-KEYWORD.

## Demo

`demo/test-cases/` is a reusable Fuseki harness (`task run` / `verify` / `snapshot` / `stop`) for
in-browser verification. The `keyword-sort-demo` case ships config, data, one query per finding, and
captured `results/pre-work.md` + `results/post-work.md` snapshots showing the before/after.
