### PR TITLE
build: tag images by commit SHA and move provenance into OCI labels

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,11 +47,47 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from pom.xml
+      ## The pom version is upstream Jena's, not a version of this fork — the
+      ## fork tracks apache/jena@main, so two different commits here can both
+      ## read 6.2.0-SNAPSHOT and mean very different things. It is therefore
+      ## recorded as an image *label* rather than used as a tag. See the tag
+      ## scheme in the metadata steps below.
+      - name: Extract upstream Jena version from pom.xml
         id: version
         run: |
           VERSION=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      ## Tag scheme, for both images:
+      ##   sha-<short>  immutable, exact, one per commit — the thing to pin and
+      ##                roll back to
+      ##   latest       floating, default branch only
+      ##
+      ## Provenance that used to be crammed into the tag lives in OCI labels
+      ## instead (revision, version, created, source), so `docker inspect` or
+      ## the GHCR UI answers "which commit, which Jena" without encoding it in
+      ## a tag that cannot be trusted to be unique.
+      - name: Docker metadata (runtime)
+        id: meta-runtime
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.FUSEKI_IMAGE }}
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
+      - name: Docker metadata (loader)
+        id: meta-loader
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.LOADER_IMAGE }}
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
 
       # Both images come from one Dockerfile via --target, sharing the `builder`
       # stage. The first build below populates that stage in the gha cache; the
@@ -92,9 +128,9 @@ jobs:
           target: runtime
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.FUSEKI_IMAGE }}:${{ steps.version.outputs.version }}
-            ${{ env.FUSEKI_IMAGE }}:latest
+          tags: ${{ steps.meta-runtime.outputs.tags }}
+          labels: ${{ steps.meta-runtime.outputs.labels }}
+          annotations: ${{ steps.meta-runtime.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -155,8 +191,8 @@ jobs:
           target: loader
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.LOADER_IMAGE }}:${{ steps.version.outputs.version }}
-            ${{ env.LOADER_IMAGE }}:latest
+          tags: ${{ steps.meta-loader.outputs.tags }}
+          labels: ${{ steps.meta-loader.outputs.labels }}
+          annotations: ${{ steps.meta-loader.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,33 @@ verify with `gh auth status`. Override per-invocation with `GHCR_OWNER=...`.
 Earlier images published under `ghcr.io/aiworkerjohns/*` as `fuseki-ai` / `fuseki-loader`;
 that account did not move with the repo and those tags are not updated.
 
+### Image tags and provenance
+
+| Tag | Mutability | Purpose |
+|-----|-----------|---------|
+| `sha-<short>` | immutable, one per commit | pin and roll back to this |
+| `latest` | floating, default branch only | a downstream consumer requires it |
+
+**The pom version is not a tag.** This fork tracks `apache/jena@main`, so `6.2.0-SNAPSHOT`
+is *upstream's* version — two unrelated commits here can both carry it. Tagging by it meant
+every push silently overwrote the previous image and left no immutable reference at all.
+It is now recorded as `org.opencontainers.image.version` instead.
+
+Provenance lives in OCI labels, applied in CI by `docker/metadata-action`:
+`org.opencontainers.image.revision` (full SHA), `.version` (upstream Jena), `.created`,
+`.source`. So `docker inspect ghcr.io/kurrawong/fuseki-lucene-shacl:latest` answers "which
+commit, which Jena" without that being encoded in a tag. The Dockerfile deliberately
+carries **no** `LABEL` line — a hardcoded one went stale when the repo moved.
+
+Only trust those labels on a **published** image. The UBI base sets its own
+`org.opencontainers.image.created` and `.revision` describing Red Hat's base build, and a
+local `docker build` inherits them unchanged — they look plausible but describe the base
+image, not your tree. CI's `--label` overrides them.
+
+`Taskfile.yml` derives `VERSION` from `pom.xml` via `sh:` rather than hardcoding it; it had
+drifted to `6.1.0-SNAPSHOT` against a `6.2.0-SNAPSHOT` pom, so local builds and CI tagged
+identical source differently. Do not replace it with a literal.
+
 ## Build Commands
 
 ```bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,17 @@
 version: '3'
 
 vars:
-  VERSION: 6.1.0-SNAPSHOT
+  # Read from pom.xml rather than hardcoded. This was pinned at 6.1.0-SNAPSHOT
+  # while the pom had moved to 6.2.0-SNAPSHOT, so local builds and CI tagged
+  # the same source differently. Deriving it cannot drift.
+  VERSION:
+    sh: grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/'
+  # Short commit SHA, matching the immutable tag CI publishes (sha-<short>).
+  # Pinned to 7 characters because that is what docker/metadata-action's
+  # `type=sha` emits; bare `--short` lets git choose a longer prefix in a repo
+  # this size, which would not match the published tag.
+  GIT_SHA:
+    sh: git rev-parse --short=7 HEAD 2>/dev/null || echo unknown
   RUNTIME_IMAGE_NAME: '{{.RUNTIME_IMAGE_NAME | default "fuseki-lucene-shacl"}}'
   IMAGE_NAME: '{{.IMAGE_NAME | default "fuseki-lucene-shacl-loader"}}'
   IMAGE_TAG: '{{.IMAGE_TAG | default .VERSION}}'

--- a/build-files/docker/Dockerfile
+++ b/build-files/docker/Dockerfile
@@ -86,7 +86,17 @@ RUN curl -fsSL -o /jq-amd64 "https://github.com/jqlang/jq/releases/download/${JQ
 
 FROM eclipse-temurin:21-jre-ubi10-minimal AS runtime
 
-LABEL org.opencontainers.image.source=https://github.com/aiworkerjohns/jena
+# No LABEL here on purpose. CI applies the full OCI label set — source,
+# revision, version, created — via docker/metadata-action, which derives them
+# from the repository and commit being built. A hardcoded source label went
+# stale and wrong when the repo moved (it still read aiworkerjohns/jena long
+# after the move); deriving it removes that failure mode.
+#
+# Careful when inspecting a LOCALLY built image: the UBI base sets its own
+# org.opencontainers.image.created and .revision, describing Red Hat's base
+# image build, not this source tree. Only images built by CI carry our values
+# (buildx --label overrides the inherited keys). Trust those labels on a
+# published image, not on a local `docker build`.
 
 WORKDIR /fuseki
 

--- a/build-files/docker/README.md
+++ b/build-files/docker/README.md
@@ -24,6 +24,29 @@ They remain two separately published images rather than one image with two
 entrypoints, so the serving image is not gated on CVEs in the distribution's
 bundled `lib/` jars — which it never executes.
 
+## Tags
+
+CI publishes each image as:
+
+| Tag | Mutability |
+|-----|-----------|
+| `sha-<short>` | immutable, one per commit — pin to this |
+| `latest` | floating, default branch only |
+
+The Jena version is **not** in the tag. This fork tracks `apache/jena@main`, so the pom
+version identifies upstream rather than any state of this fork. It is recorded as
+`org.opencontainers.image.version` instead, alongside `.revision`, `.created` and
+`.source`:
+
+```bash
+docker inspect --format '{{json .Config.Labels}}' \
+  ghcr.io/kurrawong/fuseki-lucene-shacl:latest | jq
+```
+
+Do this against a **published** image. A locally built one inherits
+`org.opencontainers.image.created` and `.revision` from the UBI base — they describe Red
+Hat's base image build, not your working tree. CI overrides them; `docker build` does not.
+
 ## Loader Usage
 
 Load RDF files into a TDB2 dataset:

--- a/demo/Taskfile.yml
+++ b/demo/Taskfile.yml
@@ -5,7 +5,11 @@ version: '3'
 vars:
   ## Must track the root pom's <version>. Override with VERSION=... if building
   ## against a differently-versioned jar.
-  VERSION: '{{.VERSION | default "6.2.0-SNAPSHOT"}}'
+  # Derived from the root pom so it cannot drift from the actual build output
+  # (the root Taskfile had drifted to 6.1.0-SNAPSHOT). Still overridable on the
+  # command line: `task VERSION=x ...`.
+  VERSION:
+    sh: grep -m1 '<version>' ../pom.xml 2>/dev/null | sed 's/.*<version>\(.*\)<\/version>.*/\1/'
   FUSEKI_JAR: ../jena-fuseki2/jena-fuseki-server/target/jena-fuseki-server-{{.VERSION}}.jar
   FUSEKI_PORT: '{{.FUSEKI_PORT | default "3030"}}'
   APP_PORT: '{{.APP_PORT | default "8000"}}'

--- a/demo/loader/docker-compose.yml
+++ b/demo/loader/docker-compose.yml
@@ -1,7 +1,7 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 services:
   loader:
-    image: ${IMAGE_NAME:-ghcr.io/kurrawong/fuseki-lucene-shacl-loader}:${IMAGE_TAG:-6.1.0-SNAPSHOT}
+    image: ${IMAGE_NAME:-ghcr.io/kurrawong/fuseki-lucene-shacl-loader}:${IMAGE_TAG:-latest}
     volumes:
       - ./config.ttl:/config/config.ttl:ro
       - ./data:/input:ro

--- a/demo/test/docker-compose.yml
+++ b/demo/test/docker-compose.yml
@@ -1,7 +1,7 @@
 # Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 services:
   fuseki:
-    image: ${IMAGE_NAME:-fuseki-lucene-shacl}:${IMAGE_TAG:-6.1.0-SNAPSHOT}
+    image: ${IMAGE_NAME:-fuseki-lucene-shacl}:${IMAGE_TAG:-latest}
     ports:
       - "3030:3030"
     volumes:


### PR DESCRIPTION
## Why

Images were tagged with the pom version, `6.2.0-SNAPSHOT`. That's *upstream Jena's* version, not a version of this fork — the fork tracks `apache/jena@main`, so two unrelated commits here both read `6.2.0-SNAPSHOT`. Since it never changes, **every push overwrote the previous image**, leaving no immutable reference to pin or roll back to.

## Tag scheme

| Tag | Mutability | Purpose |
|-----|-----------|---------|
| `sha-<short>` | immutable, one per commit | pin / roll back to this |
| `latest` | floating, default branch only | required by a downstream consumer |

Generated by `docker/metadata-action`. The upstream version isn't lost — it moves to where it can be read without being load-bearing:

```
org.opencontainers.image.version   = 6.2.0-SNAPSHOT   # upstream Jena line
org.opencontainers.image.revision  = <full SHA>
org.opencontainers.image.created   = <timestamp>
org.opencontainers.image.source    = <repo URL>
```

So `docker inspect` answers "which commit, which Jena" for any published image.

Rationale for SHA over the alternatives: auto-increment needs state kept somewhere and implies significance it doesn't have; semver needs someone to decide major/minor/patch, and this fork doesn't cut releases, it tracks a moving upstream. A SHA needs no decisions and can't be wrong.

## Also fixed

**A stale label.** The Dockerfile hardcoded `LABEL org.opencontainers.image.source=.../aiworkerjohns/jena`, wrong since the repo moved. `metadata-action` derives it from the repository being built, so it can't go stale again.

**Version drift.** The root `Taskfile.yml` hardcoded `VERSION: 6.1.0-SNAPSHOT` against a `6.2.0-SNAPSHOT` pom — so `task runtime-build` and CI tagged *identical source* differently. Both Taskfiles now derive it from `pom.xml` via `sh:`. The demo compose files fell back to a stale `6.1.0-SNAPSHOT` when `IMAGE_TAG` was unset; they now fall back to `:latest`.

## ⚠️ One subtlety worth knowing

The UBI base image sets **its own** `org.opencontainers.image.created` and `.revision`. A local `docker build` inherits those unchanged, so they describe Red Hat's base build, not your tree — they look plausible and aren't yours. Only CI-built images carry our values, because buildx `--label` overrides the inherited keys.

I found this while verifying and it contradicted my first draft of the comment, so it's now called out in the Dockerfile and both docs: **trust these labels on a published image, not a local build.**

## Verification

- Both targets build clean; the loader keeps `jq` and the bundled `apache-jena` distribution (`tdb2.xloader` present).
- Version derivation returns `6.2.0-SNAPSHOT` from the repo root *and* from `demo/`.
- `GIT_SHA` pinned to 7 chars to match `metadata-action`'s `type=sha`; bare `git rev-parse --short` returns 10 in a repo this size, which wouldn't have matched the published tag.
- `metadata-action` pinned to **v6** — v6.2.0 is current, v5 was already a major behind, and the `annotations` output is needed. Checked v6.0.0's notes: Node 24 runtime and internals only, nothing affecting these inputs.

**Not verifiable from a PR run:** the `sha-` and `latest` tags only get pushed on `main`, so the first post-merge run is what proves the tag scheme and labels land correctly. Worth an eyeball at the GHCR package page after merge.
