### PR TITLE
Remove idx:minMatchRate

### DIFF
--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -423,7 +423,6 @@ field:measuredValue
             idx:format        idx:CsvFile ;
             idx:location      "/data/measurements.csv" ;
             idx:subjectColumn "sample_iri" ;
-            idx:minMatchRate  "0.5"^^xsd:double ;
             idx:column [ idx:columnName "property" ; idx:field field:measuredProperty ] ;
             idx:column [ idx:columnName "value" ;    idx:field field:measuredValue ] ;
         ] ;
@@ -445,7 +444,6 @@ Bound fields carry **no `sh:path`** — their values come from the column. There
 | `idx:delimiter` | no | Single-character delimiter override |
 | `idx:headerless` | no | No header row; bind columns with `idx:columnIndex`. Default `false` |
 | `idx:onError` | no | `"skip"` (default, counted) or `"fail"` |
-| `idx:minMatchRate` | no | Build fails if a smaller fraction of entities matched. Default `0.0` (off) |
 | `idx:column` | yes | Repeatable binding: `idx:columnName` **or** `idx:columnIndex`, plus `idx:field` |
 | `idx:delta` | no | Delta file(s) applied over the base at build time. Several must be an ordered list |
 | `idx:opColumn` | no | Column holding `ADD`/`DELETE` in a delta. Default `"op"` |
@@ -566,7 +564,7 @@ affected entities is future work.
 ### Rules and limits
 
 - **Bulk build only.** `ShaclBulkIndexer` is the only path that populates external children. A live graph change to an entity of such a shape is refused with a warning — rebuilding from the graph alone would silently strip its children, and Lucene has no partial document update. Re-run the bulk indexer.
-- **Rows augment entities; they never create them.** A row whose subject matches no entity is counted and dropped. The count is always logged; `idx:minMatchRate` turns the catastrophic case — usually a wrong `idx:subjectPrefix` — into a build failure.
+- **Rows augment entities; they never create them.** A row whose subject matches no entity is counted and dropped. The graph and the extract are equally valid sources that we align, and neither is obliged to cover the other, so the indexer never judges how well they overlap. Match and unmatch counts and the resulting match rate are always logged — a wrong `idx:subjectPrefix` shows up as a near-zero rate. Fix it in the data, not with a threshold.
 - **An entity with no rows is still indexed**, with its graph fields and no children.
 - **A row with an empty or unparseable bound cell is dropped whole**, never coerced to `0` and never emitted as a half-populated child.
 - **No transformations.** No units, no `<0.5` detection-limit markers, no null sentinels, no computed columns. A cell either parses as its declared type or it is an error. That work belongs upstream, in whatever produced the file.

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -63,7 +63,7 @@ All tests run via JUnit 4 and are aggregated in `TS_Text.java` (Surefire only pi
 |-------|-------|---------------|
 | `TestCsvRowSource` | 15 | CSV/TSV reading: header and positional binding, `idx:subjectPrefix`, glob expansion in filename order, empty cell → null, blank join key skipped-but-counted, rows emitted in file order without an ordering check, and the config errors on open — missing file, empty glob, missing subject/bound column |
 | `TestExternalSourceAssembler` | 13 | Turtle config: narrow source, optional properties, headerless positional binding, bound fields becoming profile fields, hierarchy over external fields, and the validation rules — `idx:joinPath` xor `idx:externalSource`, required `idx:nestedName`, no `sh:path` on a bound column, exactly one of `idx:columnName`/`idx:columnIndex`, unknown format, unsupported field type |
-| `TestExternalContentIndexing` | 19 | End-to-end: rows become children of the matching entity; entities with no rows still indexed; unmatched rows counted and dropped; same-child `=` + range correlation; entity-level AND across two properties is *not* same-child; sort by a not-stored external value with `missing` placement; `idx:subjectPrefix`; `idx:minMatchRate` failing a bad join key; unsorted buffering; empty and unparseable cells; `idx:onError "fail"`; hierarchical facets over external children; live graph change does not strip external children. Plus wide children (depth-from/depth-to/analyte/value on one child): four-way same-child correlation, the decorrelation check that a Cu child and a deep child on the same hole do not satisfy one AND, and two analytes still not being same-child |
+| `TestExternalContentIndexing` | 19 | End-to-end: rows become children of the matching entity; entities with no rows still indexed; unmatched rows counted and dropped; same-child `=` + range correlation; entity-level AND across two properties is *not* same-child; sort by a not-stored external value with `missing` placement; `idx:subjectPrefix`; a bad join key building successfully with a zero match rate in the counters; unsorted buffering; empty and unparseable cells; `idx:onError "fail"`; hierarchical facets over external children; live graph change does not strip external children. Plus wide children (depth-from/depth-to/analyte/value on one child): four-way same-child correlation, the decorrelation check that a Cu child and a deep child on the same hole do not satisfy one AND, and two analytes still not being same-child |
 
 ### Existing Tests (unchanged, verifying no regressions)
 
@@ -143,7 +143,7 @@ TextIndexLucene index = (TextIndexLucene) Assembler.general().open(indexSpec);
 - Hierarchical facets: taxonomy indexing, top-level counts, drill-down via CQL filters, flat+hierarchy coexistence
 - Range facets on numeric fields: single-valued, multi-valued, open-ended buckets, mixed flat+range requests, and 5-slot `luc:facet` bindings
 - Multi-valued numeric sorting semantics (`MIN` for ascending, `MAX` for descending)
-- External content from CSV/TSV: the IRI join, match/unmatch counters, `idx:minMatchRate`, sortedness verification, and the same-child vs entity-level correlation boundary
+- External content from CSV/TSV: the IRI join, match/unmatch counters, sortedness verification, and the same-child vs entity-level correlation boundary
 
 ### Not yet covered (candidates for future tests)
 

--- a/docs/2026-07-27_external_content_indexing_design.md
+++ b/docs/2026-07-27_external_content_indexing_design.md
@@ -276,7 +276,6 @@ no join path to derive a scope name from.
 | `idx:delimiter` | Delimiter override for delimited text |
 | `idx:headerless` | No header row; bind with `idx:columnIndex` instead of `idx:columnName` |
 | `idx:onError` | `skip` (default, counted) or `fail` |
-| `idx:minMatchRate` | Build fails if fewer than this fraction of entities matched |
 
 ### Input shape
 
@@ -372,7 +371,10 @@ document, so it silently drops data.
 
 The "row matches no entity" counter is the most valuable diagnostic here: a
 subject-prefix or key-format mistake produces a technically successful build with
-near-zero matches, which is why `idx:minMatchRate` exists as a guard.
+near-zero matches, and the reported match rate is what makes that visible. The
+indexer does not enforce a minimum — the graph and the extract are equally valid
+sources being aligned, no threshold could be guessed for a legitimate partial
+overlap, and a bad join key is a data fix, not a config one.
 
 ## Not-stored semantics
 
@@ -562,7 +564,7 @@ Additive, and mostly on existing block-join rails.
   exactly one scope; bound columns exist where the schema is discoverable.
 - **`ShaclBulkIndexer`** — sort work items by `entityUri` when external sources
   are present; open sources; merge-join in `processItems`; counters for rows
-  read / matched / unmatched / skipped; enforce `idx:minMatchRate`.
+  read / matched / unmatched / skipped.
 - **`ShaclEntityBuilder`** — accept pre-resolved external rows and emit them as
   child documents in the entity's block, reusing `addFieldToDoc` so field typing,
   docvalues and points behave identically regardless of origin.
@@ -633,7 +635,9 @@ nested scope today.
 **Why is unmatched-subject a skip rather than an error?** External extracts are
 routinely broader than the graph. Failing on the first extra row would make
 normal data unusable. But silent skipping hides the catastrophic case, so the
-count is always reported and `idx:minMatchRate` turns it into a hard failure.
+count and the match rate are always reported — loudly, with a warning when
+nothing matched at all. Reporting is where it stops: judging the overlap is not
+the indexer's job.
 
 ## Open questions
 

--- a/docs/presentations/external-content-indexing.html
+++ b/docs/presentations/external-content-indexing.html
@@ -556,7 +556,6 @@
             idx:location      <span class="s">"data/measurements.csv"</span> ;
             idx:subjectColumn <span class="s">"collar_id"</span> ;
             idx:subjectPrefix <span class="s">".../gswa/collar/"</span> ;
-            idx:minMatchRate  <span class="n">"0.5"</span>^^xsd:double ;
 
             idx:column [ idx:columnName <span class="s">"property"</span>
                        ; idx:field <span class="p">field:analyte</span> ] ;

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -392,7 +392,6 @@ public class ShaclIndexMapping {
         private final Character delimiter;
         private final boolean headerless;
         private final ErrorPolicy onError;
-        private final double minMatchRate;
         private final List<ColumnBinding> columns;
         private final List<FieldDef> fields;
         private final List<String> deltaLocations;
@@ -404,10 +403,10 @@ public class ShaclIndexMapping {
         public ExternalSourceDef(ExternalFormat format, String location,
                                  String subjectColumn, int subjectColumnIndex, String subjectPrefix,
                                  Character delimiter, boolean headerless,
-                                 ErrorPolicy onError, double minMatchRate,
+                                 ErrorPolicy onError,
                                  List<ColumnBinding> columns) {
             this(format, location, subjectColumn, subjectColumnIndex, subjectPrefix,
-                delimiter, headerless, onError, minMatchRate, columns,
+                delimiter, headerless, onError, columns,
                 Collections.emptyList(), DEFAULT_OP_COLUMN);
         }
 
@@ -415,7 +414,7 @@ public class ShaclIndexMapping {
         public ExternalSourceDef(ExternalFormat format, String location,
                                  String subjectColumn, int subjectColumnIndex, String subjectPrefix,
                                  Character delimiter, boolean headerless,
-                                 ErrorPolicy onError, double minMatchRate,
+                                 ErrorPolicy onError,
                                  List<ColumnBinding> columns,
                                  List<String> deltaLocations, String opColumn) {
             this.format = Objects.requireNonNull(format, "format");
@@ -426,7 +425,6 @@ public class ShaclIndexMapping {
             this.delimiter = delimiter;
             this.headerless = headerless;
             this.onError = onError != null ? onError : ErrorPolicy.SKIP;
-            this.minMatchRate = minMatchRate;
             this.columns = columns != null
                 ? Collections.unmodifiableList(new ArrayList<>(columns))
                 : Collections.emptyList();
@@ -446,7 +444,6 @@ public class ShaclIndexMapping {
         public Character getDelimiter()          { return delimiter; }
         public boolean isHeaderless()            { return headerless; }
         public ErrorPolicy getOnError()          { return onError; }
-        public double getMinMatchRate()          { return minMatchRate; }
         public List<ColumnBinding> getColumns()  { return columns; }
         public List<FieldDef> getFields()        { return fields; }
         /** Delta files applied over the base, in order. Empty for a plain source. */
@@ -457,7 +454,7 @@ public class ShaclIndexMapping {
         /** Same source with the deltas stripped — the base layer a delta reader wraps. */
         public ExternalSourceDef withoutDeltas() {
             return new ExternalSourceDef(format, location, subjectColumn, subjectColumnIndex,
-                subjectPrefix, delimiter, headerless, onError, minMatchRate, columns);
+                subjectPrefix, delimiter, headerless, onError, columns);
         }
 
         /**
@@ -469,7 +466,7 @@ public class ShaclIndexMapping {
             List<ColumnBinding> withOp = new ArrayList<>(columns);
             withOp.add(new ColumnBinding(opColumn, -1, opField));
             return new ExternalSourceDef(format, deltaLocation, subjectColumn, subjectColumnIndex,
-                subjectPrefix, delimiter, headerless, onError, minMatchRate, withOp);
+                subjectPrefix, delimiter, headerless, onError, withOp);
         }
 
         private void validate() {
@@ -507,10 +504,6 @@ public class ShaclIndexMapping {
                         "Field " + field.getFieldIRI().getURI()
                         + " is bound to more than one column of idx:externalSource " + location);
                 }
-            }
-            if (minMatchRate < 0.0 || minMatchRate > 1.0) {
-                throw new TextIndexException(
-                    "idx:minMatchRate on " + location + " must be between 0.0 and 1.0, got " + minMatchRate);
             }
             if (!deltaLocations.isEmpty()) {
                 if (headerless) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
@@ -96,7 +96,6 @@ public class IndexVocab {
     public static final Property pDelimiter         = Vocab.property(NS, "delimiter");
     public static final Property pHeaderless        = Vocab.property(NS, "headerless");
     public static final Property pOnError           = Vocab.property(NS, "onError");
-    public static final Property pMinMatchRate      = Vocab.property(NS, "minMatchRate");
     public static final Property pColumn            = Vocab.property(NS, "column");
     public static final Property pColumnName        = Vocab.property(NS, "columnName");
     public static final Property pColumnIndex       = Vocab.property(NS, "columnIndex");

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
@@ -256,7 +256,6 @@ public class ShaclIndexAssembler {
         String subjectPrefix = getOptionalString(sourceRes, IndexVocab.pSubjectPrefix);
         Character delimiter = parseDelimiter(sourceRes);
         ErrorPolicy onError = parseErrorPolicy(sourceRes);
-        double minMatchRate = getOptionalDouble(sourceRes, IndexVocab.pMinMatchRate, 0.0);
 
         List<ColumnBinding> columns = new ArrayList<>();
         StmtIterator columnIter = sourceRes.listProperties(IndexVocab.pColumn);
@@ -276,7 +275,7 @@ public class ShaclIndexAssembler {
         String opColumn = getOptionalString(sourceRes, IndexVocab.pOpColumn);
 
         return new ExternalSourceDef(format, location, subjectColumn, subjectColumnIndex,
-            subjectPrefix, delimiter, headerless, onError, minMatchRate, columns,
+            subjectPrefix, delimiter, headerless, onError, columns,
             deltaLocations, opColumn);
     }
 
@@ -916,14 +915,6 @@ public class ShaclIndexAssembler {
             return defaultValue;
         }
         return stmt.getObject().asLiteral().getInt();
-    }
-
-    private static double getOptionalDouble(Resource resource, Property property, double defaultValue) {
-        Statement stmt = resource.getProperty(property);
-        if (stmt == null) {
-            return defaultValue;
-        }
-        return stmt.getObject().asLiteral().getDouble();
     }
 
     private static Node getOptionalResourceNode(Resource resource, Property property) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/external/ExternalChildMerger.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/external/ExternalChildMerger.java
@@ -55,10 +55,10 @@ import org.slf4j.LoggerFactory;
  * hand before anything is written; grouping by subject is therefore mandatory.
  * <p>
  * External rows <b>augment</b> entities; they never create them. A row whose subject
- * matches no entity is counted and dropped, because extracts are routinely broader
- * than the graph. The count is always reported, and {@code idx:minMatchRate} turns a
- * catastrophically low match — the signature of a wrong {@code idx:subjectPrefix} —
- * into a hard failure.
+ * matches no entity is counted and dropped, because extracts and the graph are equally
+ * valid sources that we align, and neither is obliged to cover the other. The match and
+ * unmatch counts are always reported so a wrong {@code idx:subjectPrefix} is visible in
+ * the build log; the indexer does not judge how well the two sides line up.
  */
 public class ExternalChildMerger implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(ExternalChildMerger.class);
@@ -71,7 +71,7 @@ public class ExternalChildMerger implements Closeable {
     public ExternalChildMerger(ShaclIndexMapping mapping) {
         for (IndexProfile profile : mapping.getProfiles()) {
             for (NestedDef nestedDef : profile.getExternalNestedDefs()) {
-                SourceCursor cursor = new SourceCursor(profile, nestedDef);
+                SourceCursor cursor = new SourceCursor(nestedDef);
                 cursorsByShape.computeIfAbsent(profile.getShapeNode(), k -> new ArrayList<>()).add(cursor);
                 allCursors.add(cursor);
             }
@@ -109,15 +109,12 @@ public class ExternalChildMerger implements Closeable {
 
     /**
      * Drain what is left of every source so unmatched rows are counted rather than
-     * silently ignored, report the counters, and enforce {@code idx:minMatchRate}.
+     * silently ignored, and report the counters.
      */
     public void finish() {
         for (SourceCursor cursor : allCursors) {
             cursor.drain();
             cursor.report();
-        }
-        for (SourceCursor cursor : allCursors) {
-            cursor.enforceMinMatchRate();
         }
     }
 
@@ -151,7 +148,6 @@ public class ExternalChildMerger implements Closeable {
     // ----- one configured source -----
 
     private static final class SourceCursor {
-        private final IndexProfile profile;
         private final NestedDef nestedDef;
         private final ExternalSourceDef def;
         private final ExternalRowSource source;
@@ -167,8 +163,7 @@ public class ExternalChildMerger implements Closeable {
         private long entitiesSeen;
         private long entitiesMatched;
 
-        SourceCursor(IndexProfile profile, NestedDef nestedDef) {
-            this.profile = profile;
+        SourceCursor(NestedDef nestedDef) {
             this.nestedDef = nestedDef;
             this.def = nestedDef.getExternalSource();
             this.source = ExternalRowSources.create(def);
@@ -320,21 +315,6 @@ public class ExternalChildMerger implements Closeable {
             if (stats.rowsMatched() == 0 && stats.rowsRead() > 0) {
                 log.warn("External source {} matched no entity at all. Check idx:subjectColumn and "
                     + "idx:subjectPrefix — the join key must be the full entity IRI.", describe());
-            }
-        }
-
-        void enforceMinMatchRate() {
-            double required = def.getMinMatchRate();
-            if (required <= 0.0) {
-                return;
-            }
-            double actual = stats().matchRate();
-            if (actual < required) {
-                throw new TextIndexException(String.format(Locale.US,
-                    "External source %s matched only %.1f%% of the %d entities of shape %s, "
-                    + "below the required idx:minMatchRate of %.1f%%. This usually means the "
-                    + "join key is wrong (idx:subjectColumn / idx:subjectPrefix).",
-                    describe(), actual * 100.0, entitiesSeen, profile.getShapeNode(), required * 100.0));
             }
         }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestExternalContentIndexing.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestExternalContentIndexing.java
@@ -66,8 +66,8 @@ import org.junit.Test;
  *   <li>an AND of {@code =} and a range folds into <em>one</em> child, while an AND
  *       across two properties is entity-level and explicitly not same-child;</li>
  *   <li>a not-stored value still filters, facets and sorts;</li>
- *   <li>a wrong join key fails the build via {@code idx:minMatchRate} rather than
- *       producing a successful build with nothing in it.</li>
+ *   <li>a wrong join key still builds, and is visible as a zero match rate in the
+ *       reported counters rather than being second-guessed by the indexer.</li>
  * </ul>
  */
 public class TestExternalContentIndexing {
@@ -148,10 +148,10 @@ public class TestExternalContentIndexing {
     }
 
     private ExternalSourceDef csvSource(String location, String subjectColumn, String subjectPrefix,
-                                        boolean sorted, ErrorPolicy onError, double minMatchRate,
+                                        boolean sorted, ErrorPolicy onError,
                                         FieldDef property, FieldDef value, FieldDef band) {
         return new ExternalSourceDef(ExternalFormat.CSV, location, subjectColumn, -1, subjectPrefix,
-            null, false, onError, minMatchRate,
+            null, false, onError,
             Arrays.asList(new ColumnBinding("property", -1, property),
                 new ColumnBinding("value", -1, value),
                 new ColumnBinding("band", -1, band)));
@@ -212,7 +212,7 @@ public class TestExternalContentIndexing {
         FieldDef property = propertyField();
         FieldDef value = valueField();
         FieldDef band = bandField();
-        buildIndex(csvSource(csv.toString(), "sample_iri", null, sorted, ErrorPolicy.SKIP, 0.0,
+        buildIndex(csvSource(csv.toString(), "sample_iri", null, sorted, ErrorPolicy.SKIP,
             property, value, band), nameField(), property, value, band, false);
     }
 
@@ -407,7 +407,7 @@ public class TestExternalContentIndexing {
         FieldDef property = propertyField();
         FieldDef value = valueField();
         FieldDef band = bandField();
-        buildIndex(csvSource(csv.toString(), "sample_id", NS, true, ErrorPolicy.SKIP, 0.0,
+        buildIndex(csvSource(csv.toString(), "sample_id", NS, true, ErrorPolicy.SKIP,
             property, value, band), nameField(), property, value, band, false);
 
         assertEquals(List.of("s1"), filter(eq("measuredProperty", "Au")));
@@ -415,10 +415,11 @@ public class TestExternalContentIndexing {
         assertEquals(0, onlyStats().rowsUnmatched());
     }
 
-    /** A wrong join key produces a technically successful build with near-zero matches.
-     *  idx:minMatchRate is what turns that into a failure. */
+    /** A wrong join key is a data problem, not a config error: the build succeeds and the
+     *  counters say plainly that nothing joined. The indexer aligns the two sources; it
+     *  does not judge how well they overlap, because no threshold could be guessed. */
     @Test
-    public void minMatchRateFailsABadJoinKey() throws IOException {
+    public void aWrongJoinKeyMatchesNothingAndSaysSo() throws IOException {
         Path csv = writeCsv("wrong-prefix.csv",
             "sample_iri,property,value,band\n"
             + "http://wrong.example/s1,Au,12.4,high\n"
@@ -427,13 +428,15 @@ public class TestExternalContentIndexing {
         FieldDef property = propertyField();
         FieldDef value = valueField();
         FieldDef band = bandField();
-        ExternalSourceDef source = csvSource(csv.toString(), "sample_iri", null, true,
-            ErrorPolicy.SKIP, 0.5, property, value, band);
+        buildIndex(csvSource(csv.toString(), "sample_iri", null, true, ErrorPolicy.SKIP,
+            property, value, band), nameField(), property, value, band, false);
 
-        TextIndexException e = assertThrows(TextIndexException.class,
-            () -> buildIndex(source, nameField(), property, value, band, false));
-        assertTrue("message should point at the join key: " + e.getMessage(),
-            e.getMessage().contains("idx:subjectColumn"));
+        ExternalChildMerger.SourceStats stats = onlyStats();
+        assertEquals("no row found its entity", 0, stats.rowsMatched());
+        assertEquals("both rows are counted as unmatched", 2, stats.rowsUnmatched());
+        assertEquals(0.0, stats.matchRate(), 0.0);
+        assertEquals("the entities are still indexed, just childless",
+            Collections.emptyList(), filter(eq("measuredProperty", "Au")));
     }
 
     /** An unsorted source is buffered rather than rejected, and produces the same index. */
@@ -500,7 +503,7 @@ public class TestExternalContentIndexing {
         FieldDef value = valueField();
         FieldDef band = bandField();
         ExternalSourceDef source = csvSource(csv.toString(), "sample_iri", null, true,
-            ErrorPolicy.FAIL, 0.0, property, value, band);
+            ErrorPolicy.FAIL, property, value, band);
 
         TextIndexException e = assertThrows(TextIndexException.class,
             () -> buildIndex(source, nameField(), property, value, band, false));
@@ -515,7 +518,7 @@ public class TestExternalContentIndexing {
         FieldDef property = propertyField();
         FieldDef value = valueField();
         FieldDef band = bandField();
-        buildIndex(csvSource(csv.toString(), "sample_iri", null, true, ErrorPolicy.SKIP, 0.0,
+        buildIndex(csvSource(csv.toString(), "sample_iri", null, true, ErrorPolicy.SKIP,
             property, value, band), nameField(), property, value, band, true);
 
         Map<String, Long> top = toFacetMap(textIndex.getFacetCounts(
@@ -578,7 +581,7 @@ public class TestExternalContentIndexing {
         FieldDef band = bandField();
         ExternalSourceDef source = new ExternalSourceDef(ExternalFormat.CSV,
             dir.resolve("measurements.csv").toString(), "sample_iri", -1, null,
-            null, false, ErrorPolicy.SKIP, 0.0,
+            null, false, ErrorPolicy.SKIP,
             Arrays.asList(new ColumnBinding("property", -1, property),
                 new ColumnBinding("value", -1, value),
                 new ColumnBinding("band", -1, band)),
@@ -640,7 +643,7 @@ public class TestExternalContentIndexing {
             false, true, true, true, false, false);
 
         ExternalSourceDef source = new ExternalSourceDef(ExternalFormat.CSV, csv.toString(),
-            "hole_iri", -1, null, null, false, ErrorPolicy.SKIP, 0.0,
+            "hole_iri", -1, null, null, false, ErrorPolicy.SKIP,
             Arrays.asList(new ColumnBinding("depth_from", -1, depthFrom),
                 new ColumnBinding("depth_to", -1, depthTo),
                 new ColumnBinding("analyte", -1, analyte),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestGswaMeasurementCsv.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestGswaMeasurementCsv.java
@@ -169,7 +169,7 @@ public class TestGswaMeasurementCsv {
         FieldDef belowDetection = belowDetectionField();
 
         ExternalSourceDef source = new ExternalSourceDef(ExternalFormat.CSV, csv.toString(),
-            "collar_id", -1, COLLAR_NS, null, false, ErrorPolicy.SKIP, 0.0,
+            "collar_id", -1, COLLAR_NS, null, false, ErrorPolicy.SKIP,
             Arrays.asList(new ColumnBinding("property", -1, analyte),
                 new ColumnBinding("value", -1, value),
                 new ColumnBinding("below_detection", -1, belowDetection)));

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestExternalSourceAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestExternalSourceAssembler.java
@@ -112,7 +112,6 @@ public class TestExternalSourceAssembler {
         assertEquals("sample_iri", source.getSubjectColumn());
         assertNull(source.getSubjectPrefix());
         assertEquals("skip is the default error policy", ErrorPolicy.SKIP, source.getOnError());
-        assertEquals(0.0, source.getMinMatchRate(), 0.0);
         assertEquals(2, source.getColumns().size());
     }
 
@@ -145,7 +144,6 @@ public class TestExternalSourceAssembler {
             + "            idx:subjectColumn \"sample_id\" ;\n"
             + "            idx:subjectPrefix \"https://ex.org/id/sample/\" ;\n"
             + "            idx:onError       \"fail\" ;\n"
-            + "            idx:minMatchRate  \"0.75\"^^xsd:double ;\n"
             + "            idx:column [ idx:columnName \"property\" ; idx:field field:measuredProperty ] ;\n"
             + "        ] ;\n"
             + "    ] .\n");
@@ -154,7 +152,6 @@ public class TestExternalSourceAssembler {
         assertEquals(ExternalFormat.TSV, source.getFormat());
         assertEquals("https://ex.org/id/sample/", source.getSubjectPrefix());
         assertEquals(ErrorPolicy.FAIL, source.getOnError());
-        assertEquals(0.75, source.getMinMatchRate(), 1e-9);
     }
 
     @Test

--- a/jena-text/src/test/java/org/apache/jena/query/text/external/TestCsvRowSource.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/external/TestCsvRowSource.java
@@ -80,7 +80,7 @@ public class TestCsvRowSource {
     private static ExternalSourceDef sourceDef(ExternalFormat format, String location,
                                                String subjectColumn, String subjectPrefix) {
         return new ExternalSourceDef(format, location, subjectColumn, -1, subjectPrefix,
-            null, false, ErrorPolicy.SKIP, 0.0,
+            null, false, ErrorPolicy.SKIP,
             Arrays.asList(new ColumnBinding("property", -1, PROPERTY_FIELD),
                 new ColumnBinding("value", -1, VALUE_FIELD)));
     }
@@ -160,7 +160,7 @@ public class TestCsvRowSource {
             + "https://ex.org/s/A2,Cu,0.7\n");
 
         ExternalSourceDef def = new ExternalSourceDef(ExternalFormat.CSV, file.toString(),
-            null, 0, null, null, true, ErrorPolicy.SKIP, 0.0,
+            null, 0, null, null, true, ErrorPolicy.SKIP,
             Arrays.asList(new ColumnBinding(null, 1, PROPERTY_FIELD),
                 new ColumnBinding(null, 2, VALUE_FIELD)));
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/external/TestExternalDeltaSource.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/external/TestExternalDeltaSource.java
@@ -107,7 +107,7 @@ public class TestExternalDeltaSource {
 
     private ExternalSourceDef def(Path base, List<String> deltas) {
         return new ExternalSourceDef(ExternalFormat.CSV, base.toString(), "iri", -1, null,
-            null, false, ErrorPolicy.SKIP, 0.0,
+            null, false, ErrorPolicy.SKIP,
             Arrays.asList(new ColumnBinding("property", -1, ANALYTE),
                 new ColumnBinding("value", -1, VALUE)),
             deltas, "op");
@@ -284,7 +284,7 @@ public class TestExternalDeltaSource {
     public void deltasNoLongerRequireAnOrderingAssertion() throws IOException {
         Path base = write("base.csv", BASE);
         ExternalSourceDef def = new ExternalSourceDef(ExternalFormat.CSV, base.toString(),
-            "iri", -1, null, null, false, ErrorPolicy.SKIP, 0.0,
+            "iri", -1, null, null, false, ErrorPolicy.SKIP,
             Arrays.asList(new ColumnBinding("property", -1, ANALYTE),
                 new ColumnBinding("value", -1, VALUE)),
             List.of("delta.csv"), "op");


### PR DESCRIPTION
Drops the `idx:minMatchRate` config knob from external content indexing.

The graph and an external extract are equally valid sources that we align on the entity IRI; neither is obliged to cover the other. A configurable minimum coverage asked the operator to guess a number for something unpredictable, and turned a data-quality question into a build failure. A wrong `idx:subjectPrefix` is fixed in the data, not with a threshold.

### Removed

- `IndexVocab.pMinMatchRate` — the term no longer exists, so a config still carrying it is ignored (an unrecognised `idx:` property is not an error)
- `ExternalSourceDef.minMatchRate`: field, both constructor params, `getMinMatchRate()`, and the 0.0–1.0 range validation
- `ShaclIndexAssembler` parsing, and `getOptionalDouble` with it — no other caller
- `SourceCursor.enforceMinMatchRate()` and its call from `ExternalChildMerger.finish()`. `SourceCursor` also loses its `IndexProfile` field, which existed only to name the shape in the failure message

### Kept

Reporting is not judging, so all the diagnostics stay:

- the per-source INFO line — rows read / matched / unmatched / skipped, entities matched of entities seen, and the match rate
- the WARN when a source has rows but matches no entity at all, pointing at `idx:subjectColumn` / `idx:subjectPrefix`
- `SourceStats.matchRate()`, now purely a reported number

That is what makes a bad join key visible.

### Tests

`minMatchRateFailsABadJoinKey` → `aWrongJoinKeyMatchesNothingAndSaysSo`. Same wrong-prefix CSV, opposite expectation: the build succeeds, 0 rows matched, 2 unmatched, `matchRate() == 0.0`, entities indexed childless. `TestExternalSourceAssembler` loses its two `getMinMatchRate` assertions and the `idx:minMatchRate` line from the optional-properties fixture.

`mvn test -pl jena-text` — 762 tests, 0 failures.

### Docs

`03-configuration.md` (example, property table, the augment-not-create rule), `05-testing.md`, the design doc's option table plus both rationale passages, and the presentation's config slide. The design doc's "why is unmatched-subject a skip" answer now stops at "report it" instead of escalating to a hard failure.