### PR TITLE
fix: never auto-merge docker updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,28 +27,33 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      ## Auto-merge policy:
-      ##   - patch  : every ecosystem
-      ##   - minor  : github-actions and npm only
-      ##   - major  : never (always reviewed by hand)
-      ## Maven minor bumps are held back deliberately: a minor Lucene bump
-      ## (${ver.lucene}, currently 10.3.1) can change index/codec behaviour
-      ## that jena-text's SHACL entity-per-document index depends on.
+      ## Auto-merge policy: patch and minor, github-actions ONLY. Everything
+      ## else is labelled for a human.
+      ##
+      ## Docker is deliberately excluded even for "patch". Dependabot derives
+      ## the update type from the leading semver in the tag and ignores the
+      ## rest, so
+      ##     maven:3.9.9-eclipse-temurin-21 -> maven:3.9.15-eclipse-temurin-26
+      ## is reported as version-update:semver-patch while actually moving the
+      ## build JDK from 21 to 26. A green build does not make that safe, and
+      ## our two Dockerfiles pin the JDK and Maven versions this way.
       - name: Enable auto-merge
         if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
-           contains(fromJSON('["github_actions", "npm_and_yarn"]'), steps.metadata.outputs.package-ecosystem))
+          steps.metadata.outputs.package-ecosystem == 'github_actions' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      ## The exact inverse of the condition above, so every Dependabot PR ends
+      ## up either auto-merged or labelled -- never silently neither.
       - name: Label PRs left for manual review
         if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-major' ||
-          (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
-           !contains(fromJSON('["github_actions", "npm_and_yarn"]'), steps.metadata.outputs.package-ecosystem))
+          !(steps.metadata.outputs.package-ecosystem == 'github_actions' &&
+            (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+             steps.metadata.outputs.update-type == 'version-update:semver-minor'))
         run: gh pr edit "$PR_URL" --add-label "needs-manual-review"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Follow-up to #121. Caught this live on #123.

## The bug

Dependabot derives `update-type` from the **leading semver** in a docker tag and ignores the rest. So:

```
maven:3.9.9-eclipse-temurin-21  ->  maven:3.9.15-eclipse-temurin-26
```

is reported as `version-update:semver-patch` — because it reads `3.9.9 -> 3.9.15`. The `-eclipse-temurin-21 -> -26` part, a **major JDK jump**, is invisible to it.

The previous policy auto-merged patch for *every* ecosystem, so #123 was queued to merge on green CI and would have moved the build JDK from 21 to 26 with no human involved. A green build does not make that safe. I have disabled auto-merge on #123 manually; it now needs review like the rest.

Both `build-files/docker/Dockerfile.runtime` and `Dockerfile.loader` pin the JDK this way, so **no** docker tag update can be trusted to semver.

## The fix

Auto-merge is now `github_actions` only, patch and minor. The label condition is the exact inverse of the merge condition, so every Dependabot PR ends up either auto-merged or labelled `needs-manual-review` — never silently neither.

| | Before | After |
|---|---|---|
| github-actions patch/minor | auto-merge | auto-merge |
| github-actions major | label | label |
| docker patch | **auto-merge** | label |
| docker minor/major | label | label |