### PR TITLE
Add luc:nestedMatch to project the child records a filter selected

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -187,6 +187,12 @@ it finds entities that link *to* the report.
 | `17-sort-boreholes-by-depth-asc.rq` | Sort boreholes by `depth` ascending via field-IRI sort JSON |
 | `18-nested-identifier-company-drilldown.rq` | Drill down identifier values under `identifierType = company` |
 | `19-nested-identifier-exact-pair.rq` | Correlated exact filter on `identifierType = company` + `identifierValueExact` |
+| `20-date-range-filter.rq` | Date range filter on `idx:TemporalField` using CQL2-JSON `between` |
+| `21-match-review-note-languages.rq` | `luc:match` round-tripping language-tagged literals from stored metadata |
+| `22-match-qa-passed-boolean.rq` | `luc:match` round-tripping typed boolean literals from stored metadata |
+| `23-nested-identifier-same-child-correlated.rq` | Same-child correlated filter on nested identifier records (issue #65) |
+| `24-nested-match-assay-records.rq` | `luc:nestedMatch` projecting the external CSV assay children that matched |
+| `25-nested-match-attribution-record.rq` | `luc:nestedMatch` projecting the graph-derived attribution child that matched |
 
 ### Expected results for path queries
 

--- a/demo/test/config.ttl
+++ b/demo/test/config.ttl
@@ -164,7 +164,7 @@ field:authoredByUri
 field:attributionRole
     idx:fieldName "attributionRole" ;
     idx:fieldType idx:KeywordField ;
-    idx:stored false ;
+    idx:stored true ;             # projected by luc:nestedMatch
     idx:facetable true ;
     idx:multiValued true .
 
@@ -172,7 +172,7 @@ field:attributionRole
 field:attributionAgentExact
     idx:fieldName "attributionAgentExact" ;
     idx:fieldType idx:KeywordField ;
-    idx:stored false ;
+    idx:stored true ;             # projected by luc:nestedMatch
     idx:facetable true ;
     idx:multiValued true .
 
@@ -254,7 +254,10 @@ field:grade
     idx:indexed   true ;          # range filters
     idx:facetable true ;          # range facets
     idx:sortable  true ;          # nested sort selector
-    idx:stored    false .         # the assay database is the source of truth
+    idx:stored    true .          # projected by luc:nestedMatch, so a filtered hit can
+                                  # show the assay that matched. Storing a volatile number
+                                  # means the index must be rebuilt when it changes; the
+                                  # assay database remains the source of truth.
 
 field:gradeUnits
     idx:fieldName "gradeUnits" ;

--- a/demo/test/queries/24-nested-match-assay-records.rq
+++ b/demo/test/queries/24-nested-match-assay-records.rq
@@ -9,10 +9,10 @@
 # The assay children come from data/assays.csv and never enter the graph, so these
 # values can only be read back out of the index.
 #
-# The filter is "in", not "=", on purpose: analyte is level 0 of the
-# (analyte, gradeUnits) facet hierarchy, and a lone "=" on a level-0 field compiles to
-# a taxonomy drill-down on the parent rather than a block join — which filters correctly
-# but leaves no child query for luc:nestedMatch to project from.
+# "in" is used only because two analytes are needed to show two records under one
+# borehole. A single-value "=" projects identically — analyte is level 0 of the
+# (analyte, gradeUnits) facet hierarchy, and nested-scoped fields stay on the block-join
+# path at every hierarchy level.
 
 PREFIX luc: <urn:jena:lucene:index#>
 

--- a/demo/test/queries/24-nested-match-assay-records.rq
+++ b/demo/test/queries/24-nested-match-assay-records.rq
@@ -1,0 +1,32 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Project the assay children that satisfied the filter, using luc:nestedMatch.
+#
+# The filter selects boreholes with an Au or Cu assay. A borehole assayed for both
+# has TWO matching children, so the rows for one hit describe two different assays:
+# ?record is what keeps each analyte with its own grade and units. Without it,
+# "Au", "Cu", 0.82 and 0.31 arrive as four unpaired rows.
+#
+# The assay children come from data/assays.csv and never enter the graph, so these
+# values can only be read back out of the index.
+#
+# The filter is "in", not "=", on purpose: analyte is level 0 of the
+# (analyte, gradeUnits) facet hierarchy, and a lone "=" on a level-0 field compiles to
+# a taxonomy drill-down on the parent rather than a block join — which filters correctly
+# but leaves no child query for luc:nestedMatch to project from.
+
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?entity ?record ?field ?value
+WHERE {
+    (?hit ?entity) luc:query (
+        "default"
+        "default"
+        ""
+        '{"op":"in","args":[{"property":"urn:jena:lucene:field#analyte"},["Au","Cu"]]}'
+        ""
+        10
+        0
+    ) .
+    (?hit ?record ?field ?value) luc:nestedMatch () .
+}
+ORDER BY ?entity ?record ?field

--- a/demo/test/queries/25-nested-match-attribution-record.rq
+++ b/demo/test/queries/25-nested-match-attribution-record.rq
@@ -1,0 +1,28 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# The other half of luc:nestedMatch: children derived from the graph, not a CSV.
+#
+# Two clauses on one prov:qualifiedAttribution child — "Jones as Principal
+# Investigator" — must be satisfied by the SAME attribution (see query 23 and
+# TestCorrelatedNestedAttribution). luc:nestedMatch then returns the attribution
+# that satisfied them, so the answer shows its own evidence: reports where Jones
+# merely reviewed do not match, and their attributions are not projected.
+#
+# Contrast with luc:match, which reports fields matched by the TEXT query on the
+# report itself. Here the text query is empty and all the work is in the filter.
+
+PREFIX luc: <urn:jena:lucene:index#>
+
+SELECT ?entity ?record ?field ?value
+WHERE {
+    (?hit ?entity) luc:query (
+        "default"
+        "default"
+        ""
+        '{"op":"and","args":[{"op":"=","args":[{"property":"urn:jena:lucene:field#attributionRole"},"Principal Investigator"]},{"op":"=","args":[{"property":"urn:jena:lucene:field#attributionAgentExact"},"Dr Sarah Jones"]}]}'
+        ""
+        10
+        0
+    ) .
+    (?hit ?record ?field ?value) luc:nestedMatch () .
+}
+ORDER BY ?entity ?record ?field

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -17,7 +17,8 @@ Public API rules:
 
 - Index selection is explicit and always the first object argument.
 - Field references are always field IRIs, never `idx:fieldName`.
-- `luc:query` returns `?hit`; per-hit match detail comes from `luc:match`.
+- `luc:query` returns `?hit`; per-hit match detail comes from `luc:match`, and the
+  nested child records that satisfied the filter from `luc:nestedMatch`.
 - `luc:query` no longer returns `?match`.
 - Parsing is fixed-position and fixed-arity. There is no shape-based argument inference.
 - Use `""` as the placeholder for an unused `cqlFilter` or `sortSpec`.
@@ -218,6 +219,79 @@ SELECT ?entity ?score ?field ?value WHERE {
   (?hit ?field ?value) luc:match () .
 }
 ```
+
+## luc:nestedMatch
+
+### Syntax
+
+```sparql
+(?hit ?record ?field ?value) luc:nestedMatch ()
+```
+
+The object is always `()`.
+
+### Purpose
+
+`luc:nestedMatch` projects the `idx:nested` child documents that satisfied the CQL
+filter. Where `luc:match` answers "which fields of the *text query* matched on the
+entity", this answers "which child records did the *filter* select, and what do they
+contain". It joins to `luc:query` through `?hit`, exactly as `luc:match` does.
+
+Only fields declared `idx:stored true` inside the nested block are projected; an
+indexed-but-unstored field can be filtered on but has nothing to return.
+
+### Return bindings
+
+| Variable | Type | Meaning |
+|---|---|---|
+| `?hit` | blank node | Join key from `luc:query` |
+| `?record` | blank node | Grouping key — one per matching child document |
+| `?field` | IRI | Field IRI within the child |
+| `?value` | IRI or literal | Stored field value |
+
+`?record` is the point of the API. When a filter selects two children of the same
+entity, a flat stream of `(?field ?value)` rows cannot say which value belongs with
+which key; grouping by `?record` keeps each child's fields together.
+
+### Example
+
+Given a `prov:qualifiedAttribution` nested block, "reports where Sarah Jones was the
+Principal Investigator", returning the attribution that matched:
+
+```sparql
+SELECT ?entity ?record ?field ?value WHERE {
+  (?hit ?entity)
+    luc:query ("default" "default" ""
+      '{"op":"and","args":[
+         {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionRole"},"Principal Investigator"]},
+         {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionAgentExact"},"Dr Sarah Jones"]}
+       ]}'
+      "" 10 0) .
+  (?hit ?record ?field ?value) luc:nestedMatch () .
+}
+```
+
+### Behaviour and limits
+
+- A filter with **no** nested clause projects nothing. Nothing selected a child, so
+  there is no "the child that matched" to report — returning every child of every
+  scope would be a different feature.
+- A **negated** nested clause (`{"op":"not",...}`) projects nothing for that clause.
+  It describes children that must *not* match, which are not why the entity surfaced.
+- A lone `=` on the **first level of an `idx:facetHierarchy`** projects nothing. The
+  compiler answers it with a taxonomy `DrillDownQuery` on the parent rather than a
+  block join, so no child query exists to recover. Filtering is unaffected — the right
+  entities come back, only the projection is missing. Use `in` with the same value, or
+  pair the clause with a sibling on the same nested scope, to take the block-join path:
+
+  ```json
+  {"op":"=", "args":[{"property":"…#analyte"}, "Au"]}          // filters, projects nothing
+  {"op":"in","args":[{"property":"…#analyte"}, ["Au"]]}        // filters and projects
+  ```
+- At most 100 child records per hit are projected. Exceeding that is logged, not
+  silently trimmed.
+- The projection is computed during the `luc:query` search, so it costs one extra
+  block-restricted child query per hit and needs no second Lucene search.
 
 ## luc:facet
 
@@ -544,7 +618,8 @@ page — pagination over a selector-ordered result set stays correct across page
 
 ## Shared Execution
 
-`luc:query`, `luc:facet`, and `luc:match` share a single Lucene execution when these match:
+`luc:query`, `luc:facet`, `luc:match`, and `luc:nestedMatch` share a single Lucene
+execution when these match:
 
 - resolved index identity
 - search field spec

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -278,16 +278,13 @@ SELECT ?entity ?record ?field ?value WHERE {
   scope would be a different feature.
 - A **negated** nested clause (`{"op":"not",...}`) projects nothing for that clause.
   It describes children that must *not* match, which are not why the entity surfaced.
-- A lone `=` on the **first level of an `idx:facetHierarchy`** projects nothing. The
-  compiler answers it with a taxonomy `DrillDownQuery` on the parent rather than a
-  block join, so no child query exists to recover. Filtering is unaffected — the right
-  entities come back, only the projection is missing. Use `in` with the same value, or
-  pair the clause with a sibling on the same nested scope, to take the block-join path:
-
-  ```json
-  {"op":"=", "args":[{"property":"…#analyte"}, "Au"]}          // filters, projects nothing
-  {"op":"in","args":[{"property":"…#analyte"}, ["Au"]]}        // filters and projects
-  ```
+- Projection does not depend on how a clause is written. `=` and `in` over the same
+  value, and a clause on a field that is an `idx:facetHierarchy` level versus one that
+  isn't, all project the same records. This required a compiler change: a lone `=` on
+  the *first level* of a hierarchy used to compile to a taxonomy `DrillDownQuery` on the
+  parent, which selects the same entities but carries no child query. Nested-scoped
+  fields now stay on the block-join path at every level. Root-scoped hierarchy fields
+  keep the drill-down — they have no children to lose.
 - At most 100 child records per hit are projected. Exceeding that is logged, not
   silently trimmed.
 - The projection is computed during the `luc:query` search, so it costs one extra

--- a/docs/2026-07-30_external_delta_endpoint_design.md
+++ b/docs/2026-07-30_external_delta_endpoint_design.md
@@ -1,0 +1,356 @@
+---
+title: "external delta endpoint design"
+date: "2026-07-30"
+---
+
+# 2026-07-30 External Delta Endpoint Design
+
+## Status
+
+**Designed, not built — and probably should not be built yet.** See
+[Do not build this until the volume demands it](#do-not-build-this-until-the-volume-demands-it)
+first. At the volumes now in play the same outcome is available by loading the values as
+RDF, which needs no new code at all. This note exists so the decision is recorded with
+its numbers, and so the design is ready if volume returns.
+
+Extends [2026-07-27_external_content_indexing_design.md](2026-07-27_external_content_indexing_design.md),
+whose "Delta via staged snapshot (designed, deferred)" section this supersedes, and whose
+"Live/streaming updates from external sources" out-of-scope line this reverses.
+
+## Problem
+
+External content is **rebuild-only**. `ShaclTextDocProducer.rebuildEntityDocuments()`
+reconstructs a document from the graph alone, so for a shape declaring an
+`idx:externalSource` it would write the entity back stripped of every external child.
+The producer therefore refuses outright and logs that the document is now stale
+(`ShaclTextDocProducer.java:249`).
+
+Two consequences, and the second is the one that hurts:
+
+1. There is no way to apply an external delta without rebuilding the whole index.
+2. **A graph change to an external-bearing entity is also refused.** An RDF Patch that
+   corrects a collar's name leaves the document stale, because the machinery cannot
+   rewrite the block without losing the assays.
+
+So this is not only about a new endpoint. The same missing capability blocks the
+already-working graph path.
+
+## What already works
+
+Worth stating precisely, because it sets the shape of what is missing.
+
+`TextDatasetAssembler` builds a `DatasetGraphText extends DatasetGraphTextMonitor`, and
+that wrapper is the dataset Fuseki hands to **every** write path. `PatchApply` does
+`new RDFChangesApply(action.getDataset())`
+(`jena-fuseki-core/.../servlets/PatchApply.java:143`), so a patched quad goes
+
+```
+POST /ds/patch → RDFChangesApply → DatasetGraphTextMonitor.add()
+               → ShaclTextDocProducer.change() → rebuildEntityDocuments()
+```
+
+exactly as a SPARQL Update does. **Graph-derived SHACL fields are already live over the
+RDF Patch endpoint.** Nothing in this note changes that; it extends the same path to
+cover external children.
+
+## The constraint everything follows from
+
+Lucene has no partial document update, and a block join must be written whole. Touching
+one child means rewriting the entity's entire block — parent and every child.
+`ShaclTextIndexLucene.updateEntityForProfile` (line 1379) already does exactly this: a
+delete-by-`(docIdField, discriminator)` term pair, then one `addDocuments(block)`.
+
+A live delta is therefore trivial **if** the indexer can answer "what are entity E's
+current external children?" cheaply. Today it cannot: the values are deliberately
+`idx:stored false`, and the base extract is a multi-GB sequential file. Answering that
+question is the entire design.
+
+## Design
+
+### 1. Retained rows — let Lucene own the external state
+
+Opt in per source:
+
+```turtle
+idx:externalSource [
+    idx:location   "/data/assays.csv" ;
+    idx:retainRows true ;        # default false — rebuild-only, exactly as today
+    ...
+]
+```
+
+When set, the **parent** document carries one stored, non-indexed field per nested scope
+— `_extRows$<nestedName>` — holding the raw cell text of that entity's children for that
+scope, deflated. It is the same `String[]` rows `ExternalChildMerger.toRecord()` consumes;
+nothing is transformed on the way in or out.
+
+This makes a block **self-reconstructing**: read retained rows → apply operations →
+re-emit via the existing `toRecord`/`addFieldToDoc` path, so a rebuilt block is identical
+to a bulk-built one. The rewrite stays atomic with the index, because it is still one
+`deleteDocuments` plus one `addDocuments`.
+
+> **This is internal storage, not a wire format.** Producers send text (see
+> [The wire format](#3-the-wire-format--ndjson)). Nothing outside the indexer ever sees
+> the retained-rows field. "Deflated" is a size optimisation, not an interface.
+
+**Cost.** On the measured GSWA index (2,470,212 collars, 29,707,584 children, 1,338 MB)
+retained rows are roughly 25 bytes/child raw and perhaps 8–12 compressed — about
+**+250–350 MB, or 20–25%**. That is the price of live updates, which is why it is opt-in
+per source: a batch-released source keeps today's behaviour and today's size.
+
+The alternative — a sidecar KV store (RocksDB, MapDB, LMDB) keyed by `(subject, scope)` —
+avoids the growth but adds a dependency, a crash-consistency problem between two stores
+that can now disagree, and a backup story. Take it only if the retained-rows field
+measures materially worse than projected.
+
+### 2. The graph path stops being broken
+
+With retained rows present, `rebuildEntityDocuments()` no longer needs the
+`hasExternalSource` refusal: it rebuilds from **graph + retained rows**, and
+external-bearing shapes cease to be rebuild-only. This is worth having on its own,
+independent of any endpoint.
+
+It is also what makes the two delta paths compose. Both converge on one routine:
+
+```
+rebuildBlock(entity) = graph fields (ShaclEntityBuilder)
+                     + retained external rows (optionally mutated by a delta)
+                     → updateEntityForProfile
+```
+
+An RDF patch and an external delta touching the same entity in the same transaction then
+produce one correct block, rather than two racing half-rebuilds.
+
+### 3. The wire format — NDJSON
+
+Do not invent new semantics. The operation contract is already settled and implemented in
+`DeltaRowSource` (see its class javadoc, and `docs/03-configuration.md` → Deltas):
+
+| | |
+|---|---|
+| `DELETE` | matches on the columns it fills in; an **empty cell is a wildcard**. Numeric columns compare by value, so `0.70` deletes `0.7` |
+| `ADD` | **appends**; not an upsert, because duplicate `(subject, property)` rows are legal and there is no key to upsert on. Replace = DELETE then ADD |
+| Ordering | deletes apply before adds within a subject, so row order cannot change the outcome |
+| Unmatched delete | counted and reported, not an error — deltas get replayed and overlap |
+
+NDJSON, one row per line, scope-qualified, with a leading header line:
+
+```json
+{"h":{"id":"urn:uuid:8f3c…","prev":"urn:uuid:1a90…"}}
+{"op":"D","s":"http://ex.org/bh-1","scope":"measurement","v":{"analyte":"Ag"}}
+{"op":"A","s":"http://ex.org/bh-1","scope":"measurement","v":{"analyte":"Ag","grade":51.3,"units":"ppm"}}
+```
+
+NDJSON because it streams, appends, and survives queues and blob storage without a
+container format — the same reasons the CSV form works.
+
+`v` keys are **column names, not field IRIs**. The binding stays in the config, so the
+producer keeps emitting whatever its extract already calls those columns and a config
+change does not become a producer change.
+
+`text/csv` remains accepted for the existing shape (`op,subject,cols…`, with `?scope=`
+naming the nested block), so one file drives both the CLI and the endpoint.
+
+### 4. Idempotency is load-bearing, not a nicety
+
+`ADD` appends. **Replaying a delta duplicates children silently**, and HTTP clients
+retry. RDF Patch escapes this because adding a quad twice is naturally idempotent; this
+format is not.
+
+So the header line is mandatory:
+
+- Applied ids go into Lucene commit user data (`IndexWriter.setLiveCommitData`) as a
+  bounded ring of the last N.
+- A re-POST of a seen id returns `200` with `{"applied":false,"reason":"duplicate"}`.
+- `prev` chains the deltas, so a **gap** is detectable — a missed delta is otherwise
+  invisible and permanently corrupting. An out-of-order or gapped id is a `409`, not a
+  silent apply.
+
+If the producer cannot guarantee stable ids and ordering, prefer a **replace-subject**
+operation instead: `{"op":"R","s":…,"scope":…}` clears the scope and the following adds
+repopulate it. It is trivially idempotent, and it fits a producer that can only say "here
+is the current full set for these subjects". Worth adding regardless of the id scheme.
+
+### 5. The endpoint
+
+A `fuseki:externalDelta` operation modelled directly on `PatchApply`: same `ActionREST`
+shape, same POST/PATCH, same `beginWrite`/`commit`/`abort` envelope, registered in
+`OperationRegistry`.
+
+```
+POST /ds/external
+Content-Type: application/external-delta+ndjson
+```
+
+Body → group by subject → per subject: locate the block, read retained rows, apply
+operations, rewrite the block. The matching logic is lifted verbatim from
+`DeltaRowSource.matches()` / `valuesEqual()` into a shared `DeltaOps`, so the HTTP path
+and the build-time path cannot drift apart.
+
+The response mirrors `ExternalChildMerger.SourceStats`: rows read and applied, adds,
+deletes, deletes matching nothing, subjects unmatched.
+
+Because it runs inside the Fuseki write transaction, and `ShaclTextDocProducer` already
+defers `indexer.commit()` to `finish()`, a delta and a patch in flight interleave
+correctly.
+
+### 6. Ownership and ordering
+
+Unchanged from the 2026-07-27 note: **graph changes own document lifecycle; external
+deltas own child content only.** A delta for an entity with no document is counted and
+dropped — it never creates one. A bad delta cannot destroy documents.
+
+The operational consequence, and the main sharp edge to document: **patch first, then
+delta.** Rows arriving before their entity are lost and must be replayed.
+
+Parking orphan rows for an entity that has not arrived yet would need state outside the
+index, which drags the sidecar store back in. Defer it. If co-arrival turns out to be
+common, solve it with a bundle request — graph part then external part, one transaction —
+rather than an orphan store.
+
+### 7. Selective bulk rebuild falls out
+
+Phase 3 of the 2026-07-27 note becomes the same code driven from a file rather than a
+socket: the delta names its affected subjects, and each subject's current rows come from
+its retained-rows field. No sequential pass over the base snapshot — which was the thing
+that made that phase unattractive.
+
+## Do not build this until the volume demands it
+
+The 2026-07-27 design justifies external content on volume: attributes that are "tens of
+millions of rows, an order of magnitude bigger than the graph describing the same
+entities". **Remove the volume and most of the argument goes with it.**
+
+If the extract is reduced to a max (or otherwise summarised) value per
+`(entity, property)`, loading those values as RDF is the better answer:
+
+| | External CSV + this design | **Load as RDF** |
+|---|---|---|
+| Live updates | retained rows, new endpoint, new format, idempotency ring | **RDF Patch endpoint, working today** |
+| Index overhead | +20–25% for retained rows | none |
+| New code | ~5 components across `jena-text` and `jena-fuseki-core` | **none** |
+| Values readable | not stored; source of truth only | SPARQL-visible, `DESCRIBE`-able |
+| Lucene model | `idx:externalSource` nested block | `idx:joinPath` nested block — the primary path |
+| Store growth | none | ~4 triples per `(entity, property)` |
+| Update cadence | decoupled from the graph | coupled to the graph |
+
+The Lucene side barely changes. Nested EAV children from the graph via `idx:joinPath`
+is the *original* design and supports everything the external variant does —
+`idx:facetHierarchy` per child, same-child correlation, the block-join sort selector
+(`docs/03-configuration.md` → Nested). External content was the bolt-on, not the
+foundation. Swapping the source of the children is a config change, not a code change.
+
+### The crossover, measured 2026-07-30
+
+Counted from the narrow (already-summarised) extracts in
+`gswa-prez-config/raw_data`, which are the unpivoted form of
+`DHAssayFlatSummary/dh_assay_flat_summary.csv` and `ssAssayflat/ss_assay_flat.csv`
+(~2.5 GB of wide CSV between them):
+
+| Source | Entities | Measurements | Per entity |
+|---|---|---|---|
+| `drillhole-measurements.csv` (224 MB) | 224,184 | 2,551,572 | 11.4 |
+| `surface-measurements.csv` (1.1 GB) | ~869,000 | 13,145,243 | 15.1 |
+| **Total** | **~1.09 M** | **15,696,815** | 14.4 |
+
+That is roughly **half** the 29.7 M children measured on 2026-07-27, which is the
+reduction that reopens this question.
+
+Analytes are a **closed set of 83 columns** — effectively the periodic table, stable for
+decades. This matters: the 2026-07-27 argument for nested EAV over flat leant on
+"a new property appears in the source → config regeneration", and that objection is much
+weaker against a fixed column set than against an open-ended one.
+
+Three modellings, and their cost:
+
+| Modelling | Triples/measurement | Total triples | TDB2 growth¹ | Lucene model |
+|---|---|---|---|---|
+| Qualified node, minimal (link, analyte, value) | 3 | 47.1 M | ~3–5 GB | nested EAV, 2 field IRIs |
+| **Qualified node, typed** (+ `rdf:type`) | **4** | **62.8 M** | **~4–7 GB** | nested EAV, 2 field IRIs |
+| Full `sosa:Observation` (+ unit, observed property) | 6 | 94 M | ~6–10 GB | nested EAV, 2 field IRIs |
+| Flat direct predicate (`<site> gswa:Au_PPM 12.4`) | 1 | 15.7 M | ~1–2 GB | **flat, 83 field IRIs** |
+
+¹ At 60–110 bytes/triple on disk including node table and indexes. The upper end applies
+here: measurement nodes are mostly *new* URIs and the values are distinct doubles, so
+neither the node table nor the term dictionary gets the URI reuse that keeps TDB2 compact.
+
+For scale, the loaded store is currently **15 GB**
+(`gswa-prez-config/fuseki/external_drillhole/volume`), against 47.6 GB of raw N-Quads at
+~208 bytes/line ≈ **~245 M quads** across all sources. So the typed-qualified-node option
+is **+4–7 GB on a 15 GB store (~+30–45%), and ~25% of the graph's quad count** — for data
+nothing queries by SPARQL path.
+
+That is a very different proposition from the same exercise at the original volume, which
+would have been ~119 M triples.
+
+**The Lucene index size is unchanged either way.** 15.7 M nested children index
+identically whether their source is a CSV row or a graph node — at the measured
+38.2 bytes/child, about **600 MB** of external content in both worlds. What actually
+differs is only: TDB2 growth, the retained-rows overhead (~160 MB, RDF path pays none),
+and whether the delta endpoint has to exist.
+
+| | External CSV + this design | **Load as RDF (typed qualified node)** |
+|---|---|---|
+| TDB2 growth | none | **+4–7 GB** |
+| Lucene index (children) | ~600 MB | ~600 MB — identical |
+| Retained rows | +~160 MB | none |
+| New code | ~7 components across two modules | **none** |
+| Live updates | build all of the above | **RDF Patch, working today** |
+| Extra load time | CSV merge during build | ~62.8 M triples through `tdb2.xloader` |
+
+**Verdict: load it as RDF.** +4–7 GB on a 15 GB store is a far easier trade than
+building and then maintaining a bespoke delta protocol, a wire format, an idempotency
+scheme and a retained-rows storage mode. The volume reduction is what makes it so; at
+29.7 M measurements the answer was the other way.
+
+The honest counter, which does not disappear: 62.8 M triples is a quarter of the graph's
+quad count carrying data nobody dereferences or traverses. That was objection #1 in the
+2026-07-27 note. It has become survivable, not wrong.
+
+**Keep the external content machinery either way.** It is built, tested and documented,
+and it is the right answer the moment the full measurement set — rather than a summary —
+needs to be searchable. Reverting to it is a config change.
+
+## Proposed code changes
+
+- **`ShaclIndexMapping.ExternalSourceDef`** — add `retainRows`.
+- **`ShaclIndexAssembler`** — parse `idx:retainRows`.
+- **`ShaclEntityBuilder` / `ShaclTextIndexLucene`** — write the `_extRows$<scope>` stored
+  field on the parent when retention is on; read it back when rebuilding.
+- **`ShaclTextDocProducer`** — replace the `hasExternalSource` refusal with a rebuild from
+  graph + retained rows, keeping the refusal only when retention is off.
+- **`DeltaOps`** (new) — `matches()` / `valuesEqual()` lifted out of `DeltaRowSource`,
+  used by both the file and HTTP paths.
+- **`ExternalDeltaReader`** (new) — NDJSON and CSV to a stream of operations.
+- **`ExternalDeltaApply`** (new, `jena-fuseki-core`) — the servlet, plus `Operation` and
+  `OperationRegistry` entries.
+- **Idempotency ring** — applied delta ids in Lucene commit user data.
+
+## Tests
+
+Per the repo's test discipline, red first, and **registered in `TS_Text.java`** or
+Surefire will not run them.
+
+- Retained rows round-trip: bulk build, reopen, rebuild one entity, children identical.
+- A graph patch to an external-bearing entity **keeps** its children (this is the
+  currently-failing behaviour — write it first).
+- Retention off: the refusal still fires and is still logged.
+- `ADD` appends rather than upserts; duplicate `(subject, property)` survives.
+- `DELETE` wildcard: an empty cell removes every matching child.
+- Numeric delete by value — `0.70` deletes `0.7`.
+- Deletes before adds within a subject, irrespective of row order.
+- Replaying a delta id is a no-op; a gapped `prev` is rejected.
+- A delta for an unknown subject is counted and creates no document.
+- Endpoint-level: patch and delta in one transaction produce one correct block.
+
+## Open questions
+
+1. **The reduced pair count.** Fill it in; it decides whether any of this gets built.
+2. **Does the producer emit stable ids and ordering?** If not, adopt the
+   replace-subject operation and drop the chain check.
+3. **Retained-rows size in practice** — measure before committing publicly to the 20–25%
+   figure; it is projected, not observed.
+4. **Are patch and delta co-arriving for the same entity?** Only that determines whether
+   the bundle request is needed.
+5. **Crash consistency between TDB2 and the Lucene index** is not addressed here, and is
+   not made worse — the existing commit path already has this property.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,12 +8,14 @@ This doc set covers the SHACL/entity-per-document search model in `jena-text`.
 |---|---|---|
 | `luc:query` | Done | Fixed-position query API with explicit `indexSelector` and `fieldSpec` |
 | `luc:match` | Done | Sole per-hit match-detail API |
+| `luc:nestedMatch` | Done | Projects the `idx:nested` child records a filter selected, grouped by `?record` |
 | `luc:facet` | Done | Fixed-position facet API with field IRIs and range facets |
 | Multi-index selection | Done | Query-time `indexSelector` plus `text:indexes` config |
 | Field IRIs | Done | Public SPARQL uses field IRIs only |
 | Sort pushdown | Done | Sort specs use field IRIs in the public API |
 | Nested sort selector | Done | Order by a child value where a co-located discriminator matches |
 | External content (CSV/TSV) | Done | `idx:externalSource` builds nested children from a tabular file; bulk build only |
+| External delta endpoint | Designed | NDJSON deltas over HTTP, via opt-in retained rows. Not built — at reduced volume, load the values as RDF instead |
 | Graph scoping model | Designed | Reserved synthetic field `urn:jena:lucene:field#sourceGraph`; implementation deferred |
 | Highlight API | Deferred | Reserved for later, not active in the current `luc:query` signature |
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/NestedMatch.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/NestedMatch.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+
+/**
+ * One block-join child document that satisfied the query's filter, with its stored
+ * fields projected back out.
+ * <p>
+ * The record identifier is what makes the projection usable: a hit whose filter matched
+ * two children yields two {@code NestedMatch}es, and a consumer groups by
+ * {@link #getRecordId()} to keep each child's fields together. Flattening the fields of
+ * all matching children onto the hit loses that pairing irrecoverably — with clauses on
+ * <em>role</em> and <em>agent</em>, or on <em>analyte</em> and <em>value</em>, the whole
+ * point is which value went with which key on a single child.
+ * <p>
+ * Like {@link SearchHit#getHitId()}, the identifier is a query-scoped blank node derived
+ * from the hit's rank and the child's ordinal. It is minted once, when the search runs,
+ * so repeated evaluation of the property function over the same cached hits yields the
+ * same node and joins hold.
+ */
+public class NestedMatch {
+    private final Node recordId;
+    private final String scope;
+    private final List<FieldMatch> fieldMatches;
+
+    public NestedMatch(int hitRank, int ordinal, String scope, List<FieldMatch> fieldMatches) {
+        this.recordId = NodeFactory.createBlankNode("hit" + hitRank + "r" + ordinal);
+        this.scope = scope;
+        this.fieldMatches = fieldMatches != null
+            ? Collections.unmodifiableList(new ArrayList<>(fieldMatches))
+            : Collections.emptyList();
+    }
+
+    /** Query-scoped blank node grouping this child's field matches. */
+    public Node getRecordId() { return recordId; }
+
+    /**
+     * The {@code idx:nested} scope this child belongs to — the stringified join path,
+     * an internal identity rather than a name a query author would write.
+     */
+    public String getScope() { return scope; }
+
+    public List<FieldMatch> getFieldMatches() { return fieldMatches; }
+
+    @Override
+    public String toString() {
+        return "NestedMatch{id=" + recordId + " scope=" + scope + " fields=" + fieldMatches + "}";
+    }
+}

--- a/jena-text/src/main/java/org/apache/jena/query/text/SearchHit.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SearchHit.java
@@ -42,6 +42,7 @@ public class SearchHit {
     private final Node graph;
     private final int luceneDocId;
     private List<FieldMatch> fieldMatches;
+    private List<NestedMatch> nestedMatches;
 
     public SearchHit(int index, Node entityNode, float score, Node graph, int luceneDocId) {
         this.hitId = NodeFactory.createBlankNode("hit" + index);
@@ -73,6 +74,19 @@ public class SearchHit {
 
     public void setFieldMatches(List<FieldMatch> fieldMatches) {
         this.fieldMatches = fieldMatches != null ? new ArrayList<>(fieldMatches) : null;
+    }
+
+    /**
+     * The block-join child documents that satisfied the query's filter, each carrying its
+     * own grouping node. Empty when the filter had no clause on a nested scope — nothing
+     * selected a child, so there is no "the child that matched" to report.
+     */
+    public List<NestedMatch> getNestedMatches() {
+        return nestedMatches != null ? nestedMatches : Collections.emptyList();
+    }
+
+    public void setNestedMatches(List<NestedMatch> nestedMatches) {
+        this.nestedMatches = nestedMatches != null ? new ArrayList<>(nestedMatches) : null;
     }
 
     @Override

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -843,6 +843,24 @@ public class ShaclIndexMapping {
         return null;
     }
 
+    /**
+     * The {@code idx:nested} block with the given scope name, or null if none.
+     * <p>
+     * The scope name is the one stored on each child document, so this is how the read
+     * path recovers a child's field definitions from the document it just loaded.
+     */
+    public NestedDef findNestedDefByName(String nestedName) {
+        if (nestedName == null) return null;
+        for (IndexProfile profile : profiles) {
+            for (NestedDef nestedDef : profile.getNestedDefs()) {
+                if (nestedName.equals(nestedDef.getNestedName())) {
+                    return nestedDef;
+                }
+            }
+        }
+        return null;
+    }
+
     /** True when any profile carries an {@code idx:externalSource} — such profiles are
      *  rebuild-only (see {@link ShaclTextDocProducer}). */
     public boolean hasExternalSources() {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -61,6 +61,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.ParentChildrenBlockJoinQuery;
 import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.apache.lucene.search.join.ToParentBlockJoinSortField;
@@ -212,6 +213,12 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
 
     /** Upper bound on {@link #childSortFilterCache} entries. */
     private static final int MAX_CHILD_SORT_FILTERS = 256;
+
+    /**
+     * Upper bound on child records projected per hit by {@link #computeNestedMatches}.
+     * A hit whose filter selects more children than this is logged, not silently trimmed.
+     */
+    private static final int MAX_NESTED_MATCHES_PER_HIT = 100;
 
     public ShaclTextIndexLucene(Directory directory, TextIndexConfig config) {
         this(directory, null, config);
@@ -661,6 +668,14 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                 computeFieldMatches(searcher, textQuery, resolvedFields, results);
             }
 
+            // Project the child documents the filter selected. Done here, inside the same
+            // try block, because this is the one place where the compiled query, a live
+            // searcher and valid parent doc ids all coexist — resolving children later
+            // would read doc ids against a reader that may have been refreshed since.
+            if (!results.isEmpty()) {
+                computeNestedMatches(searcher, finalQuery, results);
+            }
+
             return results;
         } catch (IOException ex) {
             throw new TextIndexException("searchWithHitIds", ex);
@@ -750,6 +765,126 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
 
             hit.setFieldMatches(fieldMatches);
         }
+    }
+
+    /**
+     * Attach to each hit the block-join child documents that satisfied the filter.
+     * <p>
+     * The child queries are recovered from the compiled query rather than from the
+     * {@link CqlExpression} it came from: the compiler has already wrapped every nested
+     * clause in a {@link ToParentBlockJoinQuery}, so its {@code getChildQuery()} is
+     * exactly the "which children" predicate, whether the clause was folded as a
+     * same-child group or lifted on its own. Nothing here re-interprets CQL.
+     * <p>
+     * Each surviving child is then re-queried with {@link ParentChildrenBlockJoinQuery},
+     * which restricts the child query to the block belonging to one parent — the same
+     * primitive an "inner hits" feature is built on, and the reason no doc id arithmetic
+     * appears in this method.
+     */
+    private void computeNestedMatches(IndexSearcher searcher, Query finalQuery, List<SearchHit> hits)
+            throws IOException {
+        List<Query> childQueries = new ArrayList<>();
+        collectChildQueries(finalQuery, childQueries);
+        if (childQueries.isEmpty()) {
+            // No nested clause: nothing selected a child, so there is no matching child
+            // to report. Returning every child of every scope would be a different
+            // feature wearing the same name.
+            return;
+        }
+
+        StoredFields storedFields = searcher.storedFields();
+        for (SearchHit hit : hits) {
+            // Sorted and de-duplicated: one child can satisfy more than one nested clause,
+            // and index order keeps the projection stable across pages.
+            Set<Integer> childDocIds = new TreeSet<>();
+            for (Query childQuery : childQueries) {
+                Query scoped = new ParentChildrenBlockJoinQuery(
+                    PARENTS_FILTER, childQuery, hit.getLuceneDocId());
+                for (ScoreDoc sd : searcher.search(scoped, MAX_NESTED_MATCHES_PER_HIT + 1).scoreDocs) {
+                    childDocIds.add(sd.doc);
+                }
+            }
+            if (childDocIds.isEmpty()) {
+                continue;
+            }
+            if (childDocIds.size() > MAX_NESTED_MATCHES_PER_HIT) {
+                log.warn("Hit {} matched {} child records; projecting the first {}",
+                    hit.getEntityNode(), childDocIds.size(), MAX_NESTED_MATCHES_PER_HIT);
+            }
+
+            List<NestedMatch> matches = new ArrayList<>();
+            for (int childDocId : childDocIds) {
+                if (matches.size() >= MAX_NESTED_MATCHES_PER_HIT) {
+                    break;
+                }
+                NestedMatch match = nestedMatchFromChild(
+                    hit.getRank(), matches.size(), storedFields.document(childDocId));
+                if (match != null) {
+                    matches.add(match);
+                }
+            }
+            hit.setNestedMatches(matches);
+        }
+    }
+
+    /**
+     * Collect the child-doc query of every {@link ToParentBlockJoinQuery} reachable in
+     * {@code query} without passing through a negation.
+     * <p>
+     * A {@code MUST_NOT} nested clause describes children that must <em>not</em> match;
+     * those children are not why the parent surfaced, so projecting them would report the
+     * opposite of what was asked.
+     */
+    private static void collectChildQueries(Query query, List<Query> out) {
+        switch (query) {
+            case ToParentBlockJoinQuery blockJoin -> out.add(blockJoin.getChildQuery());
+            case BooleanQuery booleanQuery -> {
+                for (BooleanClause clause : booleanQuery) {
+                    if (clause.occur() != BooleanClause.Occur.MUST_NOT) {
+                        collectChildQueries(clause.query(), out);
+                    }
+                }
+            }
+            case BoostQuery boost -> collectChildQueries(boost.getQuery(), out);
+            case ConstantScoreQuery constantScore -> collectChildQueries(constantScore.getQuery(), out);
+            default -> { }
+        }
+    }
+
+    /** Project one child document's stored fields, or null if it has nothing to project. */
+    private NestedMatch nestedMatchFromChild(int hitRank, int ordinal, Document childDoc) {
+        String scope = childDoc.get(NESTED_SCOPE_FIELD);
+        ShaclIndexMapping.NestedDef nestedDef = shaclMapping.findNestedDefByName(scope);
+        if (nestedDef == null) {
+            log.warn("Child document carries nested scope '{}', which is not in the current "
+                + "mapping — reindex after changing idx:joinPath", scope);
+            return null;
+        }
+
+        List<FieldMatch> fieldMatches = new ArrayList<>();
+        for (ShaclIndexMapping.FieldDef fd : nestedDef.getFields()) {
+            if (!fd.isStored()) {
+                continue;
+            }
+            String[] storedValues = childDoc.getValues(fd.getFieldName());
+            if (storedValues == null) {
+                continue;
+            }
+            Node fieldIRI = fd.getFieldIRI() != null
+                ? fd.getFieldIRI()
+                : NodeFactory.createLiteralString(fd.getFieldName());
+            for (int i = 0; i < storedValues.length; i++) {
+                // Every stored value is projected, positionally aligned with its datatype
+                // and language twins. selectStoredValue's "which one did the query mean"
+                // heuristic is not needed and would be wrong here: a child document holds
+                // exactly the one record being reported.
+                Node value = fieldValueToNode(childDoc, fd, new SelectedStoredValue(i, storedValues[i]));
+                if (value != null) {
+                    fieldMatches.add(new FieldMatch(fieldIRI, value, null));
+                }
+            }
+        }
+        return fieldMatches.isEmpty() ? null : new NestedMatch(hitRank, ordinal, scope, fieldMatches);
     }
 
     /**

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextNestedMatchPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextNestedMatchPF.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.query.QueryBuildException;
+import org.apache.jena.query.QueryExecException;
+import org.apache.jena.sparql.core.Substitute;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
+import org.apache.jena.sparql.engine.iterator.QueryIterPlainWrapper;
+import org.apache.jena.sparql.pfunction.PropFuncArg;
+import org.apache.jena.sparql.pfunction.PropertyFunctionBase;
+import org.apache.jena.sparql.util.IterLib;
+import org.apache.jena.sparql.util.Symbol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SPARQL property function projecting the nested child records that satisfied the
+ * filter ({@code luc:nestedMatch}).
+ * <p>
+ * Joins with {@code luc:query} via the shared {@code ?hit} identifier, exactly as
+ * {@code luc:match} does. Where {@code luc:match} answers "which fields of the text
+ * query matched on the entity", this answers "which {@code idx:nested} child documents
+ * satisfied the CQL filter, and what do they contain".
+ * <p>
+ * <b>Syntax:</b>
+ * <pre>
+ * (?hit ?record ?field ?value) luc:nestedMatch ()
+ * </pre>
+ * <p>
+ * One row per (child record, field, value). {@code ?record} is a query-scoped blank node
+ * shared by every row of one child, so a consumer recovers a whole record with
+ * {@code GROUP BY ?record}. That grouping is the reason this is not a variant of
+ * {@code luc:match}: when two children of the same entity match, a flat stream of
+ * (field, value) rows cannot say which value belongs with which key.
+ * <p>
+ * The object argument list is empty — all state comes from the shared
+ * {@link SearchExecution} stored in the {@link ExecutionContext}.
+ */
+public class TextNestedMatchPF extends PropertyFunctionBase {
+    private static final Logger log = LoggerFactory.getLogger(TextNestedMatchPF.class);
+
+    public TextNestedMatchPF() {}
+
+    @Override
+    public void build(PropFuncArg argSubject, Node predicate, PropFuncArg argObject, ExecutionContext execCxt) {
+        super.build(argSubject, predicate, argObject, execCxt);
+
+        if (argSubject.isList()) {
+            int size = argSubject.getArgListSize();
+            if (size < 1 || size > 4) {
+                throw new QueryBuildException("Subject must have 1-4 elements " +
+                    "(?hit ?record ?field ?value): " + argSubject);
+            }
+        }
+    }
+
+    @Override
+    public QueryIterator exec(Binding binding,
+                              PropFuncArg argSubject, Node predicate, PropFuncArg argObject,
+                              ExecutionContext execCxt) {
+
+        argSubject = Substitute.substitute(argSubject, binding);
+
+        Node hitNode = null, recordNode = null, fieldNode = null, valueNode = null;
+
+        if (argSubject.isList()) {
+            hitNode = argSubject.getArg(0);
+            if (argSubject.getArgListSize() > 1) {
+                recordNode = requireVariable(argSubject.getArg(1), "Record", argSubject);
+            }
+            if (argSubject.getArgListSize() > 2) {
+                fieldNode = requireVariable(argSubject.getArg(2), "Field", argSubject);
+            }
+            if (argSubject.getArgListSize() > 3) {
+                valueNode = requireVariable(argSubject.getArg(3), "Value", argSubject);
+            }
+        } else {
+            hitNode = argSubject.getArg();
+        }
+
+        if (hitNode == null) {
+            return IterLib.noResults(execCxt);
+        }
+
+        SearchExecution se = findSearchExecution(execCxt);
+        if (se == null) {
+            log.warn("luc:nestedMatch used without a preceding luc:query in the same query");
+            return IterLib.noResults(execCxt);
+        }
+
+        // Reuse the hits luc:query already fetched — the nested records were projected
+        // during that search and are carried on the hits.
+        List<SearchHit> allHits = se.getCachedHits();
+
+        Var hitVar = Var.isVar(hitNode) ? Var.alloc(hitNode) : null;
+        Var recordVar = recordNode != null ? Var.alloc(recordNode) : null;
+        Var fieldVar = fieldNode != null ? Var.alloc(fieldNode) : null;
+        Var valueVar = valueNode != null ? Var.alloc(valueNode) : null;
+
+        List<Binding> bindings = new ArrayList<>();
+
+        for (SearchHit sh : allHits) {
+            // ?hit already bound — keep only its own rows.
+            if (hitVar == null && !hitNode.equals(sh.getHitId())) {
+                continue;
+            }
+
+            for (NestedMatch record : sh.getNestedMatches()) {
+                for (FieldMatch fm : record.getFieldMatches()) {
+                    BindingBuilder builder = Binding.builder(binding);
+                    if (hitVar != null) builder.add(hitVar, sh.getHitId());
+                    if (recordVar != null) builder.add(recordVar, record.getRecordId());
+                    if (fieldVar != null && fm.getFieldIRI() != null) builder.add(fieldVar, fm.getFieldIRI());
+                    if (valueVar != null && fm.getValue() != null) builder.add(valueVar, fm.getValue());
+                    bindings.add(builder.build());
+                }
+            }
+        }
+
+        return QueryIterPlainWrapper.create(bindings.iterator(), execCxt);
+    }
+
+    private static Node requireVariable(Node node, String label, PropFuncArg argSubject) {
+        if (!node.isVariable()) {
+            throw new QueryExecException(label + " must be a variable: " + argSubject);
+        }
+        return node;
+    }
+
+    /**
+     * Find a SearchExecution in the execution context, stored there by luc:query or
+     * luc:facet under a key derived from the search parameters.
+     */
+    private SearchExecution findSearchExecution(ExecutionContext execCxt) {
+        String prefix = TextQuery.NS + "searchExecution/";
+        org.apache.jena.sparql.util.Context ctx = execCxt.getContext();
+        for (Symbol sym : ctx.keys()) {
+            if (sym.getSymbol().startsWith(prefix)) {
+                Object obj = ctx.get(sym);
+                if (obj instanceof SearchExecution) {
+                    return (SearchExecution) obj;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextQuery.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextQuery.java
@@ -83,6 +83,12 @@ public class TextQuery
                     return new TextMatchPF() ;
                 }
             });
+            PropertyFunctionRegistry.get().put(IndexVocab.pfNestedMatch, new PropertyFunctionFactory() {
+                @Override
+                public PropertyFunction create(String uri) {
+                    return new TextNestedMatchPF() ;
+                }
+            });
 
             JenaSystem.logLifecycle("TextQuery.init - finish") ;
             // Register indirections.

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
@@ -37,6 +37,12 @@ public class IndexVocab {
     public static final String pfQuery = NS + "query";
     public static final String pfFacet = NS + "facet";
     public static final String pfMatch = NS + "match";
+    /**
+     * Deliberately not {@code NS + "nested"}: that IRI is already the {@link #pNested}
+     * configuration predicate, and registering a property function on it would intercept
+     * any query pattern reading an {@code idx:nested} block out of a config graph.
+     */
+    public static final String pfNestedMatch = NS + "nestedMatch";
 
     // Types
     public static final Resource IndexProfile   = Vocab.resource(NS, "IndexProfile");

--- a/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/cql/CqlToLuceneCompiler.java
@@ -531,6 +531,20 @@ public class CqlToLuceneCompiler {
             return null;
         }
 
+        // A nested-scoped field stays on the block-join path even at level 0.
+        //
+        // The taxonomy drill-down matches exactly the same parents — the hierarchy facet
+        // paths of a nested scope are written onto the parent document — but it carries no
+        // child query, so nothing downstream can say WHICH child matched and luc:nestedMatch
+        // has nothing to project. Level 1+ of the same hierarchy already lifts through
+        // maybeLiftToParent, so the short-circuit made a lone level-0 equality the one
+        // filter whose compilation depended on a field happening to be declared as a
+        // hierarchy level. Root-scoped hierarchy fields keep the drill-down: they have no
+        // children, so there is nothing to lose.
+        if (mapping.findNestedDefForFieldName(field.getFieldName()) != null) {
+            return null;
+        }
+
         DrillDownQuery drillDownQuery = new DrillDownQuery(facetsConfig);
         drillDownQuery.add(hierarchy.getDimensionName(), String.valueOf(cmp.value()));
         return drillDownQuery;

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -128,6 +128,9 @@ import org.apache.jena.query.text.changes.TestDatasetMonitor;
     // luc:match property function
     , TestTextMatchPF.class
 
+    // luc:nestedMatch property function
+    , TestNestedMatchProjection.class
+
     // Shared field occurrences / fan-in
     , TestSharedFieldOccurrences.class
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNestedHierarchicalFacets.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNestedHierarchicalFacets.java
@@ -425,11 +425,15 @@ public class TestNestedHierarchicalFacets {
     }
 
     @Test
-    public void testSingleLevelTopFilterStillUsesFlattenedParentField() {
+    public void testSingleLevelTopFilterLiftsToParent() {
         CqlExpression cql = CqlParser.parse("""
             {"op":"=","args":[{"property":"urn:jena:lucene:field#identifierType"},"Company"]}
             """);
 
+        // Level 0 of a nested hierarchy lifts through ToParentBlockJoinQuery like level 1
+        // (testSingleLevelLeafFilterLiftsToParent) and like a nested field in no hierarchy
+        // at all. It previously compiled to a taxonomy DrillDownQuery on the parent, which
+        // selects the same entities but carries no child query for luc:nestedMatch.
         List<TextHit> results = textIndex.queryWithCql(null, null, cql, null, null, null, 10, null);
         assertEquals(Set.of(NS + "bh1", NS + "bh2", NS + "bh3"), toSubjectSet(results));
     }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNestedMatchProjection.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNestedMatchProjection.java
@@ -391,36 +391,62 @@ public class TestNestedMatchProjection {
     }
 
     /**
-     * A lone {@code =} on the <em>first level</em> of an {@code idx:facetHierarchy} is
-     * answered by the taxonomy: the compiler emits a {@code DrillDownQuery} against the
-     * parent's facet ordinals instead of lifting a child query through a block join. No
-     * block join means no child query to recover, so nothing is projected.
+     * A lone {@code =} on the <em>first level</em> of an {@code idx:facetHierarchy}
+     * projects, like any other nested clause.
      * <p>
-     * The filter itself is unaffected — the right entities come back. Only the
-     * "which child" projection is unavailable. Using {@code in} instead of {@code =},
-     * or pairing the clause with a sibling on the same scope, takes the block-join path
-     * and does project; the sibling-pair case is
-     * {@link #testMatchingChildRecordIsProjected}, which passes with this same hierarchy
-     * configured.
+     * It did not before: the compiler answered a level-0 equality with a taxonomy
+     * {@code DrillDownQuery} against the parent's facet ordinals, which matches the same
+     * parents but carries no child query. That made a single facet tick — the most
+     * ordinary interaction a UI has, and the one that emits {@code =} rather than
+     * {@code in} — the one case where the matching child could not be recovered.
+     * <p>
+     * {@code =} and {@code in} over the same single value must now agree on both the
+     * entities and the projection.
      */
     @Test
-    public void testLevelZeroHierarchyEqualityProjectsNoRecords() {
+    public void testLevelZeroHierarchyEqualityProjectsLikeAnyNestedClause() {
         List<SearchHit> viaEquality = search("""
             {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionRole"},"Principal Investigator"]}
             """);
         assertEquals(3, viaEquality.size(), "every report has a Principal Investigator");
         for (SearchHit hit : viaEquality) {
-            assertTrue(hit.getNestedMatches().isEmpty(),
-                "a taxonomy drill-down carries no child query to project from");
+            assertEquals(1, hit.getNestedMatches().size(),
+                "the attribution that carried the matching role is recoverable");
         }
 
         List<SearchHit> viaIn = search("""
             {"op":"in","args":[{"property":"urn:jena:lucene:field#attributionRole"},["Principal Investigator"]]}
             """);
-        assertEquals(3, viaIn.size(), "same entities via the block-join path");
+        assertEquals(3, viaIn.size(), "'in' over one value selects the same entities");
         for (SearchHit hit : viaIn) {
             assertEquals(1, hit.getNestedMatches().size(),
-                "'in' lifts through a block join, so the matching child is recoverable");
+                "and projects the same single child record");
+        }
+    }
+
+    /**
+     * The projection must not depend on whether a field happens to be declared as a
+     * hierarchy level: {@code attributionRole} is level 0 of one, {@code attributionNote}
+     * belongs to no hierarchy at all, and a lone equality on either behaves the same way.
+     */
+    @Test
+    public void testHierarchyAndNonHierarchyFieldsProjectAlike() {
+        List<SearchHit> viaHierarchyField = search("""
+            {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionRole"},"Reviewer"]}
+            """);
+        List<SearchHit> viaPlainField = search("""
+            {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionNote"},"internal-Reviewer"]}
+            """);
+
+        assertEquals(viaPlainField.size(), viaHierarchyField.size(),
+            "the two clauses select the same reports");
+        for (SearchHit hit : viaHierarchyField) {
+            assertEquals(1, hit.getNestedMatches().size(),
+                "hierarchy level-0 field projects one child");
+        }
+        for (SearchHit hit : viaPlainField) {
+            assertEquals(1, hit.getNestedMatches().size(),
+                "non-hierarchy field projects one child");
         }
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNestedMatchProjection.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNestedMatchProjection.java
@@ -1,0 +1,506 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.HierarchyDef;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
+import org.apache.jena.query.text.ShaclIndexMapping.NestedDef;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.query.text.cql.CqlParser;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Projection of the <em>child records that satisfied the filter</em> back out of the
+ * block-join index — {@link SearchHit#getNestedMatches()} and the {@code luc:nestedMatch}
+ * property function.
+ * <p>
+ * The fixture is the {@code prov:qualifiedAttribution} scope also used by
+ * {@link TestCorrelatedNestedAttribution}: each report carries two attribution children,
+ * so "which child matched" has a wrong answer available and the tests can tell the two
+ * apart. The grouping node is the point of the feature — with two matching children,
+ * a flat (field, value) stream cannot say which role goes with which agent.
+ */
+public class TestNestedMatchProjection {
+
+    private static final String EX = "http://example.org/mining/";
+    private static final String PROV = "http://www.w3.org/ns/prov#";
+    private static final String FIELD_NS = "urn:jena:lucene:field#";
+
+    private static final Node REPORT_CLASS = NodeFactory.createURI(EX + "MiningReport");
+    private static final Node LABEL_PRED = RDFS.label.asNode();
+    private static final Node QUALIFIED_ATTRIBUTION = NodeFactory.createURI(PROV + "qualifiedAttribution");
+    private static final Node HAD_ROLE = NodeFactory.createURI(PROV + "hadRole");
+    private static final Node AGENT = NodeFactory.createURI(PROV + "agent");
+    private static final Node NOTE = NodeFactory.createURI(PROV + "note");
+
+    private static final String ATTRIBUTION_SCOPE =
+        PathFactory.pathLink(QUALIFIED_ATTRIBUTION).toString();
+
+    private static final String ROLE_FIELD = FIELD_NS + "attributionRole";
+    private static final String AGENT_FIELD = FIELD_NS + "attributionAgentExact";
+    private static final String NOTE_FIELD = FIELD_NS + "attributionNote";
+    private static final String ROLE_AGENT_DIM = "attributionRole_attributionAgentExact";
+
+    private Dataset dataset;
+    private ShaclTextIndexLucene textIndex;
+
+    @BeforeEach
+    public void setUp() {
+        TextQuery.init();
+
+        FieldDef entityType = new FieldDef("entityType", FieldType.KEYWORD, null, null,
+            true, true, true, false, false, false, false,
+            NodeFactory.createURI(FIELD_NS + "entityType"));
+
+        FieldDef title = new FieldDef("title", FieldType.TEXT, null, null,
+            true, true, false, false, false, true, false,
+            NodeFactory.createURI(FIELD_NS + "title"));
+
+        FieldDef attributionRole = new FieldDef("attributionRole", FieldType.KEYWORD, null, null,
+            true, true, true, false, true, false, false,
+            NodeFactory.createURI(ROLE_FIELD));
+
+        FieldDef attributionAgentExact = new FieldDef("attributionAgentExact", FieldType.KEYWORD, null, null,
+            true, true, false, false, true, false, false,
+            NodeFactory.createURI(AGENT_FIELD));
+
+        // Indexed but NOT stored: filterable, and deliberately absent from the projection.
+        FieldDef attributionNote = new FieldDef("attributionNote", FieldType.KEYWORD, null, null,
+            false, true, false, false, true, false, false,
+            NodeFactory.createURI(NOTE_FIELD));
+
+        List<FieldOccurrence> rootOccurrences = List.of(
+            rootOccurrence(entityType, RDF.type.asNode()),
+            rootOccurrence(title, LABEL_PRED));
+
+        List<FieldOccurrence> attributionOccurrences = List.of(
+            nestedSeqOccurrence(attributionRole, HAD_ROLE, LABEL_PRED),
+            nestedSeqOccurrence(attributionAgentExact, AGENT, LABEL_PRED),
+            nestedLinkOccurrence(attributionNote, NOTE));
+
+        // A hierarchy over the scope, as the demo config has over (analyte, gradeUnits).
+        // It changes how a LONE '=' on level 0 compiles — see
+        // testLevelZeroHierarchyEqualityProjectsNoRecords.
+        HierarchyDef roleAgentHierarchy = new HierarchyDef(ROLE_AGENT_DIM,
+            Arrays.asList(attributionRole, attributionAgentExact));
+
+        NestedDef attributions = new NestedDef(
+            ATTRIBUTION_SCOPE,
+            PathFactory.pathLink(QUALIFIED_ATTRIBUTION),
+            List.of(new JoinStep(QUALIFIED_ATTRIBUTION, false)),
+            Collections.singleton(QUALIFIED_ATTRIBUTION),
+            attributionOccurrences,
+            Collections.singletonList(roleAgentHierarchy));
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(EX + "MiningReportShape"),
+            Collections.singleton(REPORT_CLASS),
+            "uri", "docType",
+            Arrays.asList(entityType, title, attributionRole, attributionAgentExact, attributionNote),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.singletonList(attributions));
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+
+        textIndex = new ShaclTextIndexLucene(
+            new ByteBuffersDirectory(), new ByteBuffersDirectory(), config);
+
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), textIndex, mapping);
+
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+        loadData();
+    }
+
+    private void loadData() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model m = dataset.getDefaultModel();
+
+            addRole(m, "PrincipalInvestigator", "Principal Investigator");
+            addRole(m, "Reviewer", "Reviewer");
+
+            addAgent(m, "author-jones", "Dr Sarah Jones");
+            addAgent(m, "author-patel", "Dr Priya Patel");
+            addAgent(m, "author-chen", "Prof Wei Chen");
+
+            addReport(m, "report-mia-2023", "Mount Isa Copper Resource Estimation 2023",
+                new String[][] {
+                    {"PrincipalInvestigator", "author-jones"},
+                    {"Reviewer", "author-patel"}
+                });
+
+            // Jones is only the Reviewer here.
+            addReport(m, "report-mia-2021", "Mount Isa Lead-Zinc Exploration Summary",
+                new String[][] {
+                    {"PrincipalInvestigator", "author-chen"},
+                    {"Reviewer", "author-jones"}
+                });
+
+            addReport(m, "report-bod-2022", "Boddington Gold Production Report 2022",
+                new String[][] {
+                    {"PrincipalInvestigator", "author-patel"},
+                    {"Reviewer", "author-chen"}
+                });
+
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private void addRole(Model m, String id, String label) {
+        m.add(ResourceFactory.createResource(EX + id), RDFS.label, label);
+    }
+
+    private void addAgent(Model m, String id, String label) {
+        Resource agent = ResourceFactory.createResource(EX + id);
+        m.add(agent, RDF.type, ResourceFactory.createResource(EX + "Author"));
+        m.add(agent, RDFS.label, label);
+    }
+
+    private void addReport(Model m, String id, String label, String[][] attributions) {
+        Resource report = ResourceFactory.createResource(EX + id);
+        m.add(report, RDF.type, ResourceFactory.createResource(EX + "MiningReport"));
+        m.add(report, RDFS.label, label);
+        for (int i = 0; i < attributions.length; i++) {
+            Resource attribution = ResourceFactory.createResource(EX + id + "-attribution-" + i);
+            m.add(report, ResourceFactory.createProperty(PROV + "qualifiedAttribution"), attribution);
+            m.add(attribution, ResourceFactory.createProperty(PROV + "hadRole"),
+                ResourceFactory.createResource(EX + attributions[i][0]));
+            m.add(attribution, ResourceFactory.createProperty(PROV + "agent"),
+                ResourceFactory.createResource(EX + attributions[i][1]));
+            m.add(attribution, ResourceFactory.createProperty(PROV + "note"),
+                "internal-" + attributions[i][0]);
+        }
+    }
+
+    private static FieldOccurrence rootOccurrence(FieldDef field, Node predicate) {
+        return new FieldOccurrence(field, PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null, null, null, null);
+    }
+
+    private static FieldOccurrence nestedSeqOccurrence(FieldDef field, Node first, Node second) {
+        return new FieldOccurrence(field,
+            PathFactory.pathSeq(PathFactory.pathLink(first), PathFactory.pathLink(second)),
+            List.of(List.of(new JoinStep(first, false), new JoinStep(second, false))),
+            new LinkedHashSet<>(Arrays.asList(first, second)),
+            null, null, null, ATTRIBUTION_SCOPE);
+    }
+
+    private static FieldOccurrence nestedLinkOccurrence(FieldDef field, Node predicate) {
+        return new FieldOccurrence(field, PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate),
+            null, null, null, ATTRIBUTION_SCOPE);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    // ---- helpers ---------------------------------------------------------------------
+
+    private List<SearchHit> search(String filterJson) {
+        return textIndex.searchWithHitIds(
+            null, null, CqlParser.parse(filterJson), null, null, null, 10);
+    }
+
+    private static SearchHit hitFor(List<SearchHit> hits, String uri) {
+        for (SearchHit hit : hits) {
+            if (hit.getEntityNode().isURI() && hit.getEntityNode().getURI().equals(uri)) {
+                return hit;
+            }
+        }
+        return null;
+    }
+
+    /** field IRI → values, for one projected child record. */
+    private static Map<String, List<String>> fieldsOf(NestedMatch record) {
+        Map<String, List<String>> byField = new HashMap<>();
+        for (FieldMatch fm : record.getFieldMatches()) {
+            byField.computeIfAbsent(fm.getFieldIRI().getURI(), k -> new ArrayList<>())
+                .add(fm.getValue() == null ? null : fm.getValue().getLiteralLexicalForm());
+        }
+        return byField;
+    }
+
+    private static final String PI_AND_JONES = """
+        {"op":"and","args":[
+          {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionRole"},"Principal Investigator"]},
+          {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionAgentExact"},"Dr Sarah Jones"]}
+        ]}
+        """;
+
+    /** Both attributions of mia-2023 match, one clause each — two children, one parent. */
+    private static final String PI_OR_REVIEWER = """
+        {"op":"or","args":[
+          {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionRole"},"Principal Investigator"]},
+          {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionRole"},"Reviewer"]}
+        ]}
+        """;
+
+    // ---- index layer -----------------------------------------------------------------
+
+    @Test
+    public void testMatchingChildRecordIsProjected() {
+        List<SearchHit> hits = search(PI_AND_JONES);
+        assertEquals(1, hits.size(), "only mia-2023 has Jones as Principal Investigator");
+
+        List<NestedMatch> records = hits.get(0).getNestedMatches();
+        assertEquals(1, records.size(), "exactly one attribution child satisfied the filter");
+
+        Map<String, List<String>> fields = fieldsOf(records.get(0));
+        assertEquals(List.of("Principal Investigator"), fields.get(ROLE_FIELD));
+        assertEquals(List.of("Dr Sarah Jones"), fields.get(AGENT_FIELD));
+    }
+
+    @Test
+    public void testNonMatchingSiblingChildIsNotProjected() {
+        List<SearchHit> hits = search(PI_AND_JONES);
+        List<NestedMatch> records = hits.get(0).getNestedMatches();
+
+        Set<String> values = new HashSet<>();
+        for (NestedMatch record : records) {
+            for (List<String> vs : fieldsOf(record).values()) {
+                values.addAll(vs);
+            }
+        }
+        assertFalse(values.contains("Reviewer"),
+            "the sibling attribution did not satisfy the filter");
+        assertFalse(values.contains("Dr Priya Patel"),
+            "the sibling attribution's agent must not leak into the projection");
+    }
+
+    @Test
+    public void testUnstoredNestedFieldIsNotProjected() {
+        List<SearchHit> hits = search(PI_AND_JONES);
+        Map<String, List<String>> fields = fieldsOf(hits.get(0).getNestedMatches().get(0));
+        assertFalse(fields.containsKey(NOTE_FIELD),
+            "attributionNote is idx:stored false — indexed, but nothing to project");
+    }
+
+    /**
+     * The case a flat (field, value) stream cannot express: two children of the same
+     * parent match, and each pairs its own role with its own agent.
+     */
+    @Test
+    public void testTwoMatchingChildrenAreProjectedAsSeparateRecords() {
+        List<SearchHit> hits = search(PI_OR_REVIEWER);
+        SearchHit mia2023 = hitFor(hits, EX + "report-mia-2023");
+        assertNotNull(mia2023, "mia-2023 matches both branches of the OR");
+
+        List<NestedMatch> records = mia2023.getNestedMatches();
+        assertEquals(2, records.size(), "both attribution children satisfied the filter");
+
+        assertEquals(2, new HashSet<>(List.of(
+                records.get(0).getRecordId(), records.get(1).getRecordId())).size(),
+            "each child record gets its own grouping node");
+
+        Map<String, String> roleToAgent = new HashMap<>();
+        for (NestedMatch record : records) {
+            Map<String, List<String>> fields = fieldsOf(record);
+            roleToAgent.put(fields.get(ROLE_FIELD).get(0), fields.get(AGENT_FIELD).get(0));
+        }
+        assertEquals(Map.of(
+                "Principal Investigator", "Dr Sarah Jones",
+                "Reviewer", "Dr Priya Patel"),
+            roleToAgent,
+            "role and agent stay paired within each child record");
+    }
+
+    @Test
+    public void testRootOnlyFilterProjectsNoRecords() {
+        List<SearchHit> hits = search("""
+            {"op":"=","args":[{"property":"urn:jena:lucene:field#entityType"},"http://example.org/mining/MiningReport"]}
+            """);
+        assertEquals(3, hits.size(), "all three reports match the root clause");
+        for (SearchHit hit : hits) {
+            assertTrue(hit.getNestedMatches().isEmpty(),
+                "no nested clause in the filter, so no child was selected by one");
+        }
+    }
+
+    /**
+     * A lone {@code =} on the <em>first level</em> of an {@code idx:facetHierarchy} is
+     * answered by the taxonomy: the compiler emits a {@code DrillDownQuery} against the
+     * parent's facet ordinals instead of lifting a child query through a block join. No
+     * block join means no child query to recover, so nothing is projected.
+     * <p>
+     * The filter itself is unaffected — the right entities come back. Only the
+     * "which child" projection is unavailable. Using {@code in} instead of {@code =},
+     * or pairing the clause with a sibling on the same scope, takes the block-join path
+     * and does project; the sibling-pair case is
+     * {@link #testMatchingChildRecordIsProjected}, which passes with this same hierarchy
+     * configured.
+     */
+    @Test
+    public void testLevelZeroHierarchyEqualityProjectsNoRecords() {
+        List<SearchHit> viaEquality = search("""
+            {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionRole"},"Principal Investigator"]}
+            """);
+        assertEquals(3, viaEquality.size(), "every report has a Principal Investigator");
+        for (SearchHit hit : viaEquality) {
+            assertTrue(hit.getNestedMatches().isEmpty(),
+                "a taxonomy drill-down carries no child query to project from");
+        }
+
+        List<SearchHit> viaIn = search("""
+            {"op":"in","args":[{"property":"urn:jena:lucene:field#attributionRole"},["Principal Investigator"]]}
+            """);
+        assertEquals(3, viaIn.size(), "same entities via the block-join path");
+        for (SearchHit hit : viaIn) {
+            assertEquals(1, hit.getNestedMatches().size(),
+                "'in' lifts through a block join, so the matching child is recoverable");
+        }
+    }
+
+    @Test
+    public void testNegatedNestedClauseProjectsNoRecords() {
+        List<SearchHit> hits = search("""
+            {"op":"and","args":[
+              {"op":"=","args":[{"property":"urn:jena:lucene:field#entityType"},"http://example.org/mining/MiningReport"]},
+              {"op":"not","args":[
+                {"op":"=","args":[{"property":"urn:jena:lucene:field#attributionAgentExact"},"Dr Sarah Jones"]}
+              ]}
+            ]}
+            """);
+        assertEquals(1, hits.size(), "only bod-2022 has no Jones attribution");
+        assertTrue(hits.get(0).getNestedMatches().isEmpty(),
+            "a negated clause describes children that must NOT match — they are not results");
+    }
+
+    // ---- property function layer ------------------------------------------------------
+
+    @Test
+    public void testNestedMatchPFGroupsFieldsByRecord() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n"
+            + "SELECT ?s ?record ?field ?value WHERE {\n"
+            + "  (?hit ?s) luc:query (\"default\" \"default\" \"\" '" + inline(PI_OR_REVIEWER) + "' \"\" 10 0) .\n"
+            + "  (?hit ?record ?field ?value) luc:nestedMatch () .\n"
+            + "}";
+
+        Map<String, Map<String, String>> byRecord = new HashMap<>();
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                QuerySolution sol = rs.next();
+                assertNotNull(sol.get("record"), "?record must be bound");
+                if (!sol.getResource("s").getURI().equals(EX + "report-mia-2023")) {
+                    continue;
+                }
+                byRecord
+                    .computeIfAbsent(sol.get("record").toString(), k -> new HashMap<>())
+                    .put(sol.getResource("field").getURI(), sol.getLiteral("value").getLexicalForm());
+            }
+        } finally {
+            dataset.end();
+        }
+
+        assertEquals(2, byRecord.size(), "two child records for mia-2023");
+        Set<Map<String, String>> rows = new HashSet<>(byRecord.values());
+        assertEquals(Set.of(
+                Map.of(ROLE_FIELD, "Principal Investigator", AGENT_FIELD, "Dr Sarah Jones"),
+                Map.of(ROLE_FIELD, "Reviewer", AGENT_FIELD, "Dr Priya Patel")),
+            rows,
+            "each ?record groups one child's fields, correlated");
+    }
+
+    @Test
+    public void testNestedMatchPFJoinsOnBoundHit() {
+        String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n"
+            + "SELECT ?s ?value WHERE {\n"
+            + "  (?hit ?s) luc:query (\"default\" \"default\" \"\" '" + inline(PI_AND_JONES) + "' \"\" 10 0) .\n"
+            + "  (?hit ?record ?field ?value) luc:nestedMatch () .\n"
+            + "  FILTER (?field = <" + AGENT_FIELD + ">)\n"
+            + "}";
+
+        Set<String> agents = new HashSet<>();
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(sparql, dataset)) {
+            ResultSet rs = qe.execSelect();
+            while (rs.hasNext()) {
+                agents.add(rs.next().getLiteral("value").getLexicalForm());
+            }
+        } finally {
+            dataset.end();
+        }
+        assertEquals(Set.of("Dr Sarah Jones"), agents,
+            "only the agent on the child that satisfied both clauses");
+    }
+
+    /** Collapse a text block into one line so it can sit inside a SPARQL string literal. */
+    private static String inline(String json) {
+        return json.replaceAll("\\s+", " ").trim();
+    }
+}


### PR DESCRIPTION
Block-join child documents were write-only. `_nestedScope` appeared when building documents and in the nested sort selector, and nowhere on the read path — so a filter could constrain on `idx:nested` fields, but nothing could report *which* child satisfied it, and stored child values were unreachable.

## The API

```sparql
(?hit ?record ?field ?value) luc:nestedMatch ()
```

Empty object list, joins to `luc:query` through `?hit` exactly like `luc:match`. **No existing SPARQL signature changes** — `luc:query`, `luc:facet` and `luc:match` are untouched.

`?record` is the point of it. When a filter selects two children of one entity, a flat `(field, value)` stream cannot say which value belongs with which key. From the demo:

| ?entity | ?record | ?field | ?value |
|---|---|---|---|
| bh-bh-001 | `_:Bhit0r0` | analyte | "Au" |
| bh-bh-001 | `_:Bhit0r0` | grade | 0.82 |
| bh-bh-001 | `_:Bhit0r0` | gradeUnits | "ppm" |
| bh-bh-001 | `_:Bhit0r1` | analyte | "Cu" |
| bh-bh-001 | `_:Bhit0r1` | grade | 0.31 |
| bh-bh-001 | `_:Bhit0r1` | gradeUnits | "pct" |

That is also why it is a new property function rather than a fifth slot on `luc:match`: widening `luc:match` would interleave parent text-match rows with child rows in one stream with no discriminator, silently changing what existing queries receive.

Registered as `luc:nestedMatch`, not `luc:nested` — `urn:jena:lucene:index#nested` is already the `idx:nested` config predicate, and a property function on that IRI would intercept queries reading a nested block out of a config graph.

## How it works

- The projection runs inside `searchWithHitIds`, the one place where the compiled query, a live searcher and valid parent doc ids coexist. Resolving children later would read doc ids against a reader that may have been refreshed since. Cost is one block-restricted child query per hit.
- Child queries come from the **compiled Lucene query**, not from CQL. The compiler has already wrapped every nested clause in a `ToParentBlockJoinQuery`, so `getChildQuery()` is exactly the "which children" predicate — and this catches both the same-child fold and single-leaf lifts. Hooking `compileSameScopeFold` alone would have missed lone clauses.
- `ParentChildrenBlockJoinQuery` restricts a child query to one parent's block, so there is no doc id arithmetic.
- `MUST_NOT` clauses are skipped: a negated clause describes children that must *not* match.
- Multi-valued child fields project every stored value, positionally aligned with their datatype/language twins. `selectStoredValue`'s guess-which-one-matched heuristic is neither needed nor correct here.
- At most 100 records per hit, logged rather than silently trimmed.

## Compiler change (commit 3)

The projection is driven by whether a nested clause compiled to a block join, which exposed an inconsistency worth fixing rather than documenting.

A lone `=` on the **first level** of an `idx:facetHierarchy` compiled to a taxonomy `DrillDownQuery` against the parent's facet ordinals. It selects exactly the same entities, but carries no child query — so there was nothing to project. Level 1+ of the same hierarchy already lifted through `maybeLiftToParent`, as does a nested field in no hierarchy at all. Only level 0 diverged, which meant a filter compiled differently because someone had declared a facet hierarchy over the field.

The user-visible shape of that: a faceted UI emits `=` for one selected value and `in` for two or more (`demo/app-static/app.js:417-422`). Ticking a single analyte returned the right boreholes with **no** assay rows; ticking a second made them appear; unticking it made them vanish. "Narrowing my search deleted the data."

Nested-scoped fields now stay on the block-join path at every hierarchy level. Root-scoped hierarchy fields keep the drill-down — they have no children, so nothing is lost and the taxonomy path stays the cheaper option. Hierarchy drill-down **facet counting** is unaffected: it goes through `getFacetCounts(..., drillDown)`, not CQL equality compilation.

The cost is the drill-down's slight efficiency edge on a lone level-0 equality over a nested field. If you'd rather keep that and take the limitation back, this is one self-contained commit (`8c3b01d`) and can be dropped without touching the rest.

## Testing

`TestNestedMatchProjection` — 10 tests, registered in `TS_Text`. Full suite **772 tests, all passing** (762 before). The fixture gives each entity two children so a wrong answer is available: the matching child is projected, the sibling is not, unstored fields do not appear, root-only and negated filters project nothing, two matching children come back as two `?record` groups with role and agent still paired, and `=` / `in` / hierarchy-level / non-hierarchy fields all project alike.

`testSingleLevelTopFilterStillUsesFlattenedParentField` asserted the entity set rather than the mechanism, so it passed unchanged — but its name described the old compilation. Renamed to `testSingleLevelTopFilterLiftsToParent` to match its level-1 sibling.

Verified end to end against the running demo on both nested kinds — the external CSV `assay` scope and the graph-derived `prov:qualifiedAttribution` scope — including the single-facet-tick case that was previously empty.

## Demo changes

`field:grade`, `field:attributionRole` and `field:attributionAgentExact` are now `idx:stored true`, with new queries `24-nested-match-assay-records.rq` and `25-nested-match-attribution-record.rq`. Storing `grade` means the index must be rebuilt when an assay value changes; the assay database remains the source of truth, as the config comment notes.

Commit 2 carries an unrelated external-delta-endpoint design note that was sitting uncommitted locally.
