### PR TITLE
build: publish to ghcr.io/kurrawong and rename images to fuseki-lucene-shacl

### DIFF
--- a/.claude/skills/scan-images/SKILL.md
+++ b/.claude/skills/scan-images/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scan-images
 description: >-
-  Scan the Fuseki Docker images (fuseki-ai runtime, fuseki-loader indexer) for OS
+  Scan the Fuseki Docker images (fuseki-lucene-shacl runtime, fuseki-lucene-shacl-loader indexer) for OS
   and Java-library CVEs by running the Taskfile `scan` task (trivy), then report the
   findings and propose the exact dependency / base-image changes that fix them. Use
   when asked to scan, audit, or check the Docker images for vulnerabilities or CVEs.
@@ -23,8 +23,8 @@ Maven builder stage and the same `eclipse-temurin:21-jre-ubi10-minimal` runtime 
 
 | Image | Target | Contents |
 |-------|--------|----------|
-| `fuseki-ai` | `runtime` | lean server — just `jena-fuseki-server.jar` |
-| `fuseki-loader` | `loader` | everything in `runtime` **+** bundled `apache-jena` distribution (`/fuseki/apache-jena/lib/*.jar`) **+** `jq`; multi-mode `loader-entrypoint.sh` |
+| `fuseki-lucene-shacl` | `runtime` | lean server — just `jena-fuseki-server.jar` |
+| `fuseki-lucene-shacl-loader` | `loader` | everything in `runtime` **+** bundled `apache-jena` distribution (`/fuseki/apache-jena/lib/*.jar`) **+** `jq`; multi-mode `loader-entrypoint.sh` |
 
 Implication for triage: a **base / OS** CVE affects *both* images. A **Java-library** CVE
 often exists in both, but trivy can only version-detect the unpacked jars in the loader's
@@ -52,12 +52,12 @@ task scan SCAN_SEVERITY=CRITICAL,HIGH,MEDIUM # widen severity
 - If an image is missing locally the task tells you to build it first
   (`task loader-build` / `task runtime-build`).
 
-> **Scan the *right* image.** A scan only describes the exact local tag you point it at.
-> `demo/test/docker-compose.yml` reuses the `fuseki-ai` image tag for a *different*,
-> Alpine-based demo build — so a stale demo image can masquerade as the production runtime and
-> report Alpine CVEs the real UBI image never had. For an accurate production scan, rebuild
-> from the root Taskfile first (`task runtime-build` / `task loader-build`) and confirm
-> `Metadata.OS` in the JSON report reads `redhat` (the UBI base), not `alpine`.
+> **Scan the *right* image.** A scan only describes the exact local tag you point it at, and
+> `demo/` consumes the same `fuseki-lucene-shacl` / `fuseki-lucene-shacl-loader` tags it can
+> also pull from GHCR — so a stale or pulled image can be scanned in place of the one your
+> working tree would build. For an accurate scan of current source, rebuild from the root
+> Taskfile first (`task runtime-build` / `task loader-build`) and confirm `Metadata.OS` in the
+> JSON report reads `redhat` (the UBI base).
 
 ## Turn each finding into a suggested fix
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,8 +17,13 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  FUSEKI_IMAGE: ghcr.io/${{ github.repository_owner }}/fuseki-ai
-  LOADER_IMAGE: ghcr.io/${{ github.repository_owner }}/fuseki-loader
+  ## Owner is a lowercase literal, not ${{ github.repository_owner }}. That
+  ## expression returns the owner with its original casing — "Kurrawong" — and
+  ## Docker repository names must be lowercase, so buildx rejected the tag
+  ## before reaching the registry and every push since the repo moved failed
+  ## with: invalid tag "ghcr.io/Kurrawong/...": repository name must be lowercase
+  FUSEKI_IMAGE: ghcr.io/kurrawong/fuseki-lucene-shacl
+  LOADER_IMAGE: ghcr.io/kurrawong/fuseki-lucene-shacl-loader
 
 jobs:
   build-and-push:
@@ -54,9 +59,9 @@ jobs:
       # than once per image. The builder is pinned to linux/amd64, so the
       # multi-arch push steps reuse it too.
 
-      # ─── fuseki-ai: build amd64 (load), scan, push multi-arch on main ───────
+      # ─── fuseki-lucene-shacl: build amd64 (load), scan, push multi-arch on main ───────
 
-      - name: Build fuseki-ai (amd64, load for scan)
+      - name: Build fuseki-lucene-shacl (amd64, load for scan)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -64,21 +69,21 @@ jobs:
           target: runtime
           platforms: linux/amd64
           load: true
-          tags: fuseki-ai:scan
+          tags: fuseki-lucene-shacl:scan
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Scan fuseki-ai (HIGH, CRITICAL)
+      - name: Scan fuseki-lucene-shacl (HIGH, CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: fuseki-ai:scan
+          image-ref: fuseki-lucene-shacl:scan
           format: table
           severity: HIGH,CRITICAL
           scanners: vuln
           exit-code: '1'
           ignore-unfixed: false
 
-      - name: Push fuseki-ai (multi-arch)
+      - name: Push fuseki-lucene-shacl (multi-arch)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
@@ -93,9 +98,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # ─── fuseki-loader: build amd64 (load), smoke-test, scan, push multi-arch ──
+      # ─── fuseki-lucene-shacl-loader: build amd64 (load), smoke-test, scan, push multi-arch ──
 
-      - name: Build fuseki-loader (amd64, load for scan)
+      - name: Build fuseki-lucene-shacl-loader (amd64, load for scan)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -103,11 +108,11 @@ jobs:
           target: loader
           platforms: linux/amd64
           load: true
-          tags: fuseki-loader:scan
+          tags: fuseki-lucene-shacl-loader:scan
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke-test fuseki-loader with tdb2.xloader
+      - name: Smoke-test fuseki-lucene-shacl-loader with tdb2.xloader
         run: |
           mkdir -p "$RUNNER_TEMP/xloader-db" "$RUNNER_TEMP/xloader-tmp"
           docker run --rm \
@@ -117,7 +122,7 @@ jobs:
             -v "$PWD/build-files/docker/test-xloader/data:/rdf:ro" \
             -v "$RUNNER_TEMP/xloader-db:/data/DB" \
             -v "$RUNNER_TEMP/xloader-tmp:/tmp" \
-            fuseki-loader:scan
+            fuseki-lucene-shacl-loader:scan
 
       - name: Verify xloader smoke-test dataset
         run: |
@@ -126,22 +131,22 @@ jobs:
           } | docker run --rm -i \
                 -v "$RUNNER_TEMP/xloader-db:/data/DB" \
                 --entrypoint java \
-                fuseki-loader:scan \
+                fuseki-lucene-shacl-loader:scan \
                 -cp /fuseki/jena-fuseki-server.jar tdb2.tdbquery --loc /data/DB/ds --query=- --results=csv)"
           echo "$actual"
           test "$(printf '%s' "$actual" | tail -n 1 | tr -d '\r')" = "4"
 
-      - name: Scan fuseki-loader (HIGH, CRITICAL)
+      - name: Scan fuseki-lucene-shacl-loader (HIGH, CRITICAL)
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: fuseki-loader:scan
+          image-ref: fuseki-lucene-shacl-loader:scan
           format: table
           severity: HIGH,CRITICAL
           scanners: vuln
           exit-code: '1'
           ignore-unfixed: false
 
-      - name: Push fuseki-loader (multi-arch)
+      - name: Push fuseki-lucene-shacl-loader (multi-arch)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/scan-published.yml
+++ b/.github/workflows/scan-published.yml
@@ -13,8 +13,10 @@ permissions:
   issues: write
 
 env:
-  FUSEKI_IMAGE: ghcr.io/${{ github.repository_owner }}/fuseki-ai
-  LOADER_IMAGE: ghcr.io/${{ github.repository_owner }}/fuseki-loader
+  ## Lowercase literal owner — see the note in docker.yml. The repo owner is
+  ## "Kurrawong", and Docker repository names must be lowercase.
+  FUSEKI_IMAGE: ghcr.io/kurrawong/fuseki-lucene-shacl
+  LOADER_IMAGE: ghcr.io/kurrawong/fuseki-lucene-shacl-loader
 
 jobs:
   scan:
@@ -27,24 +29,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Scan fuseki-ai
+      - name: Scan fuseki-lucene-shacl
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.FUSEKI_IMAGE }}:latest
           format: table
           severity: HIGH,CRITICAL
           scanners: vuln
-          output: trivy-fuseki-ai.txt
+          output: trivy-fuseki-lucene-shacl.txt
           exit-code: '0'
 
-      - name: Scan fuseki-loader
+      - name: Scan fuseki-lucene-shacl-loader
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.LOADER_IMAGE }}:latest
           format: table
           severity: HIGH,CRITICAL
           scanners: vuln
-          output: trivy-fuseki-loader.txt
+          output: trivy-fuseki-lucene-shacl-loader.txt
           exit-code: '0'
 
       - name: Detect findings
@@ -55,10 +57,10 @@ jobs:
           # table, so the file is empty / has no Total line.
           ai_findings=0
           loader_findings=0
-          if [ -s trivy-fuseki-ai.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-ai.txt; then
+          if [ -s trivy-fuseki-lucene-shacl.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-lucene-shacl.txt; then
             ai_findings=1
           fi
-          if [ -s trivy-fuseki-loader.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-loader.txt; then
+          if [ -s trivy-fuseki-lucene-shacl-loader.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-lucene-shacl-loader.txt; then
             loader_findings=1
           fi
           if [ "$ai_findings" = "1" ] || [ "$loader_findings" = "1" ]; then
@@ -79,18 +81,18 @@ jobs:
             echo "- **Scanned at:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
             echo ""
             echo "### \`${{ env.FUSEKI_IMAGE }}:latest\`"
-            if [ -s trivy-fuseki-ai.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-ai.txt; then
+            if [ -s trivy-fuseki-lucene-shacl.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-lucene-shacl.txt; then
               echo '```'
-              cat trivy-fuseki-ai.txt
+              cat trivy-fuseki-lucene-shacl.txt
               echo '```'
             else
               echo "_clean — no HIGH/CRITICAL findings_"
             fi
             echo ""
             echo "### \`${{ env.LOADER_IMAGE }}:latest\`"
-            if [ -s trivy-fuseki-loader.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-loader.txt; then
+            if [ -s trivy-fuseki-lucene-shacl-loader.txt ] && grep -qE "Total: [1-9][0-9]*" trivy-fuseki-lucene-shacl-loader.txt; then
               echo '```'
-              cat trivy-fuseki-loader.txt
+              cat trivy-fuseki-lucene-shacl-loader.txt
               echo '```'
             else
               echo "_clean — no HIGH/CRITICAL findings_"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,11 +26,27 @@ git remote add upstream https://github.com/apache/jena.git
 git fetch upstream main
 ```
 
-**Docker image pushes to GHCR**: images still publish to `ghcr.io/aiworkerjohns/*`
-(`Taskfile.yml` defaults `GHCR_OWNER` to `aiworkerjohns`), which has not moved with the
-repo. The `gh` CLI must have `aiworkerjohns` as the active account with the
-`write:packages` scope — verify with `gh auth status` and switch if needed:
-`gh auth switch --user aiworkerjohns`. Override per-invocation with `GHCR_OWNER=...`.
+**Docker image pushes to GHCR**: images publish to `ghcr.io/kurrawong/*`, following the
+repo to its new home:
+
+| Image | Dockerfile target |
+|-------|-------------------|
+| `ghcr.io/kurrawong/fuseki-lucene-shacl` | `runtime` |
+| `ghcr.io/kurrawong/fuseki-lucene-shacl-loader` | `loader` |
+
+The owner is written as the **lowercase literal `kurrawong`**, not
+`${{ github.repository_owner }}`. That expression preserves the owner's casing —
+`Kurrawong` — and Docker repository names must be lowercase, so buildx rejects the tag
+before contacting the registry. Every CI push failed this way between the repo move and
+2026-07-30 with `invalid tag "ghcr.io/Kurrawong/...": repository name must be lowercase`.
+Do not "simplify" it back to the expression.
+
+CI pushes with `GITHUB_TOKEN` (`packages: write`), which needs no extra setup. For local
+`task *-ghcr-push`, the `gh` CLI needs the `write:packages` scope for the `Kurrawong` org —
+verify with `gh auth status`. Override per-invocation with `GHCR_OWNER=...`.
+
+Earlier images published under `ghcr.io/aiworkerjohns/*` as `fuseki-ai` / `fuseki-loader`;
+that account did not move with the repo and those tags are not updated.
 
 ## Build Commands
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,10 +4,12 @@ version: '3'
 
 vars:
   VERSION: 6.1.0-SNAPSHOT
-  RUNTIME_IMAGE_NAME: '{{.RUNTIME_IMAGE_NAME | default "fuseki-ai"}}'
-  IMAGE_NAME: '{{.IMAGE_NAME | default "fuseki-loader"}}'
+  RUNTIME_IMAGE_NAME: '{{.RUNTIME_IMAGE_NAME | default "fuseki-lucene-shacl"}}'
+  IMAGE_NAME: '{{.IMAGE_NAME | default "fuseki-lucene-shacl-loader"}}'
   IMAGE_TAG: '{{.IMAGE_TAG | default .VERSION}}'
-  GHCR_OWNER: '{{.GHCR_OWNER | default "aiworkerjohns"}}'
+  # Must be lowercase: Docker repository names reject uppercase, so "Kurrawong"
+  # cannot be used verbatim.
+  GHCR_OWNER: '{{.GHCR_OWNER | default "kurrawong"}}'
   # Vulnerability scanning (trivy). TRIVY can point at an alternate binary.
   TRIVY: '{{.TRIVY | default "trivy"}}'
   TRIVY_MIN_VERSION: '0.69.3'
@@ -70,10 +72,11 @@ tasks:
       - docker buildx build --builder {{.BUILDX_BUILDER}} --platform {{.ACR_PLATFORMS}} --target loader -f build-files/docker/Dockerfile -t {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:{{.IMAGE_TAG}} -t {{.ACR_NAME}}.azurecr.io/{{.IMAGE_NAME}}:latest --push .
 
   push_gswa:
-    desc: Push runtime (as rdf-delta-server) and fuseki-loader to the GSWA ACR (gswareg.azurecr.io) with :IMAGE_TAG and :latest
+    desc: Push runtime (as rdf-delta-server) and the loader to the GSWA ACR (gswareg.azurecr.io) with :IMAGE_TAG and :latest
     cmds:
       # On gswareg the runtime is published under the GSWA naming convention
-      # (rdf-delta-server), not fuseki-ai. GHCR and gswadevacr keep fuseki-ai.
+      # (rdf-delta-server), not fuseki-lucene-shacl. GHCR and gswadevacr use
+      # fuseki-lucene-shacl.
       - task: runtime-acr-push
         vars:
           ACR_NAME: gswareg

--- a/build-files/docker/README.md
+++ b/build-files/docker/README.md
@@ -7,10 +7,10 @@ SHACL-based text indexing, spatial indexing, and TDB2 datasets.
 
 Both images come from a single `Dockerfile`, selected with `--target`:
 
-**`--target runtime`** (`fuseki-ai`) — Runs a Fuseki server with a mounted config
+**`--target runtime`** (`fuseki-lucene-shacl`) — Runs a Fuseki server with a mounted config
 and pre-built databases.
 
-**`--target loader`** (`fuseki-loader`) — Bulk data loading and index building.
+**`--target loader`** (`fuseki-lucene-shacl-loader`) — Bulk data loading and index building.
 Runs `loader-entrypoint.sh` to load RDF data into TDB2 and optionally build text
 and spatial indexes.
 
@@ -34,7 +34,7 @@ docker run \
   -v "./databases:/databases" \
   -v "./config.ttl:/config.ttl" \
   --rm \
-  ghcr.io/aiworkerjohns/jena-loader:latest
+  ghcr.io/kurrawong/fuseki-lucene-shacl-loader:latest
 ```
 
 The loader reads the assembler config at `/config.ttl` to discover the TDB2
@@ -50,7 +50,7 @@ docker run \
   -v "./databases:/databases" \
   -v "./config.ttl:/config.ttl" \
   --rm \
-  ghcr.io/aiworkerjohns/jena-loader:latest
+  ghcr.io/kurrawong/fuseki-lucene-shacl-loader:latest
 ```
 
 ## Environment Variables
@@ -131,7 +131,7 @@ docker run \
   -v "./databases:/databases" \
   -v "./config.ttl:/config/config.ttl" \
   -p 3030:3030 \
-  ghcr.io/aiworkerjohns/jena-runtime:latest
+  ghcr.io/kurrawong/fuseki-lucene-shacl:latest
 ```
 
 The runtime image starts Fuseki with `--config /config/config.ttl` and enables
@@ -143,10 +143,10 @@ From the repository root:
 
 ```bash
 # Loader image
-docker build --target loader -f build-files/docker/Dockerfile -t jena-loader:dev .
+docker build --target loader -f build-files/docker/Dockerfile -t fuseki-lucene-shacl-loader:dev .
 
 # Runtime image
-docker build --target runtime -f build-files/docker/Dockerfile -t jena-runtime:dev .
+docker build --target runtime -f build-files/docker/Dockerfile -t fuseki-lucene-shacl:dev .
 ```
 
 The Dockerfile is multi-stage: a shared `builder` stage runs Maven once

--- a/demo/README.md
+++ b/demo/README.md
@@ -269,7 +269,7 @@ Build the loader image from the repo root:
 task -d .. loader-build
 ```
 
-This produces `fuseki-loader:6.1.0-SNAPSHOT`.
+This produces `fuseki-lucene-shacl-loader:6.1.0-SNAPSHOT`.
 
 ### Running
 
@@ -280,7 +280,7 @@ docker run --rm \
   -v fuseki-db:/data/DB \
   -v fuseki-lucene:/data/Lucene \
   -e JAVA_OPTS="-Xmx8g" \
-  fuseki-loader:6.1.0-SNAPSHOT
+  fuseki-lucene-shacl-loader:6.1.0-SNAPSHOT
 ```
 
 | Volume mount | Purpose |
@@ -319,14 +319,14 @@ docker run --rm \
   -v fuseki-db:/data/DB \
   -v fuseki-lucene:/data/Lucene \
   -e JAVA_OPTS="-Xmx8g" \
-  ghcr.io/aiworkerjohns/fuseki-loader:6.1.0-SNAPSHOT
+  ghcr.io/kurrawong/fuseki-lucene-shacl-loader:6.1.0-SNAPSHOT
 
 # 2. Start the server with the same volumes
 docker run -d -p 3030:3030 \
   -v ./config.ttl:/fuseki/config.ttl:ro \
   -v fuseki-db:/fuseki/DB \
   -v fuseki-lucene:/fuseki/Lucene \
-  ghcr.io/aiworkerjohns/fuseki-ai:6.1.0-SNAPSHOT
+  ghcr.io/kurrawong/fuseki-lucene-shacl:6.1.0-SNAPSHOT
 ```
 
 A `docker-compose.yml` example is provided in `loader/`.

--- a/demo/Taskfile.yml
+++ b/demo/Taskfile.yml
@@ -10,9 +10,9 @@ vars:
   FUSEKI_PORT: '{{.FUSEKI_PORT | default "3030"}}'
   APP_PORT: '{{.APP_PORT | default "8000"}}'
   SERVER_URL: http://localhost:{{.FUSEKI_PORT}}
-  IMAGE_NAME: '{{.IMAGE_NAME | default "fuseki-ai"}}'
+  IMAGE_NAME: '{{.IMAGE_NAME | default "fuseki-lucene-shacl"}}'
   IMAGE_TAG: '{{.IMAGE_TAG | default .VERSION}}'
-  GHCR_OWNER: '{{.GHCR_OWNER | default "aiworkerjohns"}}'
+  GHCR_OWNER: '{{.GHCR_OWNER | default "kurrawong"}}'
 
 tasks:
   # ── Shared ───────────────────────────────────────────────
@@ -256,7 +256,7 @@ tasks:
     desc: Run the loader image in text-only reindex mode against an existing TDB2 store
     dir: loader
     env:
-      IMAGE_NAME: 'fuseki-loader'
+      IMAGE_NAME: 'fuseki-lucene-shacl-loader'
       IMAGE_TAG: '{{.IMAGE_TAG}}'
       MODE: 'index'
     cmds:
@@ -266,7 +266,7 @@ tasks:
     desc: Run the GHCR loader image in text-only reindex mode against an existing TDB2 store
     dir: loader
     env:
-      IMAGE_NAME: 'ghcr.io/{{.GHCR_OWNER}}/fuseki-loader'
+      IMAGE_NAME: 'ghcr.io/{{.GHCR_OWNER}}/fuseki-lucene-shacl-loader'
       IMAGE_TAG: '{{.IMAGE_TAG}}'
       MODE: 'index'
     cmds:

--- a/demo/loader/docker-compose.yml
+++ b/demo/loader/docker-compose.yml
@@ -1,7 +1,7 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 services:
   loader:
-    image: ${IMAGE_NAME:-ghcr.io/aiworkerjohns/fuseki-loader}:${IMAGE_TAG:-6.1.0-SNAPSHOT}
+    image: ${IMAGE_NAME:-ghcr.io/kurrawong/fuseki-lucene-shacl-loader}:${IMAGE_TAG:-6.1.0-SNAPSHOT}
     volumes:
       - ./config.ttl:/config/config.ttl:ro
       - ./data:/input:ro

--- a/demo/test/docker-compose.yml
+++ b/demo/test/docker-compose.yml
@@ -1,7 +1,7 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 services:
   fuseki:
-    image: ${IMAGE_NAME:-fuseki-ai}:${IMAGE_TAG:-6.1.0-SNAPSHOT}
+    image: ${IMAGE_NAME:-fuseki-lucene-shacl}:${IMAGE_TAG:-6.1.0-SNAPSHOT}
     ports:
       - "3030:3030"
     volumes:


### PR DESCRIPTION
Fixes the reason **no images have appeared in GHCR since the repo moved**, and renames both images away from the "ai" branding.

## Root cause — not a missing secret

Both workflows built image names from `${{ github.repository_owner }}`. That expression preserves the owner's **casing**. It used to expand to `aiworkerjohns` (already lowercase); it now expands to `Kurrawong`. Docker repository names must be lowercase, so buildx rejected the tag before ever contacting the registry:

```
ERROR: failed to build: invalid tag "ghcr.io/Kurrawong/fuseki-ai:6.2.0-SNAPSHOT":
       repository name must be lowercase
```

Two consequences worth noting:

- The trivy scan was **passing**. The job died on the push step. Because steps run sequentially with no `if: always()`, all five `fuseki-loader` steps were skipped — so the loader hasn't been smoke-tested on `main` either.
- The nightly `scan-published` failure is downstream of this: there was never a published image for it to pull.

## Change

Lowercase literal owner, and the rename:

| Before | After | Target |
|---|---|---|
| `ghcr.io/Kurrawong/fuseki-ai` (invalid) | `ghcr.io/kurrawong/fuseki-lucene-shacl` | `runtime` |
| `ghcr.io/Kurrawong/fuseki-loader` (invalid) | `ghcr.io/kurrawong/fuseki-lucene-shacl-loader` | `loader` |

The literal is deliberate. `CLAUDE.md` now records why it must not be "simplified" back to the expression, since that reintroduces the exact failure.

Swept through: `docker.yml`, `scan-published.yml`, root + demo `Taskfile.yml`, both demo compose files, `build-files/docker/README.md`, `demo/README.md`, the `scan-images` skill, and the `CLAUDE.md` GHCR section.

## Two incidental corrections

- `build-files/docker/README.md` documented `jena-loader` / `jena-runtime` — names CI has never published.
- The `scan-images` skill warned that `demo/` reuses the runtime tag for a separate Alpine-based build. That build was removed in `d891f6b0fb` (its Dockerfiles are gone, and `demo/` now only pulls or runs the published images). The warning now describes the real hazard: scanning a pulled image instead of the one your tree would build.

## ⚠️ Consumer impact

- **gswadevacr** receives the runtime under `RUNTIME_IMAGE_NAME`, so **its image name changes with this PR**. Anything pulling `gswadevacr.azurecr.io/fuseki-ai` needs repointing.
- **gswareg** is unaffected — `push_gswa` overrides the runtime name to `rdf-delta-server`.
- Old `ghcr.io/aiworkerjohns/fuseki-ai` / `fuseki-loader` tags are frozen, not redirected. That account did not move with the repo.
- Local `task *-ghcr-push` now needs `write:packages` on the **Kurrawong** org rather than the `aiworkerjohns` account.

## Verification

The Dockerfile is untouched by this PR, so the build behaviour verified in #132 still holds. What matters here is that the first `main` push after merge actually publishes — that is the thing that has been broken and cannot be proven from a PR run, since pushes are gated on `github.ref == 'refs/heads/main'`.
