### PR TITLE
feat: nested sort selector — order by a nested value where discriminator = X

### DIFF
--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -466,6 +466,25 @@ state that independently in `cqlFilter` — the two compose.
 When an entity has several matching children the parent key collapses MIN (ascending) /
 MAX (descending). The normal one-record-per-type case makes MIN = MAX.
 
+#### Why filter in two places?
+
+Because the two filters act on different things. `cqlFilter` decides *which documents*
+come back; a sort reads its key from doc-values on a document that has already been
+picked. Filtering on the discriminator therefore does nothing at all to the sort key.
+
+Concretely: nested values live on the child documents, not the parent, so a plain
+`{"field":"urn:jena:lucene:field#identifierValue"}` sort finds no key on any parent and
+imposes no order — whatever `cqlFilter` says. And even where a value *is* flattened onto
+the parent, the sort collapses the entity's whole bag: an entity whose companyID is
+`C-200` but whose govID is `A-000` sorts on `A-000`. The filter chose the entity; the
+sort key still came from the wrong record.
+
+The sort's own `filter` is what keeps the child identity long enough to say "take the
+value from *this* child". The same split exists elsewhere: Elasticsearch's nested sort
+takes its own `nested.filter` independent of the query, and in SQL the discriminator
+belongs in the `LEFT JOIN ... ON` clause — move it to `WHERE` and the outer join
+collapses, dropping the very rows you wanted to keep.
+
 The selector is nested-only. A flat multivalued field is a decorrelated bag with no
 surviving per-value discriminator, so a `filter` on a root-scoped field is an error
 (`sort filter requires a nested field`). Both fields must belong to the *same*

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -431,6 +431,67 @@ Multi-sort:
 ]
 ```
 
+Any sort object may also carry `"missing": "first" | "last"` to place entities that have no
+value for the sort field. Omit it to keep Lucene's own default placement.
+
+### Nested Sort Selector
+
+To order by a value drawn from one specific nested child record — "sort by the identifier
+value *where* `identifierType = companyID`" — add a `filter` to the sort object:
+
+```json
+{
+  "field":  "urn:jena:lucene:field#identifierValue",
+  "filter": {"field":"urn:jena:lucene:field#identifierType","eq":"companyID"},
+  "order":  "asc",
+  "missing": "last"
+}
+```
+
+| Key | Meaning |
+|-----|---------|
+| `field` | the child value field to sort on; must be `idx:sortable` |
+| `filter.field` | the co-located discriminator on the same child document |
+| `filter.eq` | the value that discriminator must equal |
+| `order` | `asc` (default) / `desc`, as for a flat sort |
+| `missing` | `first` \| `last` — placement of entities with no matching child. Default `last` |
+
+The nested scope is inferred from `field`; it is not part of the wire format.
+
+The `filter` is a **sort selector, not a result filter**. It chooses which child supplies
+the sort key and never removes entities: those with no matching child keep their place in
+the result set and are positioned by `missing`. To also restrict *which* entities appear,
+state that independently in `cqlFilter` — the two compose.
+
+When an entity has several matching children the parent key collapses MIN (ascending) /
+MAX (descending). The normal one-record-per-type case makes MIN = MAX.
+
+The selector is nested-only. A flat multivalued field is a decorrelated bag with no
+surviving per-value discriminator, so a `filter` on a root-scoped field is an error
+(`sort filter requires a nested field`). Both fields must belong to the *same*
+`idx:nested` block — that is what puts them on one child document.
+
+Data-modelling requirements (no extra index configuration):
+
+```turtle
+:sampleShape idx:nested [
+    idx:joinPath sdo:identifier ;
+    idx:property field:identifierType ;    # discriminator -> child filter
+    idx:property field:identifierValue ;   # value         -> sort key
+] .
+
+field:identifierType
+    idx:fieldName "identifierType" ; idx:fieldType idx:KeywordField ;
+    idx:indexed true ; idx:facetable true ; sh:path sdo:propertyID .
+
+field:identifierValue
+    idx:fieldName "identifierValue" ; idx:fieldType idx:KeywordField ;
+    idx:sortable true ; sh:path sdo:value .
+```
+
+Because the sort happens inside Lucene, it is applied before `limit`/`offset` cut the
+page — pagination over a selector-ordered result set stays correct across page boundaries.
+
 ## Shared Execution
 
 `luc:query`, `luc:facet`, and `luc:match` share a single Lucene execution when these match:

--- a/docs/2026-07-02_nested_sort_selector_design.md
+++ b/docs/2026-07-02_nested_sort_selector_design.md
@@ -1,0 +1,205 @@
+---
+title: "nested sort selector design"
+date: "2026-07-02"
+---
+
+# 2026-07-02 Nested Sort Selector Design
+
+## Status
+
+Proposed. Not yet implemented. This note records the design for ordering parent
+(entity-per-document) search results by a value drawn from a specific nested
+child record — e.g. "sort by the identifier value **where** identifierType =
+companyID", or "sort by the agent name **where** attributionRole = owner".
+
+## Problem
+
+Results are entity-per-document. A single entity commonly carries repeated,
+qualified child records:
+
+- identifiers: `?s sdo:identifier [ sdo:propertyID ?type ; sdo:value ?val ]`
+- prov attributions: `?s prov:qualifiedAttribution [ prov:agent ?a ; prov:hadRole ?role ]`
+
+Consumers (Prez) pivot these into columns and want to sort the whole result set
+by **one** of those columns — sort by the *companyID* identifier, or by the
+*owner* agent — while keeping every entity in the result set and keeping
+pagination correct over large result sets (1000+ hits).
+
+The current sort spec (`SortSpec` / `SortSpecParser`) names a single flat field
+on the parent doc. It cannot express "the value where type = X", because:
+
+- flat multivalued fields are a decorrelated bag on the parent doc; the
+  type↔value correlation is lost at flatten time,
+- so the only available control is the MIN/MAX selector across the bag.
+
+Doing the discrimination in SPARQL (`ORDER BY ?val` on a pivoted, `FILTER`ed
+var) is not viable: the ordering would run in ARQ *after* `luc:query` has already
+applied `limit`/`offset`, so it cannot reorder across the page boundary without
+pulling the entire result set out of Lucene first.
+
+## Design
+
+The correlation we need is already preserved in the index: fields inside one
+`idx:nested` block are emitted onto the **same child document** (block-join
+layout, `_blockKind`, `_nestedScope`, `PARENTS_FILTER`). Lucene provides
+`ToParentBlockJoinSortField` (present in `lucene-join-10.3.1`), which sorts
+**parent** docs by a docvalues field on their **children**, restricted by a
+child filter and collapsed with a MIN/MAX selector.
+
+So "sort by identifierValue where identifierType = companyID" maps to:
+
+> sort parents by the `identifierValue` docvalue, taken only from child docs
+> where `identifierType = companyID`, MIN (asc) / MAX (desc) if more than one.
+
+Key semantic distinction: the child predicate is a **sort selector**, not a
+result filter. It chooses which child supplies the sort key; it must **not**
+drop entities that have no matching child (those get a defined missing-value
+placement instead). This is why it lives in the sort spec and not in
+`cqlFilter`.
+
+The selector is only meaningful for nested fields — on a flat field there is no
+surviving per-value discriminator to test — so `filter` present is both
+necessary and sufficient to select the block-join path. This makes the API
+rule total and lets the scope be inferred rather than stated.
+
+## SPARQL / API part
+
+The sort spec is the 5th argument of `luc:query`
+(`indexSelector fieldSpec queryString cqlFilter sortSpec limit offset`).
+Extend the sort **object** (array-of-objects for multi-sort is unchanged):
+
+Flat sort (unchanged, still valid):
+
+```json
+{ "field": "urn:jena:lucene:field#year", "order": "desc" }
+```
+
+Nested sort selector (new):
+
+```json
+{
+  "field":  "urn:jena:lucene:field#identifierValue",
+  "filter": { "field": "urn:jena:lucene:field#identifierType", "eq": "companyID" },
+  "order":  "asc",
+  "missing": "last"
+}
+```
+
+- `field` — the child value field to sort on; must be `idx:sortable`.
+- `filter.field` / `filter.eq` — the co-located discriminator on the same child
+  doc.
+- `order` — `asc` (default) / `desc`, as today.
+- `missing` — optional, `first` | `last`; placement of entities with no matching
+  child. Default `last`.
+- `nested` scope is **inferred** from `field` and is **not** part of the public
+  API.
+
+Parser rules (`SortSpecParser`):
+
+- `field` only → flat sort (today's behaviour).
+- `field` + `filter` → nested block-join sort; infer scope via
+  `findNestedDefForFieldName(field)`, validate `filter.field` resolves to a field
+  in the **same** nested block.
+- `filter` on a field that resolves to a flat (root) field → hard error:
+  "sort filter requires a nested field".
+
+Preset form (recommended for Prez, optional to implement): a profile may
+pre-declare a named sort IRI that resolves to
+`(valueField, filterField, filterValue)`, so the wire format stays the trivial
+flat shape (`{"field":"urn:jena:lucene:sort#byCompanyId","order":"asc"}`) and the
+client need not assemble the selector at query time. Inline form remains the
+escape hatch for ad-hoc columns.
+
+## Indexer part
+
+No indexer/config code changes. The only requirement is data-modelling, taught by
+example in the docs/config:
+
+- the discriminator and the value must be `idx:property` occurrences of the
+  **same** `idx:nested` block (so they land on one child doc),
+- the value field must be `idx:sortable true` (single-valued per child →
+  `SortedDocValues` / `SortedNumericDocValuesField`, already emitted by
+  `addFieldToDoc`, which children share),
+- the discriminator field must be `idx:indexed true` (queryable for the child
+  filter `TermQuery`).
+
+Example shape fragment:
+
+```turtle
+:sampleShape idx:nested [
+    idx:joinPath sdo:identifier ;
+    idx:property field:identifierType ;    # discriminator -> child filter
+    idx:property field:identifierValue ;   # value         -> sort key
+] .
+
+field:identifierType
+    idx:fieldName "identifierType" ; idx:fieldType idx:KeywordField ;
+    idx:indexed true ; idx:facetable true ; sh:path sdo:propertyID .
+
+field:identifierValue
+    idx:fieldName "identifierValue" ; idx:fieldType idx:KeywordField ;
+    idx:sortable true ; sh:path sdo:value .
+```
+
+## Proposed code changes
+
+Small, additive, and on existing block-join rails. Detail left to implementer.
+
+- `SortSpec` — carry the optional selector: value field (existing), plus
+  `filterField`, `filterValue`, `missing`. Flat specs leave them null.
+- `SortSpecParser` — parse `filter` / `missing`; infer scope; validate
+  same-block and flat-field-error rules above.
+- `ShaclTextIndexLucene.buildLuceneSort` — branch when a spec has a selector:
+  emit `ToParentBlockJoinSortField(childValueField, type, reverse,
+  PARENTS_FILTER, childFilterBitSet)` with `setMissingValue(...)`, instead of the
+  plain `SortField`. Build `childFilterBitSet` from a `BooleanQuery` of
+  `NESTED_SCOPE_FIELD = <scope>` MUST `filterField = filterValue` (same pattern
+  already used for correlated nested search / `PARENTS_FILTER`).
+- (Optional) profile/assembler — parse named sort presets.
+- Tests — `TestNativeFacetCounts`-style: index entities with multiple identifier
+  types, assert parent order by the companyID value asc/desc, and assert
+  entities lacking a companyID land per `missing`. Add the new test class to
+  `TS_Text.java`.
+
+## Discussion
+
+**Why block-join sort and not SPARQL `ORDER BY`.** Correct pagination requires
+sorting *before* truncation to a page. `luc:query` pushes `limit`/`offset` down
+into the Lucene search, so the sort must happen there too. A SPARQL `ORDER BY`
+on a pivoted variable runs after the Lucene window is already cut, forcing a
+fetch-everything-then-sort in ARQ that degrades with result size and defeats the
+pushed-down pagination. It also introduces cartesian rows (one `?val` per child)
+and undefined ordering for entities with no matching child.
+
+**Why a sort selector and not a `cqlFilter` clause.** They answer different
+questions. `cqlFilter` restricts *which entities appear*; putting
+`identifierType = companyID` there would drop every entity lacking a companyID
+identifier. The selector restricts *which child supplies the sort key* while
+keeping all entities, placing the unmatched ones via the missing-value policy.
+A caller that wants both "only companyID docs" and "sorted by it" states them
+independently — filter in `cqlFilter`, order in the sort spec — and they compose.
+
+**Why the selector is nested-only.** A flat multivalued field is a decorrelated
+bag; flattening destroys the type↔value tuple, so there is no per-value
+discriminator to test. The correlation only survives in the block-join child
+doc. The one apparent exception (sort by the `@en` label only) is the same
+pattern in disguise: a per-value discriminator that would itself require nesting
+to filter on. Hence `filter` present ⟺ block-join path, and it is an error on a
+flat field.
+
+**Known edges (decide, then document).**
+
+- *Selector on multiple matching children* — if an entity has two companyID
+  identifiers, the parent key collapses MIN (asc) / MAX (desc). Normal case is
+  one-per-type, so MIN = MAX.
+- *Missing values* — entities with no matching child have no key; `missing`
+  makes placement explicit rather than incidental.
+- *Value cardinality* — a `sortable` keyword must be single-valued per child
+  (one record → one value), else the child doc fails on duplicate docvalues.
+
+**Out of scope.** Numeric observation pivots (sort samples by an `Au` grade
+where the observable property is a *value*, not a distinct type/predicate) are
+deliberately not covered here; that discrimination is by sibling value and is
+being handled by SQL pushdown separately. This design targets the qualified
+patterns whose discriminator is an explicit co-located property: identifiers and
+prov-qualified attributions.

--- a/docs/2026-07-02_nested_sort_selector_design.md
+++ b/docs/2026-07-02_nested_sort_selector_design.md
@@ -7,7 +7,12 @@ date: "2026-07-02"
 
 ## Status
 
-Proposed. Not yet implemented. This note records the design for ordering parent
+Implemented. See `docs/02-sparql-api.md` → "Nested Sort Selector" for the user-facing
+API, and `TestNestedSortSelector` / `TestSortSpec` for the behaviour this note specifies.
+The named-sort-preset variant below was **not** implemented — the inline form covers the
+requirement and a preset adds config surface for no new capability.
+
+This note records the design for ordering parent
 (entity-per-document) search results by a value drawn from a specific nested
 child record — e.g. "sort by the identifier value **where** identifierType =
 companyID", or "sort by the agent name **where** attributionRole = owner".

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/mod/ui/FMod_UI.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/mod/ui/FMod_UI.java
@@ -172,7 +172,11 @@ public class FMod_UI implements FusekiModule {
 
         ResourceFactory resourceFactory = ResourceFactory.closeable();
         Resource resource = resourceFactory.newClassLoaderResource(resourceName);
-        if ( resource != null )
+        // Jetty 12.1.10 changed newClassLoaderResource: a resource that is not on the
+        // classpath now comes back as a non-null Resource with a null URI, where it
+        // previously came back as null. Both mean "not found" — fall through to the
+        // caller's next lookup rather than NPE.
+        if ( resource != null && resource.getURI() != null )
             return resource.getURI().toString();
         return null;
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -63,6 +63,7 @@ import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
+import org.apache.lucene.search.join.ToParentBlockJoinSortField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -201,6 +202,16 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
     /** Key for {@link #openFacetCache}. {@code searchFields} are intentionally omitted —
      *  with no query and no filter they have no effect on the result. */
     private record OpenFacetCacheKey(FacetRequest facetRequest, int maxValues, int minCount) {}
+
+    /**
+     * Child-filter {@link BitSetProducer}s for nested sort selectors, keyed by
+     * {@code scope + field + value}. See {@link #childSortFilter}.
+     */
+    private final java.util.concurrent.ConcurrentMap<String, BitSetProducer> childSortFilterCache =
+        new java.util.concurrent.ConcurrentHashMap<>();
+
+    /** Upper bound on {@link #childSortFilterCache} entries. */
+    private static final int MAX_CHILD_SORT_FILTERS = 256;
 
     public ShaclTextIndexLucene(Directory directory, TextIndexConfig config) {
         this(directory, null, config);
@@ -2382,26 +2393,15 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
         SortField[] fields = new SortField[sortSpecs.size()];
         for (int i = 0; i < sortSpecs.size(); i++) {
             SortSpec spec = sortSpecs.get(i);
-            SortField.Type sortType = SortField.Type.STRING; // default
 
             // Resolve field identifier (IRI) to Lucene field name
             ShaclIndexMapping.FieldDef fd = shaclMapping.findField(spec.field());
             String luceneFieldName = fd != null ? LiteralFieldSupport.queryFieldName(fd) : spec.field();
-            if (fd != null) {
-                sortType = switch (fd.getFieldType()) {
-                    case KEYWORD -> SortField.Type.STRING;
-                    case INT -> SortField.Type.INT;
-                    case LONG -> SortField.Type.LONG;
-                    case DOUBLE -> SortField.Type.DOUBLE;
-                    case TEMPORAL -> SortField.Type.LONG;
-                    case TEXT -> throw new TextIndexException(
-                        "Cannot sort on TEXT field '" + spec.field() + "'. Use KEYWORD for sortable fields.");
-                    case LATLON -> throw new TextIndexException(
-                        "Cannot sort on LATLON field '" + spec.field() + "'.");
-                };
-            }
+            SortField.Type sortType = fd != null ? sortTypeFor(fd, spec.field()) : SortField.Type.STRING;
 
-            if (fd != null && isNumericField(fd)) {
+            if (spec.hasSelector()) {
+                fields[i] = buildSelectorSortField(spec, fd, luceneFieldName, sortType);
+            } else if (fd != null && isNumericField(fd)) {
                 SortedNumericSelector.Type selector = spec.descending()
                     ? SortedNumericSelector.Type.MAX
                     : SortedNumericSelector.Type.MIN;
@@ -2415,7 +2415,163 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
             } else {
                 fields[i] = new SortField(luceneFieldName, sortType, spec.descending());
             }
+
+            // A selector spec has already applied its (defaulted) missing placement.
+            if (!spec.hasSelector()) {
+                applyMissingPlacement(fields[i], spec.missing(), sortType, spec.descending());
+            }
         }
         return new Sort(fields);
+    }
+
+    /** The Lucene sort value type for a mapped field, rejecting the types that have no order. */
+    private static SortField.Type sortTypeFor(ShaclIndexMapping.FieldDef fd, String fieldIRI) {
+        return switch (fd.getFieldType()) {
+            case KEYWORD -> SortField.Type.STRING;
+            case INT -> SortField.Type.INT;
+            case LONG -> SortField.Type.LONG;
+            case DOUBLE -> SortField.Type.DOUBLE;
+            case TEMPORAL -> SortField.Type.LONG;
+            case TEXT -> throw new TextIndexException(
+                "Cannot sort on TEXT field '" + fieldIRI + "'. Use KEYWORD for sortable fields.");
+            case LATLON -> throw new TextIndexException(
+                "Cannot sort on LATLON field '" + fieldIRI + "'.");
+        };
+    }
+
+    /**
+     * Build the {@link ToParentBlockJoinSortField} for a nested sort selector: order parent
+     * docs by {@code spec.field()} taken from the child docs where the co-located
+     * discriminator {@code spec.filterField()} equals {@code spec.filterValue()}, collapsing
+     * MIN (ascending) / MAX (descending) when an entity has several matching children.
+     * <p>
+     * The selector chooses the sort key only — it never removes entities. Parents with no
+     * matching child have no key and are placed by {@code spec.missing()} (default last).
+     */
+    private SortField buildSelectorSortField(SortSpec spec, ShaclIndexMapping.FieldDef fd,
+            String luceneFieldName, SortField.Type sortType) {
+        if (fd == null) {
+            throw new TextIndexException("Unknown sort field: '" + spec.field() + "'. "
+                + "Available fields: " + shaclMapping.getAllFieldNames());
+        }
+        ShaclIndexMapping.NestedDef scope = shaclMapping.findNestedDefForFieldName(fd.getFieldName());
+        if (scope == null) {
+            throw new TextIndexException("Sort filter requires a nested field: '" + spec.field()
+                + "' is not part of an idx:nested block. A flat multivalued field keeps no "
+                + "per-value discriminator to filter on.");
+        }
+        if (!fd.isSortable()) {
+            throw new TextIndexException("Sort field '" + spec.field()
+                + "' is not idx:sortable, so it has no sort doc-values to select from.");
+        }
+
+        ShaclIndexMapping.FieldDef filterFd = shaclMapping.findField(spec.filterField());
+        if (filterFd == null) {
+            throw new TextIndexException("Unknown sort filter field: '" + spec.filterField() + "'. "
+                + "Available fields: " + shaclMapping.getAllFieldNames());
+        }
+        ShaclIndexMapping.NestedDef filterScope =
+            shaclMapping.findNestedDefForFieldName(filterFd.getFieldName());
+        if (filterScope == null || !filterScope.getNestedName().equals(scope.getNestedName())) {
+            throw new TextIndexException("Sort filter field '" + spec.filterField()
+                + "' must belong to the same idx:nested block as sort field '" + spec.field()
+                + "' (block '" + scope.getNestedName() + "'); the type/value correlation only "
+                + "survives on a single child document.");
+        }
+
+        BitSetProducer childFilter = childSortFilter(scope, filterFd, spec.filterValue());
+        SortField sortField = new ToParentBlockJoinSortField(
+            luceneFieldName, sortType, spec.descending(), PARENTS_FILTER, childFilter);
+        SortSpec.MissingPlacement missing =
+            spec.missing() != null ? spec.missing() : SortSpec.MissingPlacement.LAST;
+        applyMissingPlacement(sortField, missing, sortType, spec.descending());
+        return sortField;
+    }
+
+    /**
+     * {@link BitSetProducer} matching the child docs a sort selector may draw its key from:
+     * children of the given nested scope whose discriminator field equals {@code value}.
+     * <p>
+     * Cached per selector — a {@link QueryBitSetProducer} memoises its per-segment bitset for
+     * the life of a reader generation (Lucene evicts on reader close), so paging through a
+     * large result set re-runs the child filter once rather than once per page. The key space
+     * is caller-supplied (the selector's discriminator value), so the cache is bounded and
+     * stops admitting entries once full rather than growing with query traffic.
+     */
+    private BitSetProducer childSortFilter(ShaclIndexMapping.NestedDef scope,
+            ShaclIndexMapping.FieldDef filterFd, String value) {
+        String key = scope.getNestedName() + ' ' + filterFd.getFieldName() + ' ' + value;
+        BitSetProducer cached = childSortFilterCache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        builder.add(new TermQuery(new Term(NESTED_SCOPE_FIELD, scope.getNestedName())),
+            BooleanClause.Occur.FILTER);
+        builder.add(childDiscriminatorQuery(filterFd, value), BooleanClause.Occur.MUST);
+        BitSetProducer producer = new QueryBitSetProducer(builder.build());
+        if (childSortFilterCache.size() >= MAX_CHILD_SORT_FILTERS) {
+            return producer;
+        }
+        BitSetProducer existing = childSortFilterCache.putIfAbsent(key, producer);
+        return existing != null ? existing : producer;
+    }
+
+    /** Exact-match query for a sort selector's discriminator value on a child doc. */
+    private static Query childDiscriminatorQuery(ShaclIndexMapping.FieldDef filterFd, String value) {
+        String fieldName = filterFd.getFieldName();
+        if (!filterFd.isIndexed()) {
+            throw new TextIndexException("Sort filter field '" + fieldName
+                + "' is not idx:indexed, so it cannot be matched.");
+        }
+        try {
+            return switch (filterFd.getFieldType()) {
+                // KEYWORD with a normalizer indexes the normalized term, so normalize the
+                // comparison value the same way (mirrors the CQL compiler's = handling).
+                case KEYWORD, TEXT -> {
+                    Analyzer norm = filterFd.getNormalizer();
+                    BytesRef term = norm != null ? norm.normalize(fieldName, value) : new BytesRef(value);
+                    yield new TermQuery(new Term(fieldName, term));
+                }
+                case INT -> IntPoint.newExactQuery(fieldName, Integer.parseInt(value));
+                case LONG -> LongPoint.newExactQuery(fieldName, Long.parseLong(value));
+                case DOUBLE -> DoublePoint.newExactQuery(fieldName, Double.parseDouble(value));
+                case TEMPORAL, LATLON -> throw new TextIndexException(
+                    "Sort filter field '" + fieldName + "' has unsupported type "
+                        + filterFd.getFieldType() + "; use a KEYWORD discriminator.");
+            };
+        } catch (NumberFormatException ex) {
+            throw new TextIndexException("Sort filter value '" + value + "' is not a valid "
+                + filterFd.getFieldType() + " for field '" + fieldName + "'");
+        }
+    }
+
+    /**
+     * Set the sort field's missing value so that {@code missing} means absolute placement in
+     * the final result order.
+     * <p>
+     * Lucene applies the sort's reverse multiplier <em>outside</em> the comparator, so a
+     * "missing sorts high" sentinel would surface first under a descending sort. Flipping the
+     * sentinel by {@code reverse} keeps {@code first}/{@code last} meaning what the caller
+     * sees. A no-op when {@code missing} is null, which leaves Lucene's own default.
+     */
+    private static void applyMissingPlacement(SortField sortField, SortSpec.MissingPlacement missing,
+            SortField.Type sortType, boolean reverse) {
+        if (missing == null) {
+            return;
+        }
+        boolean sentinelHigh = (missing == SortSpec.MissingPlacement.LAST) != reverse;
+        switch (sortType) {
+            case STRING -> sortField.setMissingValue(
+                sentinelHigh ? SortField.STRING_LAST : SortField.STRING_FIRST);
+            case INT -> sortField.setMissingValue(
+                sentinelHigh ? Integer.MAX_VALUE : Integer.MIN_VALUE);
+            case LONG -> sortField.setMissingValue(
+                sentinelHigh ? Long.MAX_VALUE : Long.MIN_VALUE);
+            case DOUBLE -> sortField.setMissingValue(
+                sentinelHigh ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY);
+            default -> throw new TextIndexException(
+                "Cannot apply 'missing' placement to sort type " + sortType);
+        }
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/SortSpec.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SortSpec.java
@@ -21,15 +21,52 @@
 
 package org.apache.jena.query.text;
 
+import java.util.Locale;
+
 /**
  * Sort specification for Lucene query results.
+ * <p>
+ * A spec is either <em>flat</em> — sort parents by a field on the parent doc — or a
+ * <em>nested sort selector</em>: sort parents by a field on one of their block-join
+ * child docs, choosing the child by a co-located discriminator. The selector is a
+ * sort-key chooser, not a result filter: entities with no matching child stay in the
+ * result set and are placed per {@link #missing()}.
  *
- * @param field      the Lucene field name to sort by
- * @param descending true for descending order, false for ascending
+ * @param field       the field identifier (IRI) to sort by; for a selector spec this is
+ *                    the child value field
+ * @param descending  true for descending order, false for ascending
+ * @param filterField the co-located child discriminator field identifier (IRI), or null
+ *                    for a flat sort
+ * @param filterValue the value {@code filterField} must equal on the child supplying the
+ *                    sort key; null for a flat sort
+ * @param missing     placement of entities with no sort value, or null for the Lucene
+ *                    default (selector specs default to {@link MissingPlacement#LAST})
  */
-public record SortSpec(String field, boolean descending) {
+public record SortSpec(String field, boolean descending, String filterField,
+                       String filterValue, MissingPlacement missing) {
+
+    /** Where entities with no sort value land in the final result order. */
+    public enum MissingPlacement { FIRST, LAST }
+
+    /** Flat sort — no child selector, Lucene-default missing-value placement. */
+    public SortSpec(String field, boolean descending) {
+        this(field, descending, null, null, null);
+    }
+
+    /** True when this spec selects its sort key from a nested child doc. */
+    public boolean hasSelector() {
+        return filterField != null;
+    }
 
     public String toCanonical() {
-        return field + (descending ? ":desc" : ":asc");
+        StringBuilder sb = new StringBuilder(field);
+        if (filterField != null) {
+            sb.append('[').append(filterField).append('=').append(filterValue).append(']');
+        }
+        sb.append(descending ? ":desc" : ":asc");
+        if (missing != null) {
+            sb.append(":missing-").append(missing.name().toLowerCase(Locale.ROOT));
+        }
+        return sb.toString();
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/SortSpecParser.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SortSpecParser.java
@@ -36,6 +36,16 @@ import org.apache.jena.atlas.json.JsonValue;
  * Single: {@code {"field": "year", "order": "desc"}}
  * Multi:  {@code [{"field": "year", "order": "desc"}, {"field": "title"}]}
  * Default order is ascending.
+ * <p>
+ * A spec may also carry a nested sort selector — sort by a child field, choosing the
+ * child by a co-located discriminator:
+ * <pre>{@code
+ * {"field": "...#identifierValue",
+ *  "filter": {"field": "...#identifierType", "eq": "companyID"},
+ *  "order": "asc", "missing": "last"}
+ * }</pre>
+ * Parsing here is purely syntactic; the nested scope is inferred and validated against
+ * the SHACL mapping in {@code ShaclTextIndexLucene.buildLuceneSort}.
  */
 public class SortSpecParser {
 
@@ -67,7 +77,54 @@ public class SortSpecParser {
             String order = obj.get("order").getAsString().value();
             descending = "desc".equalsIgnoreCase(order);
         }
-        return new SortSpec(field, descending);
+
+        String filterField = null;
+        String filterValue = null;
+        if (obj.hasKey("filter")) {
+            JsonValue filterVal = obj.get("filter");
+            if (!filterVal.isObject()) {
+                throw new TextIndexException(
+                    "Sort spec 'filter' must be an object {\"field\":..., \"eq\":...}: " + obj);
+            }
+            JsonObject filter = filterVal.getAsObject();
+            if (!filter.hasKey("field") || !filter.hasKey("eq")) {
+                throw new TextIndexException(
+                    "Sort spec 'filter' must have both 'field' and 'eq' keys: " + obj);
+            }
+            filterField = filter.get("field").getAsString().value();
+            filterValue = asLexicalForm(filter.get("eq"), obj);
+        }
+
+        SortSpec.MissingPlacement missing = null;
+        if (obj.hasKey("missing")) {
+            String placement = obj.get("missing").getAsString().value();
+            if ("first".equalsIgnoreCase(placement)) {
+                missing = SortSpec.MissingPlacement.FIRST;
+            } else if ("last".equalsIgnoreCase(placement)) {
+                missing = SortSpec.MissingPlacement.LAST;
+            } else {
+                throw new TextIndexException(
+                    "Sort spec 'missing' must be 'first' or 'last', got '" + placement + "'");
+            }
+        }
+
+        return new SortSpec(field, descending, filterField, filterValue, missing);
+    }
+
+    /** Lexical form of a filter's {@code eq} value — strings, numbers and booleans all
+     *  become the term text the discriminator field was indexed with. */
+    private static String asLexicalForm(JsonValue value, JsonObject context) {
+        if (value.isString()) {
+            return value.getAsString().value();
+        }
+        if (value.isNumber()) {
+            return value.getAsNumber().value().toString();
+        }
+        if (value.isBoolean()) {
+            return Boolean.toString(value.getAsBoolean().value());
+        }
+        throw new TextIndexException(
+            "Sort spec filter 'eq' must be a string, number or boolean: " + context);
     }
 
     /**

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -101,6 +101,8 @@ import org.junit.runners.Suite.SuiteClasses;
     , TestCqlParser.class
     , TestCqlToLuceneCompiler.class
     , TestSortSpec.class
+    // Nested sort selector: order by a child value where the co-located discriminator = X
+    , TestNestedSortSelector.class
     , TestTextIndexRegistry.class
 
     // Spatial filtering

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNestedSortSelector.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNestedSortSelector.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
+import org.apache.jena.query.text.ShaclIndexMapping.NestedDef;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * End-to-end coverage for the nested sort selector — "order by the nested value where the
+ * co-located discriminator = X" (see
+ * {@code docs/2026-07-02_nested_sort_selector_design.md}).
+ * <p>
+ * Entities carry repeated qualified identifiers: {@code (identifierType, identifierValue,
+ * identifierRank)} triples on one child doc each. The tests drive {@code luc:query} with the
+ * selector sort spec and assert:
+ * <ul>
+ *   <li>parents order by the value drawn from the <em>matching</em> child, not by the
+ *       decorrelated MIN/MAX over the flattened bag;</li>
+ *   <li>the selector never drops entities — those with no matching child are placed per
+ *       {@code missing} (default last), in both sort directions;</li>
+ *   <li>ordering happens before the {@code limit}/{@code offset} window, so pagination is
+ *       correct across a page boundary;</li>
+ *   <li>a selector composes with, and is independent of, a {@code cqlFilter}.</li>
+ * </ul>
+ */
+public class TestNestedSortSelector {
+
+    private static final String NS = "http://example.org/";
+    private static final String SCHEMA = "https://schema.org/";
+    private static final String FP = "urn:jena:lucene:field#";
+
+    private static final Node BOREHOLE_CLASS = NodeFactory.createURI(NS + "Borehole");
+    private static final Node TITLE_PRED = NodeFactory.createURI(NS + "title");
+    private static final Node IDENTIFIER_PRED = NodeFactory.createURI(SCHEMA + "identifier");
+    private static final Node ID_TYPE_PRED = NodeFactory.createURI(SCHEMA + "propertyID");
+    private static final Node ID_VALUE_PRED = NodeFactory.createURI(SCHEMA + "value");
+    private static final Node ID_RANK_PRED = NodeFactory.createURI(SCHEMA + "position");
+
+    private Dataset dataset;
+
+    @Before
+    public void setUp() {
+        TextQuery.init();
+
+        // TEXT default-search field so one query string matches every entity.
+        FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, false, true);
+        // Discriminator: indexed (queryable for the child filter), not sortable.
+        FieldDef idType = new FieldDef("identifierType", FieldType.KEYWORD, null,
+            true, true, true, false, true, false);
+        // Sort key: sortable. Multi-valued because the parent doc flattens every identifier
+        // value into one bag — the child docs still hold one value each.
+        FieldDef idValue = new FieldDef("identifierValue", FieldType.KEYWORD, null,
+            true, true, false, true, true, false);
+        FieldDef idRank = new FieldDef("identifierRank", FieldType.INT, null,
+            true, true, false, true, true, false);
+
+        NestedDef identifierNest = new NestedDef(
+            "identifier",
+            PathFactory.pathLink(IDENTIFIER_PRED),
+            Collections.singletonList(new JoinStep(IDENTIFIER_PRED, false)),
+            Collections.singleton(IDENTIFIER_PRED),
+            Arrays.asList(occurrence(idType, ID_TYPE_PRED),
+                occurrence(idValue, ID_VALUE_PRED),
+                occurrence(idRank, ID_RANK_PRED)),
+            Collections.emptyList());
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + "BoreholeShape"),
+            Collections.singleton(BOREHOLE_CLASS),
+            "uri", "docType",
+            Arrays.asList(titleField, idType, idValue, idRank),
+            Collections.singletonList(occurrence(titleField, TITLE_PRED)),
+            Collections.emptyList(),
+            Collections.singletonList(identifierNest));
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+
+        ShaclTextIndexLucene textIndex =
+            new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+        Dataset base = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            base.asDatasetGraph(), textIndex, mapping);
+        dataset = TextDatasetFactory.create(base, textIndex, true, producer);
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Node predicate) {
+        return new FieldOccurrence(
+            field, PathFactory.pathLink(predicate),
+            ShaclIndexAssembler.extractPathVariants(PathFactory.pathLink(predicate)),
+            Collections.singleton(predicate),
+            null, null, null, null);
+    }
+
+    /**
+     * Four entities whose companyID order differs from every other ordering in the fixture —
+     * insertion order, and the MIN/MAX over the whole bag of identifier values — so a passing
+     * selector test cannot be explained by an incidental tie-break.
+     * <pre>
+     *   entity   companyID    other identifiers    MIN over all values
+     *   bh1      B-100        govID Z-999          B-100
+     *   bh2      A-050        govID A-001          A-001
+     *   bh3      (none)       govID M-500          M-500
+     *   bh4      C-200        govID A-000          A-000
+     * </pre>
+     * companyID ascending: bh2, bh1, bh4, (bh3 has no key).
+     * MIN over all values:  bh4, bh2, bh1, bh3.
+     */
+    private void addStandardFixtures() {
+        addBorehole("bh1", new String[][] {{"companyID", "B-100", "20"}, {"govID", "Z-999", "1"}});
+        addBorehole("bh2", new String[][] {{"companyID", "A-050", "30"}, {"govID", "A-001", "2"}});
+        addBorehole("bh3", new String[][] {{"govID", "M-500", "3"}});
+        addBorehole("bh4", new String[][] {{"companyID", "C-200", "10"}, {"govID", "A-000", "4"}});
+    }
+
+    /** Each row of {@code identifiers} is {type, value, rank} and becomes one child doc. */
+    private void addBorehole(String localName, String[][] identifiers) {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            Resource bh = ResourceFactory.createResource(NS + localName);
+            model.add(bh, RDF.type, ResourceFactory.createResource(BOREHOLE_CLASS.getURI()));
+            model.add(bh, ResourceFactory.createProperty(TITLE_PRED.getURI()), "borehole");
+            for (int i = 0; i < identifiers.length; i++) {
+                Resource idNode = ResourceFactory.createResource(NS + localName + "-id-" + i);
+                model.add(bh, ResourceFactory.createProperty(IDENTIFIER_PRED.getURI()), idNode);
+                model.add(idNode, ResourceFactory.createProperty(ID_TYPE_PRED.getURI()), identifiers[i][0]);
+                model.add(idNode, ResourceFactory.createProperty(ID_VALUE_PRED.getURI()), identifiers[i][1]);
+                model.add(idNode, ResourceFactory.createProperty(ID_RANK_PRED.getURI()),
+                    model.createTypedLiteral(Integer.parseInt(identifiers[i][2])));
+            }
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    // ---- Sort-spec JSON helpers ----
+
+    private static String selectorSort(String valueField, String filterField, String filterValue,
+            String order, String missing) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"field\":\"").append(FP).append(valueField).append("\"")
+          .append(",\"filter\":{\"field\":\"").append(FP).append(filterField)
+          .append("\",\"eq\":\"").append(filterValue).append("\"}")
+          .append(",\"order\":\"").append(order).append("\"");
+        if (missing != null) {
+            sb.append(",\"missing\":\"").append(missing).append("\"");
+        }
+        return sb.append("}").toString();
+    }
+
+    private List<String> query(String sortSpec) {
+        return query(sortSpec, "", 100, 0);
+    }
+
+    /** Run {@code luc:query} and return the matched entity local names in result order. */
+    private List<String> query(String sortSpec, String cqlFilter, int limit, int offset) {
+        String sparql =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"borehole\" '" + cqlFilter + "' " +
+            "    '" + sortSpec + "' " + limit + " " + offset + ") .\n" +
+            "}";
+
+        List<String> ordered = new ArrayList<>();
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                ordered.add(sol.getResource("s").getURI().substring(NS.length()));
+            }
+        } finally {
+            dataset.end();
+        }
+        return ordered;
+    }
+
+    // ---- Tests ----
+
+    /**
+     * The core claim: parents order by the identifier value taken from the companyID child.
+     * The same field without a selector cannot express this — nested values live on the child
+     * docs, so every parent is keyless and the flat sort imposes no order at all.
+     */
+    @Test
+    public void testSortByNestedValueWhereDiscriminatorMatches() {
+        addStandardFixtures();
+
+        List<String> selectorOrder =
+            query(selectorSort("identifierValue", "identifierType", "companyID", "asc", null));
+        assertEquals("parents must order by the companyID identifier value",
+            Arrays.asList("bh2", "bh1", "bh4", "bh3"), selectorOrder);
+
+        List<String> flatOrder = query("{\"field\":\"" + FP + "identifierValue\",\"order\":\"asc\"}");
+        assertEquals("the flat sort still returns every entity",
+            new TreeSet<>(selectorOrder), new TreeSet<>(flatOrder));
+        assertNotEquals("the selector must discriminate, not fall back to the flat sort",
+            flatOrder, selectorOrder);
+    }
+
+    /** Descending reverses the matched-child keys and still keeps the unmatched entity last. */
+    @Test
+    public void testSortDescending() {
+        addStandardFixtures();
+
+        assertEquals(Arrays.asList("bh4", "bh1", "bh2", "bh3"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "desc", null)));
+    }
+
+    /**
+     * The selector chooses a sort key; it must not filter. Every entity survives, and the one
+     * with no companyID child lands per {@code missing} — default last, explicitly first when
+     * asked, in both directions.
+     */
+    @Test
+    public void testMissingPlacement() {
+        addStandardFixtures();
+
+        assertEquals("default missing placement is last",
+            Arrays.asList("bh2", "bh1", "bh4", "bh3"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "asc", null)));
+        assertEquals(Arrays.asList("bh3", "bh2", "bh1", "bh4"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "asc", "first")));
+        assertEquals(Arrays.asList("bh2", "bh1", "bh4", "bh3"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "asc", "last")));
+        assertEquals(Arrays.asList("bh3", "bh4", "bh1", "bh2"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "desc", "first")));
+        assertEquals(Arrays.asList("bh4", "bh1", "bh2", "bh3"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "desc", "last")));
+    }
+
+    /** A numeric child value sorts numerically, not lexically (rank 10 &lt; 20 &lt; 30). */
+    @Test
+    public void testNumericNestedValue() {
+        addStandardFixtures();
+
+        assertEquals(Arrays.asList("bh4", "bh1", "bh2", "bh3"),
+            query(selectorSort("identifierRank", "identifierType", "companyID", "asc", null)));
+        assertEquals(Arrays.asList("bh2", "bh1", "bh4", "bh3"),
+            query(selectorSort("identifierRank", "identifierType", "companyID", "desc", null)));
+        assertEquals("missing rank placed first on request",
+            Arrays.asList("bh3", "bh4", "bh1", "bh2"),
+            query(selectorSort("identifierRank", "identifierType", "companyID", "asc", "first")));
+    }
+
+    /**
+     * The sort runs inside Lucene, before the limit/offset window is cut, so paging returns
+     * consecutive slices of the fully ordered result rather than re-ordering a page.
+     */
+    @Test
+    public void testPaginationAcrossPageBoundary() {
+        addStandardFixtures();
+
+        String sort = selectorSort("identifierValue", "identifierType", "companyID", "asc", null);
+        assertEquals(Arrays.asList("bh2", "bh1"), query(sort, "", 2, 0));
+        assertEquals(Arrays.asList("bh4", "bh3"), query(sort, "", 2, 2));
+    }
+
+    /**
+     * Selector and {@code cqlFilter} answer different questions and compose: the filter
+     * decides which entities appear, the selector decides their order.
+     */
+    @Test
+    public void testComposesWithCqlFilter() {
+        addStandardFixtures();
+
+        String cql = "{\"op\":\"=\",\"args\":[{\"property\":\"" + FP + "identifierType\"},\"companyID\"]}";
+        assertEquals(Arrays.asList("bh2", "bh1", "bh4"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "asc", null),
+                cql, 100, 0));
+    }
+
+    /**
+     * With more than one matching child the parent key collapses MIN ascending / MAX
+     * descending, so bh5's key is D-100 going up and D-900 coming down.
+     */
+    @Test
+    public void testMultipleMatchingChildrenCollapseMinMax() {
+        addBorehole("bh1", new String[][] {{"companyID", "C-500", "1"}});
+        addBorehole("bh5", new String[][] {{"companyID", "D-100", "2"}, {"companyID", "D-900", "3"}});
+        addBorehole("bh6", new String[][] {{"companyID", "E-000", "4"}});
+
+        assertEquals("ascending takes the MIN of the matching children",
+            Arrays.asList("bh1", "bh5", "bh6"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "asc", null)));
+        assertEquals("descending takes the MAX of the matching children",
+            Arrays.asList("bh6", "bh5", "bh1"),
+            query(selectorSort("identifierValue", "identifierType", "companyID", "desc", null)));
+    }
+
+    /** A selector whose discriminator value matches nothing leaves every entity unmatched. */
+    @Test
+    public void testNoChildMatchesSelector() {
+        addStandardFixtures();
+
+        List<String> result =
+            query(selectorSort("identifierValue", "identifierType", "noSuchType", "asc", null));
+        assertEquals("all entities are retained when no child matches", 4, result.size());
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
@@ -31,6 +31,8 @@ import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
 import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
+import org.apache.jena.query.text.ShaclIndexMapping.NestedDef;
 import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
 import org.apache.jena.sparql.path.Path;
 import org.apache.jena.sparql.path.PathFactory;
@@ -40,6 +42,7 @@ import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
+import org.apache.lucene.search.join.ToParentBlockJoinSortField;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.junit.Test;
 
@@ -99,6 +102,248 @@ public class TestSortSpec {
     public void testIsSortSpec() {
         assertTrue(SortSpecParser.isSortSpec("{\"field\":\"year\"}"));
         assertFalse(SortSpecParser.isSortSpec("{\"op\":\"=\"}"));
+    }
+
+    // ---- Nested sort selector: parsing ----
+
+    @Test
+    public void testParseNestedSelector() {
+        List<SortSpec> specs = SortSpecParser.parse(
+            "{\"field\":\"identifierValue\","
+            + "\"filter\":{\"field\":\"identifierType\",\"eq\":\"companyID\"},"
+            + "\"order\":\"desc\",\"missing\":\"first\"}");
+        assertEquals(1, specs.size());
+        SortSpec spec = specs.get(0);
+        assertTrue(spec.hasSelector());
+        assertEquals("identifierValue", spec.field());
+        assertTrue(spec.descending());
+        assertEquals("identifierType", spec.filterField());
+        assertEquals("companyID", spec.filterValue());
+        assertEquals(SortSpec.MissingPlacement.FIRST, spec.missing());
+    }
+
+    @Test
+    public void testParseFlatSpecHasNoSelector() {
+        SortSpec spec = SortSpecParser.parse("{\"field\":\"year\"}").get(0);
+        assertFalse(spec.hasSelector());
+        assertNull(spec.filterField());
+        assertNull(spec.filterValue());
+        assertNull("absent 'missing' leaves Lucene's own default in place", spec.missing());
+    }
+
+    @Test
+    public void testParseNonStringFilterValue() {
+        SortSpec spec = SortSpecParser.parse(
+            "{\"field\":\"reading\",\"filter\":{\"field\":\"sensorId\",\"eq\":42}}").get(0);
+        assertEquals("42", spec.filterValue());
+    }
+
+    @Test(expected = TextIndexException.class)
+    public void testParseFilterWithoutEqThrows() {
+        SortSpecParser.parse("{\"field\":\"identifierValue\",\"filter\":{\"field\":\"identifierType\"}}");
+    }
+
+    @Test(expected = TextIndexException.class)
+    public void testParseNonObjectFilterThrows() {
+        SortSpecParser.parse("{\"field\":\"identifierValue\",\"filter\":\"companyID\"}");
+    }
+
+    @Test(expected = TextIndexException.class)
+    public void testParseUnknownMissingPlacementThrows() {
+        SortSpecParser.parse("{\"field\":\"year\",\"missing\":\"middle\"}");
+    }
+
+    @Test
+    public void testSelectorToCanonicalDistinguishesFilterValue() {
+        SortSpec companyId = new SortSpec("value", false, "type", "companyID", null);
+        SortSpec govId = new SortSpec("value", false, "type", "govID", null);
+        assertEquals("value[type=companyID]:asc", companyId.toCanonical());
+        assertNotEquals("shared-execution keys must distinguish selectors",
+            companyId.toCanonical(), govId.toCanonical());
+        assertEquals("value[type=companyID]:asc:missing-first",
+            new SortSpec("value", false, "type", "companyID",
+                SortSpec.MissingPlacement.FIRST).toCanonical());
+    }
+
+    // ---- Nested sort selector: mapping validation in buildLuceneSort ----
+
+    /**
+     * Two nested blocks plus a flat field, so the selector's scope rules have something to
+     * be wrong about: identifier(identifierType, identifierValue) and
+     * attribution(attributionRole, agentName), with a root-scoped {@code year}.
+     */
+    private static ShaclTextIndexLucene selectorTestIndex() {
+        Node yearPred = NodeFactory.createURI("http://example.org/year");
+        Node identifierPred = NodeFactory.createURI("http://example.org/identifier");
+        Node idTypePred = NodeFactory.createURI("http://example.org/propertyID");
+        Node idValuePred = NodeFactory.createURI("http://example.org/value");
+        Node attributionPred = NodeFactory.createURI("http://example.org/qualifiedAttribution");
+        Node rolePred = NodeFactory.createURI("http://example.org/hadRole");
+        Node agentPred = NodeFactory.createURI("http://example.org/agent");
+
+        FieldDef yearField = new FieldDef("year", FieldType.INT, null,
+            true, true, false, true, false, false);
+        FieldDef idType = new FieldDef("identifierType", FieldType.KEYWORD, null,
+            true, true, true, false, true, false);
+        FieldDef idValue = new FieldDef("identifierValue", FieldType.KEYWORD, null,
+            true, true, false, true, true, false);
+        FieldDef idLabel = new FieldDef("identifierLabel", FieldType.KEYWORD, null,
+            true, true, false, false, true, false);
+        FieldDef role = new FieldDef("attributionRole", FieldType.KEYWORD, null,
+            true, true, true, false, true, false);
+        FieldDef agentName = new FieldDef("agentName", FieldType.KEYWORD, null,
+            true, true, false, true, true, false);
+
+        NestedDef identifierNest = new NestedDef(
+            "identifier", PathFactory.pathLink(identifierPred),
+            Collections.singletonList(new JoinStep(identifierPred, false)),
+            Collections.singleton(identifierPred),
+            Arrays.asList(occurrence(idType, PathFactory.pathLink(idTypePred), Collections.singleton(idTypePred)),
+                occurrence(idValue, PathFactory.pathLink(idValuePred), Collections.singleton(idValuePred)),
+                occurrence(idLabel, PathFactory.pathLink(idValuePred), Collections.singleton(idValuePred))),
+            Collections.emptyList());
+        NestedDef attributionNest = new NestedDef(
+            "attribution", PathFactory.pathLink(attributionPred),
+            Collections.singletonList(new JoinStep(attributionPred, false)),
+            Collections.singleton(attributionPred),
+            Arrays.asList(occurrence(role, PathFactory.pathLink(rolePred), Collections.singleton(rolePred)),
+                occurrence(agentName, PathFactory.pathLink(agentPred), Collections.singleton(agentPred))),
+            Collections.emptyList());
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI("http://example.org/Shape"),
+            Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
+            "uri", "docType",
+            Arrays.asList(yearField, idType, idValue, idLabel, role, agentName),
+            Collections.singletonList(
+                occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred))),
+            Collections.emptyList(),
+            Arrays.asList(identifierNest, attributionNest));
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        TextIndexConfig config = new TextIndexConfig(ShaclIndexAssembler.deriveEntityDefinition(mapping));
+        config.setShaclMapping(mapping);
+        return new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+    }
+
+    @Test
+    public void testSelectorBuildsBlockJoinSortField() {
+        ShaclTextIndexLucene textIndex = selectorTestIndex();
+        try {
+            SortField ascending = textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "identifierValue", false, FP + "identifierType", "companyID", null)))
+                .getSort()[0];
+            assertTrue(ascending instanceof ToParentBlockJoinSortField);
+            assertEquals("identifierValue", ascending.getField());
+            assertEquals(SortField.Type.STRING, ascending.getType());
+            assertFalse(ascending.getReverse());
+            assertEquals("default missing placement is last",
+                SortField.STRING_LAST, ascending.getMissingValue());
+
+            // Lucene applies the reverse multiplier outside the comparator, so an absolute
+            // "missing last" needs the opposite sentinel once the sort is descending.
+            SortField descending = textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "identifierValue", true, FP + "identifierType", "companyID", null)))
+                .getSort()[0];
+            assertTrue(descending.getReverse());
+            assertEquals(SortField.STRING_FIRST, descending.getMissingValue());
+        } finally {
+            textIndex.close();
+        }
+    }
+
+    @Test
+    public void testFlatSpecStillBuildsPlainSortField() {
+        ShaclTextIndexLucene textIndex = selectorTestIndex();
+        try {
+            SortField flat = textIndex.buildLuceneSort(
+                List.of(new SortSpec(FP + "year", false))).getSort()[0];
+            assertFalse(flat instanceof ToParentBlockJoinSortField);
+            assertNull("an absent 'missing' must not change flat sort behaviour",
+                flat.getMissingValue());
+        } finally {
+            textIndex.close();
+        }
+    }
+
+    /** {@code missing} is honoured on flat sorts too, on both the STRING and numeric paths. */
+    @Test
+    public void testFlatSpecHonoursExplicitMissingPlacement() {
+        ShaclTextIndexLucene textIndex = selectorTestIndex();
+        try {
+            SortField year = textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "year", false, null, null, SortSpec.MissingPlacement.LAST)))
+                .getSort()[0];
+            assertEquals(Integer.MAX_VALUE, year.getMissingValue());
+
+            SortField yearDesc = textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "year", true, null, null, SortSpec.MissingPlacement.LAST)))
+                .getSort()[0];
+            assertEquals(Integer.MIN_VALUE, yearDesc.getMissingValue());
+
+            SortField value = textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "identifierValue", false, null, null,
+                    SortSpec.MissingPlacement.FIRST))).getSort()[0];
+            assertEquals(SortField.STRING_FIRST, value.getMissingValue());
+        } finally {
+            textIndex.close();
+        }
+    }
+
+    @Test
+    public void testSelectorOnFlatFieldThrows() {
+        ShaclTextIndexLucene textIndex = selectorTestIndex();
+        try {
+            textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "year", false, FP + "identifierType", "companyID", null)));
+            fail("a selector on a root-scoped field must be rejected");
+        } catch (TextIndexException ex) {
+            assertTrue(ex.getMessage(), ex.getMessage().contains("requires a nested field"));
+        } finally {
+            textIndex.close();
+        }
+    }
+
+    @Test
+    public void testSelectorAcrossDifferentNestedBlocksThrows() {
+        ShaclTextIndexLucene textIndex = selectorTestIndex();
+        try {
+            textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "identifierValue", false, FP + "attributionRole", "owner", null)));
+            fail("a discriminator from another nested block must be rejected");
+        } catch (TextIndexException ex) {
+            assertTrue(ex.getMessage(), ex.getMessage().contains("same idx:nested block"));
+        } finally {
+            textIndex.close();
+        }
+    }
+
+    @Test
+    public void testSelectorOnUnsortableFieldThrows() {
+        ShaclTextIndexLucene textIndex = selectorTestIndex();
+        try {
+            textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "identifierLabel", false, FP + "identifierType", "companyID", null)));
+            fail("a non-sortable sort field must be rejected");
+        } catch (TextIndexException ex) {
+            assertTrue(ex.getMessage(), ex.getMessage().contains("not idx:sortable"));
+        } finally {
+            textIndex.close();
+        }
+    }
+
+    @Test
+    public void testSelectorWithUnknownFilterFieldThrows() {
+        ShaclTextIndexLucene textIndex = selectorTestIndex();
+        try {
+            textIndex.buildLuceneSort(List.of(
+                new SortSpec(FP + "identifierValue", false, FP + "noSuchField", "companyID", null)));
+            fail("an unresolvable discriminator field must be rejected");
+        } catch (TextIndexException ex) {
+            assertTrue(ex.getMessage(), ex.getMessage().contains("Unknown sort filter field"));
+        } finally {
+            textIndex.close();
+        }
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <ver.jakarta.json>2.0.1</ver.jakarta.json>
 
     <!-- These two must be in-step -->
-    <ver.jetty>12.1.7</ver.jetty>
+    <ver.jetty>12.1.11</ver.jetty>
     <ver.jakarta-servlet>6.1.0</ver.jakarta-servlet>
 
     <!--


### PR DESCRIPTION
Implements `docs/2026-07-02_nested_sort_selector_design.md` (the design doc was previously the only commit on this branch).

## Problem

Results are entity-per-document, and entities commonly carry repeated qualified child records (identifiers, prov attributions). Consumers pivot these into columns and want to order the whole result set by **one** of them — "sort by the *companyID* identifier", "sort by the *owner* agent" — while keeping every entity and keeping pagination correct.

A flat sort can't express this: flattening decorrelates the type↔value tuple, leaving only MIN/MAX over the bag. Doing it in SPARQL `ORDER BY` doesn't work either — ordering would run in ARQ *after* `luc:query` has already cut the `limit`/`offset` window.

## API

The sort object (5th `luc:query` argument) gains an optional selector:

```json
{
  "field":  "urn:jena:lucene:field#identifierValue",
  "filter": {"field":"urn:jena:lucene:field#identifierType","eq":"companyID"},
  "order":  "asc",
  "missing": "last"
}
```

The `filter` is a **sort-key selector, not a result filter** — it chooses which child supplies the key and never drops entities. Those with no matching child are placed by `missing` (default `last`). To also restrict which entities appear, say so independently in `cqlFilter`; the two compose. The nested scope is inferred from `field` and is not part of the wire format.

## Implementation

Small and additive, on the existing block-join rails.

- `SortSpec` — carries `filterField` / `filterValue` / `missing`; `toCanonical()` includes them so shared-execution keys distinguish selectors.
- `SortSpecParser` — parses `filter` and `missing` syntactically.
- `ShaclTextIndexLucene.buildLuceneSort` — emits `ToParentBlockJoinSortField(childValueField, type, reverse, PARENTS_FILTER, childFilter)`, where `childFilter` is `_nestedScope = <scope>` MUST `filterField = filterValue`. Multiple matching children collapse MIN (asc) / MAX (desc). Child-filter `BitSetProducer`s are cached (bounded at 256 entries — the key space is caller-supplied) so paging doesn't re-run the child filter per page.
- Validation is a hard error for: a `filter` on a root-scoped field, a discriminator from a *different* `idx:nested` block, an unknown field, or a non-`idx:sortable` sort field.
- `missing` is honoured on flat sorts too. Absent, Lucene's own default is kept — existing flat sort behaviour is unchanged.

Lucene applies the reverse multiplier *outside* the comparator, so the missing-value sentinel is flipped by `reverse` to make `first`/`last` mean absolute placement in what the caller sees.

**No indexer or assembler changes.** The only requirement is data modelling: discriminator and value must be `idx:property` occurrences of the same `idx:nested` block, the value `idx:sortable`, the discriminator `idx:indexed`.

## Tests

`TestNestedSortSelector` (new, registered in `TS_Text`) drives `luc:query` end-to-end and covers:

- ordering by the matched child's value, demonstrably distinct from what the flat sort produces
- descending
- `missing` first/last, in both directions, with the unmatched entity always retained
- numeric child values sorting numerically
- pagination across a page boundary (sort applied before the window is cut)
- composition with `cqlFilter`
- MIN/MAX collapse when an entity has several matching children
- a selector matching no children at all

`TestSortSpec` adds parser coverage (`filter`, `missing`, malformed forms) and the mapping-validation error cases.

Full `jena-text` suite: 646 tests, 0 failures.

## Not implemented

The design's optional named-sort-preset variant — the inline form covers the requirement and a preset adds config surface for no new capability. Noted in the design doc's status.
