### PR TITLE
Fix multi-valued keyword sorting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,12 @@ mvn test -pl jena-text -Dtest="TestShaclIndexMapping,TestShaclDocumentBuilding,T
 
 **Important**: Surefire only discovers `**/TS_*.java` suite files. New test classes must be added to `TS_Text.java` or they won't run in CI.
 
+### Test discipline
+
+- **Documented recommendations must be backed by a test.** Any behaviour or config pattern we recommend in documentation (e.g. the `idx:normalizer` twin-field pattern) must have a test that exercises the *exact* recommended shape — including the real field cardinality (single- vs multi-valued). Advice must not outrun coverage.
+- **Write the test first and confirm it fails (red) before fixing (green).** For a bug fix or a new behaviour, add the failing test, run it, and verify it fails for the expected reason; only then apply the fix and watch it pass. Keep the red and green as separate commits where practical so the TDD step is visible in history.
+- **Test the corners of the config matrix, not one axis at a time.** When a change interacts with existing flags (sortable × multiValued × normalized × field type), cover the intersection that production configs actually use — not just each axis in isolation.
+
 ### Fuseki UI (JavaScript)
 
 ```bash

--- a/demo/test-cases/keyword-multivalued-sort/README.md
+++ b/demo/test-cases/keyword-multivalued-sort/README.md
@@ -1,0 +1,43 @@
+# Test case: `keyword-multivalued-sort`
+
+Live, in-browser check of the **GSWA shape**: a `KEYWORD` field that is `sortable` **and**
+`multiValued` **and** carries `idx:normalizer`. This is the intersection of the normalizer
+feature (#90) and the multi-valued sort fix (#92/#93) — the field a real deployment uses
+(`field:nameSort` fed from a multi-valued `schema:name`).
+
+Multi-valued sortable KEYWORD fields use `SortedSetDocValues` with a MIN/MAX selector; the
+normalizer must be applied to those bytes, or the sort silently falls back to raw
+(case-sensitive). This case confirms it does not.
+
+## Field under test (`config.ttl`)
+
+```turtle
+field:nameSort
+    idx:fieldType idx:KeywordField ;
+    idx:sortable true ;
+    idx:multiValued true ;
+    idx:normalizer [ a text:LowerCaseKeywordAnalyzer ] .
+```
+
+## Run
+
+From `demo/test-cases/`:
+
+```bash
+task run    CASE=keyword-multivalued-sort
+task verify CASE=keyword-multivalued-sort
+task stop
+```
+
+UI: `http://localhost:3032/#/dataset/ds/query`
+
+## Expected results
+
+| Query | Demonstrates | Expected |
+|-------|--------------|----------|
+| `01-multivalued-sort` | multi-valued + normalized sort is case-insensitive | `apple, Zebra, Äpfel` |
+| `02-multivalued-min` | ascending uses the **normalized** MIN per entity | `…/eOne` then `…/eTwo` |
+
+If the normalizer were **not** applied to the multi-valued sort key, query 01 would return
+raw-byte order (`Zebra, apple, Äpfel`) and query 02 would return `eTwo` before `eOne`
+(raw min `"Yak"` < `"Beta"`). Seeing the expected order confirms #93 + #90 compose correctly.

--- a/demo/test-cases/keyword-multivalued-sort/config.ttl
+++ b/demo/test-cases/keyword-multivalued-sort/config.ttl
@@ -1,0 +1,66 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+## Live check for the GSWA case: a KEYWORD field that is sortable + MULTI-VALUED +
+## normalized (idx:normalizer). Exercises the SortedSetDocValues sort path (#92/#93)
+## combined with the normalizer (#90). Fully in-memory — nothing written to disk.
+
+PREFIX :        <#>
+PREFIX field:   <urn:jena:lucene:field#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX text:    <http://jena.apache.org/text#>
+PREFIX idx:     <urn:jena:lucene:index#>
+PREFIX sh:      <http://www.w3.org/ns/shacl#>
+PREFIX ex:      <http://example.org/>
+
+## --- Fuseki server ---
+
+[] rdf:type fuseki:Server ;
+   fuseki:services ( :service ) .
+
+:service rdf:type fuseki:Service ;
+    fuseki:name "ds" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query  ; fuseki:name "query"  ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update ; fuseki:name "update" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; fuseki:name "data"   ] ;
+    fuseki:dataset :text_dataset .
+
+## --- Text-indexed dataset (in-memory) ---
+
+:text_dataset rdf:type text:TextDataset ;
+    text:dataset :base_dataset ;
+    text:indexes ( :index ) .
+
+:base_dataset rdf:type ja:DatasetTxnMem .
+
+:index rdf:type text:TextIndexShacl ;
+    text:indexId "default" ;
+    text:directory "mem" ;
+    text:shapes ( :ThingShape ) ;
+    text:storeValues true ;
+    idx:fusekiBase "http://localhost:3032" .
+
+## --- Field definitions ---
+
+## TEXT default-search field: lets a query token match a group of entities.
+field:title
+    idx:fieldName "title" ;
+    idx:fieldType idx:TextField ;
+    idx:stored true ;
+    idx:defaultSearch true .
+
+## The GSWA-shaped sort field: KEYWORD, sortable, MULTI-VALUED, normalized.
+field:nameSort
+    idx:fieldName "nameSort" ;
+    idx:fieldType idx:KeywordField ;
+    idx:sortable true ;
+    idx:multiValued true ;
+    idx:normalizer [ a text:LowerCaseKeywordAnalyzer ] .
+
+## --- Shape ---
+
+:ThingShape
+    sh:targetClass ex:Thing ;
+    sh:property [ idx:field field:title    ; sh:path ex:title ] ;
+    sh:property [ idx:field field:nameSort ; sh:path ex:name ] .

--- a/demo/test-cases/keyword-multivalued-sort/data.ttl
+++ b/demo/test-cases/keyword-multivalued-sort/data.ttl
@@ -1,0 +1,14 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX ex:  <http://example.org/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+## Group A (ex:title "namesort") — one name each; shows case-insensitive multi-valued sort.
+ex:eZebra  a ex:Thing ; ex:title "namesort" ; ex:name "Zebra"  .
+ex:eapple  a ex:Thing ; ex:title "namesort" ; ex:name "apple"  .
+ex:eAepfel a ex:Thing ; ex:title "namesort" ; ex:name "Äpfel"  .
+
+## Group B (ex:title "minsel") — genuine multi-valued entity; ascending must use the
+## normalized MIN. eOne's normalized min is "apple" (not raw "Yak"), so eOne sorts before eTwo.
+ex:eOne a ex:Thing ; ex:title "minsel" ; ex:name "Yak" ; ex:name "apple" .
+ex:eTwo a ex:Thing ; ex:title "minsel" ; ex:name "Beta" .

--- a/demo/test-cases/keyword-multivalued-sort/queries/01-multivalued-sort.rq
+++ b/demo/test-cases/keyword-multivalued-sort/queries/01-multivalued-sort.rq
@@ -1,0 +1,11 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#@ Multi-valued + normalized KEYWORD sort (SortedSet path). One name per entity in this group.
+#@ Expect: apple, Zebra, Äpfel  (case-insensitive). Raw bytes would give Zebra, apple, Äpfel.
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/>
+
+SELECT ?name WHERE {
+  (?hit ?s ?score) luc:query ("default" "default" "namesort" "" '{"field":"urn:jena:lucene:field#nameSort","order":"asc"}' 100 0) .
+  ?s ex:name ?name .
+}

--- a/demo/test-cases/keyword-multivalued-sort/queries/02-multivalued-min.rq
+++ b/demo/test-cases/keyword-multivalued-sort/queries/02-multivalued-min.rq
@@ -1,0 +1,12 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#@ Genuine multi-valued entity: ascending sort uses the normalized MIN per entity.
+#@ eOne has names {Yak, apple} -> normalized min "apple"; eTwo has "Beta" -> "beta".
+#@ Expect entity order: http://example.org/eOne then .../eTwo  (apple < beta).
+#@ Raw bytes would pick eOne's min as "Yak" (0x59) < "Beta" (0x42)? -> eTwo first (wrong).
+
+PREFIX luc: <urn:jena:lucene:index#>
+PREFIX ex:  <http://example.org/>
+
+SELECT ?s WHERE {
+  (?hit ?s ?score) luc:query ("default" "default" "minsel" "" '{"field":"urn:jena:lucene:field#nameSort","order":"asc"}' 100 0) .
+}

--- a/demo/test-cases/keyword-multivalued-sort/results/verified.md
+++ b/demo/test-cases/keyword-multivalued-sort/results/verified.md
@@ -1,0 +1,26 @@
+# keyword-multivalued-sort — verified results
+
+Captured 2026-07-17 15:43:46
+
+```
+=== 01-multivalued-sort.rq ===
+Multi-valued + normalized KEYWORD sort (SortedSet path). One name per entity in this group.
+Expect: apple, Zebra, Äpfel  (case-insensitive). Raw bytes would give Zebra, apple, Äpfel.
+--- result ---
+name
+apple
+Zebra
+Äpfel
+
+=== 02-multivalued-min.rq ===
+Genuine multi-valued entity: ascending sort uses the normalized MIN per entity.
+eOne has names {Yak, apple} -> normalized min "apple"; eTwo has "Beta" -> "beta".
+Expect entity order: http://example.org/eOne then .../eTwo  (apple < beta).
+Raw bytes would pick eOne's min as "Yak" (0x59) < "Beta" (0x42)? -> eTwo first (wrong).
+--- result ---
+s
+http://example.org/eOne
+http://example.org/eTwo
+
+Compare the above against keyword-multivalued-sort/README.md (Expected results).
+```

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -14,6 +14,14 @@ All tests run via JUnit 4 and are aggregated in `TS_Text.java` (Surefire only pi
 
 ---
 
+## Test discipline
+
+- **Documented recommendations must be backed by a test.** Anything we recommend in docs (e.g. the `idx:normalizer` twin-field pattern) needs a test exercising the *exact* recommended shape, including the real field cardinality (single- vs multi-valued). Advice must not outrun coverage.
+- **Red before green.** For a bug fix or new behaviour, add the failing test first, confirm it fails for the expected reason, then apply the fix. Keep red and green as separate commits where practical so the TDD step is visible.
+- **Cover the corners of the config matrix.** When a change interacts with existing flags (`sortable × multiValued × normalized × field type`), test the intersection production configs actually use — not each axis alone. (This is why multi-valued + normalized KEYWORD sorting had a gap: single-valued and multi-valued were each tested, but never together.)
+
+---
+
 ## Test Suite Overview
 
 ### SHACL Faceting Tests

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -1010,10 +1010,13 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                     doc.add(new SortedSetDocValuesFacetField(fieldName, strVal));
                 }
                 if (fieldDef.isSortable()) {
+                    // Normalized key (if a normalizer is declared) drives both the single- and
+                    // multi-valued sort DocValues, so multi-valued sorting is case-normalized too.
+                    BytesRef sortValue = kwKey != null ? kwKey : new BytesRef(strVal);
                     if (fieldDef.isMultiValued()) {
-                        doc.add(new SortedSetDocValuesField(fieldName, new BytesRef(strVal)));
+                        doc.add(new SortedSetDocValuesField(fieldName, sortValue));
                     } else {
-                        doc.add(new SortedDocValuesField(fieldName, kwKey != null ? kwKey : new BytesRef(strVal)));
+                        doc.add(new SortedDocValuesField(fieldName, sortValue));
                     }
                 }
                 break;
@@ -1121,10 +1124,12 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                     doc.add(new SortedSetDocValuesFacetField(fieldName, lexical));
                 }
                 if (fieldDef.isSortable()) {
+                    // Normalized key (if any) drives both single- and multi-valued sort DocValues.
+                    BytesRef sortValue = kwKey != null ? kwKey : new BytesRef(lexical);
                     if (fieldDef.isMultiValued()) {
-                        doc.add(new SortedSetDocValuesField(fieldName, new BytesRef(lexical)));
+                        doc.add(new SortedSetDocValuesField(fieldName, sortValue));
                     } else {
-                        doc.add(new SortedDocValuesField(fieldName, kwKey != null ? kwKey : new BytesRef(lexical)));
+                        doc.add(new SortedDocValuesField(fieldName, sortValue));
                     }
                 }
             }

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -1010,7 +1010,11 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                     doc.add(new SortedSetDocValuesFacetField(fieldName, strVal));
                 }
                 if (fieldDef.isSortable()) {
-                    doc.add(new SortedDocValuesField(fieldName, kwKey != null ? kwKey : new BytesRef(strVal)));
+                    if (fieldDef.isMultiValued()) {
+                        doc.add(new SortedSetDocValuesField(fieldName, new BytesRef(strVal)));
+                    } else {
+                        doc.add(new SortedDocValuesField(fieldName, kwKey != null ? kwKey : new BytesRef(strVal)));
+                    }
                 }
                 break;
 
@@ -1117,7 +1121,11 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                     doc.add(new SortedSetDocValuesFacetField(fieldName, lexical));
                 }
                 if (fieldDef.isSortable()) {
-                    doc.add(new SortedDocValuesField(fieldName, kwKey != null ? kwKey : new BytesRef(lexical)));
+                    if (fieldDef.isMultiValued()) {
+                        doc.add(new SortedSetDocValuesField(fieldName, new BytesRef(lexical)));
+                    } else {
+                        doc.add(new SortedDocValuesField(fieldName, kwKey != null ? kwKey : new BytesRef(lexical)));
+                    }
                 }
             }
             case INT -> addIntegerLiteralField(doc, fieldDef, lexical);
@@ -2393,6 +2401,12 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                     ? SortedNumericSelector.Type.MAX
                     : SortedNumericSelector.Type.MIN;
                 fields[i] = new SortedNumericSortField(luceneFieldName, sortType, spec.descending(), selector);
+            } else if (fd != null && fd.getFieldType() == ShaclIndexMapping.FieldType.KEYWORD
+                    && fd.isMultiValued()) {
+                SortedSetSelector.Type selector = spec.descending()
+                    ? SortedSetSelector.Type.MAX
+                    : SortedSetSelector.Type.MIN;
+                fields[i] = new SortedSetSortField(luceneFieldName, spec.descending(), selector);
             } else {
                 fields[i] = new SortField(luceneFieldName, sortType, spec.descending());
             }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -115,6 +115,8 @@ import org.junit.runners.Suite.SuiteClasses;
     , TestKeywordNormalizer.class
     // idx:normalizer on a multi-valued KEYWORD field (SortedSet path)
     , TestKeywordNormalizerMultiValued.class
+    // twin-field pattern: same predicate -> TEXT search field + normalized KEYWORD sort field
+    , TestKeywordNormalizerTwinField.class
 
     // luc:match property function
     , TestTextMatchPF.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -113,6 +113,8 @@ import org.junit.runners.Suite.SuiteClasses;
     , TestKeywordRawSortAndExactMatch.class
     // idx:normalizer feature: case-insensitive KEYWORD sort + exact match
     , TestKeywordNormalizer.class
+    // idx:normalizer on a multi-valued KEYWORD field (SortedSet path)
+    , TestKeywordNormalizerMultiValued.class
 
     // luc:match property function
     , TestTextMatchPF.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizerMultiValued.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizerMultiValued.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.analyzer.LowerCaseKeywordAnalyzer;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Sorting on a KEYWORD field that is BOTH {@code multiValued} AND has an {@code idx:normalizer}.
+ * This is the GSWA case ({@code field:nameSort} is multi-valued + normalized) and the intersection
+ * that neither the #90 (normalizer, single-valued) nor #92/#93 (multi-valued, raw) tests covered.
+ *
+ * Multi-valued sortable KEYWORD fields use {@code SortedSetDocValues} with a MIN/MAX selector; the
+ * normalizer must be applied to those bytes too, or the sort silently falls back to raw (case-sensitive).
+ */
+public class TestKeywordNormalizerMultiValued {
+
+    private static final String NS = "http://example.org/";
+    private static final String FP = "urn:jena:lucene:field#";
+    private static final Node THING_CLASS = NodeFactory.createURI(NS + "Thing");
+    private static final Node TITLE_PRED = NodeFactory.createURI(NS + "title");
+    private static final Node NAME_PRED = NodeFactory.createURI(NS + "name");
+
+    private static final String AEPFEL = "Äpfel";
+
+    private Dataset dataset;
+    private final Map<String, String> uriToLabel = new LinkedHashMap<>();
+
+    @Before
+    public void setUp() {
+        TextQuery.init();
+
+        FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, false, true);
+        // KEYWORD, sortable, MULTI-VALUED, with a lower-casing normalizer.
+        FieldDef nameField = new FieldDef("name", FieldType.KEYWORD, null, null,
+            true, true, false, true, true, false, false, null, new LowerCaseKeywordAnalyzer());
+
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(titleField, PathFactory.pathLink(TITLE_PRED), Collections.singleton(TITLE_PRED)),
+            occurrence(nameField, PathFactory.pathLink(NAME_PRED), Collections.singleton(NAME_PRED)));
+
+        IndexProfile thingProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "ThingShape"),
+            Collections.singleton(THING_CLASS),
+            "uri", "docType",
+            Arrays.asList(titleField, nameField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(thingProfile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setValueStored(true);
+
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), textIndex, mapping);
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+    }
+
+    private void addThing(String localName, String... names) {
+        String uri = NS + localName;
+        uriToLabel.put(uri, localName);
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            Resource r = ResourceFactory.createResource(uri);
+            model.add(r, RDF.type, ResourceFactory.createResource(NS + "Thing"));
+            model.add(r, ResourceFactory.createProperty(NS + "title"), "thing");
+            for (String name : names) {
+                model.add(r, ResourceFactory.createProperty(NS + "name"), name);
+            }
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field, path, ShaclIndexAssembler.extractPathVariants(path), predicates,
+            null, null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    /** One value per entity, but the field is multi-valued → exercises the SortedSet path. */
+    @Test
+    public void testMultiValuedNormalizedSortIsCaseInsensitive() {
+        addThing("eZebra",  "Zebra");
+        addThing("eapple",  "apple");
+        addThing("eAepfel", AEPFEL);
+
+        // Normalized keys: zebra, apple, äpfel → ascending: apple < zebra < äpfel.
+        assertEquals("multi-valued + normalized KEYWORD sort must be case-insensitive",
+            Arrays.asList("eapple", "eZebra", "eAepfel"), querySortedEntities());
+    }
+
+    /** Genuine multi-value entities: ascending uses the normalized MIN per entity. */
+    @Test
+    public void testMultiValuedNormalizedSortUsesNormalizedMin() {
+        addThing("eOne", "Yak", "apple");  // normalized min = "apple"
+        addThing("eTwo", "Beta");          // normalized     = "beta"
+
+        // Normalized: "apple" (eOne) < "beta" (eTwo).
+        // Raw bytes would pick eOne's min as "Yak" (0x59) and eTwo as "Beta" (0x42) → eTwo first (wrong).
+        assertEquals("multi-valued MIN selector must use the normalized value",
+            Arrays.asList("eOne", "eTwo"), querySortedEntities());
+    }
+
+    private List<String> querySortedEntities() {
+        String sparql =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"thing\" \"\" " +
+            "    '{\"field\":\"" + FP + "name\",\"order\":\"asc\"}' 100 0) .\n" +
+            "}";
+
+        List<String> ordered = new ArrayList<>();
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                ordered.add(uriToLabel.get(sol.getResource("s").getURI()));
+            }
+        } finally {
+            dataset.end();
+        }
+        return ordered;
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizerTwinField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizerTwinField.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.analyzer.LowerCaseKeywordAnalyzer;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The documented "twin field" pattern for a full-text label, exercised end to end:
+ * ONE predicate ({@code ex:name}) populates BOTH a {@code TEXT} {@code defaultSearch}
+ * field (for {@code luc:query} full-text search) AND a normalized sortable {@code KEYWORD}
+ * field (for the sortSpec). This mirrors the GSWA config where {@code schema:name} feeds
+ * {@code field:name} (TEXT) and a proposed {@code field:nameSort} (KEYWORD + idx:normalizer).
+ *
+ * Confirms: a single full-text query matches via the TEXT field while the results come back
+ * in case-insensitive order via the normalized KEYWORD twin.
+ */
+public class TestKeywordNormalizerTwinField {
+
+    private static final String NS = "http://example.org/";
+    private static final String FP = "urn:jena:lucene:field#";
+    private static final Node THING_CLASS = NodeFactory.createURI(NS + "Thing");
+    private static final Node NAME_PRED = NodeFactory.createURI(NS + "name");
+
+    private Dataset dataset;
+    private final Map<String, String> uriToName = new LinkedHashMap<>();
+
+    @Before
+    public void setUp() {
+        TextQuery.init();
+
+        // Same predicate (ex:name) feeds both fields:
+        //  - nameText: TEXT, defaultSearch -> tokenized for full-text search
+        //  - nameSort: KEYWORD, sortable, lower-casing normalizer -> case-insensitive sort key
+        FieldDef nameText = new FieldDef("nameText", FieldType.TEXT, null,
+            true, true, false, false, false, true);
+        FieldDef nameSort = new FieldDef("nameSort", FieldType.KEYWORD, null, null,
+            true, true, false, true, false, false, false, null, new LowerCaseKeywordAnalyzer());
+
+        List<FieldOccurrence> rootOccurrences = Arrays.asList(
+            occurrence(nameText, PathFactory.pathLink(NAME_PRED), Collections.singleton(NAME_PRED)),
+            occurrence(nameSort, PathFactory.pathLink(NAME_PRED), Collections.singleton(NAME_PRED)));
+
+        IndexProfile thingProfile = new IndexProfile(
+            NodeFactory.createURI(NS + "ThingShape"),
+            Collections.singleton(THING_CLASS),
+            "uri", "docType",
+            Arrays.asList(nameText, nameSort),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(thingProfile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setValueStored(true);
+
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), textIndex, mapping);
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+    }
+
+    private void addThing(String localName, String name) {
+        String uri = NS + localName;
+        uriToName.put(uri, name);
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            Resource r = ResourceFactory.createResource(uri);
+            model.add(r, RDF.type, ResourceFactory.createResource(NS + "Thing"));
+            model.add(r, ResourceFactory.createProperty(NS + "name"), name);
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field, path, ShaclIndexAssembler.extractPathVariants(path), predicates,
+            null, null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    /**
+     * Full-text search hits the shared TEXT field; the sortSpec on the normalized KEYWORD
+     * twin returns the matches in case-insensitive order.
+     */
+    @Test
+    public void testTwinFieldSearchViaTextSortViaNormalizedKeyword() {
+        // All three share the search token "bonaparte" (found via the tokenized TEXT field).
+        addThing("rZeta",  "Bonaparte Zeta");
+        addThing("rAlpha", "bonaparte alpha");
+        addThing("rMecca", "Bonaparte Mecca");
+
+        String sparql =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT ?s WHERE {\n" +
+            "  (?hit ?s ?score) luc:query (\"default\" \"default\" \"bonaparte\" \"\" " +
+            "    '{\"field\":\"" + FP + "nameSort\",\"order\":\"asc\"}' 100 0) .\n" +
+            "}";
+
+        List<String> ordered = new ArrayList<>();
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                ordered.add(uriToName.get(sol.getResource("s").getURI()));
+            }
+        } finally {
+            dataset.end();
+        }
+
+        // The full-text term matched all three via the TEXT twin.
+        assertEquals("full-text search should match all three via the TEXT field", 3, ordered.size());
+
+        // Normalized (lower-cased) sort keys: "bonaparte alpha" < "bonaparte mecca" < "bonaparte zeta".
+        assertEquals("sort must be case-insensitive via the normalized KEYWORD twin",
+            Arrays.asList("bonaparte alpha", "Bonaparte Mecca", "Bonaparte Zeta"), ordered);
+
+        // Raw-byte order (no normalizer) would put the capital-B names first: Mecca, Zeta, alpha.
+        assertNotEquals("must not be raw-byte order",
+            Arrays.asList("Bonaparte Mecca", "Bonaparte Zeta", "bonaparte alpha"), ordered);
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestShaclDocumentBuilding.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestShaclDocumentBuilding.java
@@ -35,6 +35,7 @@ import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
 import org.apache.jena.sparql.path.Path;
 import org.apache.jena.sparql.path.PathFactory;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.junit.After;
@@ -113,6 +114,21 @@ public class TestShaclDocumentBuilding {
             ShaclIndexAssembler.extractPathVariants(path),
             predicates,
             null, null, null, null);
+    }
+
+    private static IndexProfile multiValuedKeywordProfile() {
+        Node remarksPred = NodeFactory.createURI(NS + "remarks");
+        FieldDef remarksField = new FieldDef("remarks", FieldType.KEYWORD, null,
+            false, true, false, true, true, false);
+        return new IndexProfile(
+            NodeFactory.createURI(NS + "RemarksShape"),
+            Collections.singleton(BOOK_CLASS),
+            "uri", "docType",
+            Collections.singletonList(remarksField),
+            Collections.singletonList(occurrence(remarksField, PathFactory.pathLink(remarksPred),
+                Collections.singleton(remarksPred))),
+            Collections.emptyList(),
+            Collections.emptyList());
     }
 
     @After
@@ -247,6 +263,41 @@ public class TestShaclDocumentBuilding {
     }
 
     @Test
+    public void testMultiValuedSortableKeywordStringsUseSortedSetDocValues() {
+        IndexProfile profile = multiValuedKeywordProfile();
+        Entity entity = new Entity("http://example.org/book1", null);
+        entity.addValue("remarks", "First remark");
+        entity.addValue("remarks", "Second remark");
+
+        Document doc = textIndex.docFromMapping(entity, profile);
+
+        IndexableField[] fields = doc.getFields("remarks");
+        assertEquals(4, fields.length);
+        assertEquals(2, Arrays.stream(fields)
+            .filter(field -> field.fieldType().docValuesType() == DocValuesType.SORTED_SET)
+            .count());
+        textIndex.updateEntityForProfile(entity, profile);
+        textIndex.commit();
+    }
+
+    @Test
+    public void testMultiValuedSortableKeywordLiteralsUseSortedSetDocValues() {
+        IndexProfile profile = multiValuedKeywordProfile();
+        Entity entity = new Entity("http://example.org/book1", null);
+        entity.addValue("remarks", NodeFactory.createLiteralString("First remark"));
+        entity.addValue("remarks", NodeFactory.createLiteralString("Second remark"));
+
+        Document doc = textIndex.docFromMapping(entity, profile);
+
+        IndexableField[] fields = doc.getFields("remarks");
+        assertEquals(2, Arrays.stream(fields)
+            .filter(field -> field.fieldType().docValuesType() == DocValuesType.SORTED_SET)
+            .count());
+        textIndex.updateEntityForProfile(entity, profile);
+        textIndex.commit();
+    }
+
+    @Test
     public void testNonMultiValuedSortableFieldOnlyIndexesFirstValue() {
         Entity entity = new Entity("http://example.org/book1", null);
         entity.addValue("category", "Science");
@@ -257,6 +308,9 @@ public class TestShaclDocumentBuilding {
         assertEquals("Science", doc.get("category"));
         assertEquals("Should only index one category value for non-multi-valued field", 2,
             doc.getFields("category").length);
+        assertEquals(1, Arrays.stream(doc.getFields("category"))
+            .filter(field -> field.fieldType().docValuesType() == DocValuesType.SORTED)
+            .count());
         textIndex.updateEntityForProfile(entity, testProfile);
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
@@ -38,6 +38,8 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSelector;
 import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.search.SortedSetSelector;
+import org.apache.lucene.search.SortedSetSortField;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.junit.Test;
 
@@ -217,6 +219,97 @@ public class TestSortSpec {
             SortField field = sort.getSort()[0];
             assertTrue(field instanceof SortedNumericSortField);
             assertEquals(SortedNumericSelector.Type.MIN, ((SortedNumericSortField) field).getSelector());
+        } finally {
+            textIndex.close();
+        }
+    }
+
+    @Test
+    public void testMultiValuedKeywordSortUsesMinAndMaxSelectors() {
+        Node remarksPred = NodeFactory.createURI("http://example.org/remarks");
+        FieldDef remarksField = new FieldDef("remarks", FieldType.KEYWORD, null,
+            false, true, false, true, true, false);
+
+        List<FieldOccurrence> rootOccurrences = Collections.singletonList(
+            occurrence(remarksField, PathFactory.pathLink(remarksPred), Collections.singleton(remarksPred)));
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI("http://example.org/Shape"),
+            Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
+            "uri", "docType",
+            Collections.singletonList(remarksField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+
+        try {
+            SortField ascending = textIndex.buildLuceneSort(
+                List.of(new SortSpec(FP + "remarks", false))).getSort()[0];
+            assertTrue(ascending instanceof SortedSetSortField);
+            assertEquals(SortedSetSelector.Type.MIN,
+                ((SortedSetSortField) ascending).getSelector());
+            assertFalse(ascending.getReverse());
+
+            SortField descending = textIndex.buildLuceneSort(
+                List.of(new SortSpec(FP + "remarks", true))).getSort()[0];
+            assertTrue(descending instanceof SortedSetSortField);
+            assertEquals(SortedSetSelector.Type.MAX,
+                ((SortedSetSortField) descending).getSelector());
+            assertTrue(descending.getReverse());
+        } finally {
+            textIndex.close();
+        }
+    }
+
+    @Test
+    public void testMultiValuedKeywordSortOrdering() {
+        Node remarksPred = NodeFactory.createURI("http://example.org/remarks");
+        FieldDef remarksField = new FieldDef("remarks", FieldType.KEYWORD, null,
+            false, true, false, true, true, false);
+
+        List<FieldOccurrence> rootOccurrences = Collections.singletonList(
+            occurrence(remarksField, PathFactory.pathLink(remarksPred), Collections.singleton(remarksPred)));
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI("http://example.org/Shape"),
+            Collections.singleton(NodeFactory.createURI("http://example.org/Thing")),
+            "uri", "docType",
+            Collections.singletonList(remarksField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        ShaclTextIndexLucene textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+
+        try {
+            Entity first = new Entity("http://example.org/first", null);
+            first.addValue("remarks", "alpha");
+            first.addValue("remarks", "yankee");
+            textIndex.updateEntityForProfile(first, profile);
+
+            Entity second = new Entity("http://example.org/second", null);
+            second.addValue("remarks", NodeFactory.createLiteralString("bravo"));
+            second.addValue("remarks", NodeFactory.createLiteralString("zulu"));
+            textIndex.updateEntityForProfile(second, profile);
+            textIndex.commit();
+
+            List<SearchHit> ascending = textIndex.searchWithHitIds(
+                Collections.emptyList(), null, null,
+                List.of(new SortSpec(FP + "remarks", false)), null, null, 10);
+            assertEquals(List.of("http://example.org/first", "http://example.org/second"),
+                ascending.stream().map(hit -> hit.getEntityNode().getURI()).toList());
+
+            List<SearchHit> descending = textIndex.searchWithHitIds(
+                Collections.emptyList(), null, null,
+                List.of(new SortSpec(FP + "remarks", true)), null, null, 10);
+            assertEquals(List.of("http://example.org/second", "http://example.org/first"),
+                descending.stream().map(hit -> hit.getEntityNode().getURI()).toList());
         } finally {
             textIndex.close();
         }


### PR DESCRIPTION
## Summary

- use `SortedSetDocValuesField` for multi-valued sortable SHACL keyword fields
- use deterministic `MIN`/`MAX` selectors for ascending/descending keyword sorting
- retain `SortedDocValuesField` for single-valued keyword fields
- cover Java strings, RDF literals, IndexWriter acceptance, selector construction, and end-to-end ordering

## Upgrade note

Existing SHACL indexes containing a field previously written as `SORTED` must be rebuilt because Lucene cannot change an existing field's DocValues type to `SORTED_SET` in place. SHACL mode does not currently promise index-format compatibility across these changes.

## Testing

- `mvn test -pl jena-text -Dtest=TestShaclDocumentBuilding,TestSortSpec` — 25 passed
- `mvn test -pl jena-text` — 614 passed, 8 skipped
- `mvn verify -pl jena-text -DskipTests` — passed, including compilation, packaging, SBOM, source, and javadoc generation
- `git diff --check` — passed

Fixes #92


## CI vulnerability remediation

The Docker image scan exposed `CVE-2026-49268` in `org.apache.shiro:shiro-core:2.1.0` inside `jena-fuseki-server.jar`. The managed Apache Shiro BOM is updated to 2.2.1, the fixed stable release.

Validation:

- Fuseki Main and Server tests — 789 passed
- dependency tree — all Shiro artifacts resolve to 2.2.1
- local runtime Docker image build — passed
- Trivy HIGH/CRITICAL scan of `fuseki-ai:scan` — 0 OS and 0 JAR vulnerabilities
