### PR TITLE
Remove the ?graph slot from luc:query and move ?rank last

### DIFF
--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -2145,7 +2145,7 @@ SELECT ?value ?count WHERE {
             const offset = (this.currentPage - 1) * this.limit;
 
             const queryBranch =
-                `    { (?hit ?entity ?score ?rank ?totalHits) luc:query ('default' ${sparqlQuote(searchField)} ${sparqlQuote(term)} ${filterArg} ${sortArg} ${this.limit} ${offset}) }`;
+                `    { (?hit ?entity ?score ?totalHits ?rank) luc:query ('default' ${sparqlQuote(searchField)} ${sparqlQuote(term)} ${filterArg} ${sortArg} ${this.limit} ${offset}) }`;
 
             // Page 2+ of an unchanged filter set reuses the buckets already on screen —
             // they cannot have changed, and recomputing them is the expensive half.
@@ -3027,7 +3027,7 @@ function statsApp() {
                 const statsQuery = `${SPARQL_PREFIXES}
 SELECT ?entity ?score ?totalHits ?field ?value ?low ?high ?count
 WHERE {
-    { (?hit ?entity ?score ?rank ?totalHits) luc:query ('default' 'default' '*' '' '' 0 0) }
+    { (?hit ?entity ?score ?totalHits) luc:query ('default' 'default' '*' '' '' 0 0) }
     UNION
     { (?field ?value ?low ?high ?count) luc:facet ('default' 'default' '*' ${sparqlQuote(facetFieldsJson)} '' 0 0) }
 }`;

--- a/docs/01-user-guide.md
+++ b/docs/01-user-guide.md
@@ -81,14 +81,14 @@ These are separate on purpose.
 ### `luc:query`
 
 ```sparql
-(?hit ?entity ?score ?rank ?totalHits)
+(?hit ?entity ?score ?totalHits)
   luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
 ```
 
 Example with filter:
 
 ```sparql
-(?hit ?entity ?score ?rank ?totalHits)
+(?hit ?entity ?score ?totalHits)
   luc:query (
     "default"
     "default"
@@ -118,7 +118,7 @@ Example with sort:
 Paging — second page of 10:
 
 ```sparql
-(?hit ?entity ?score ?rank ?totalHits)
+(?hit ?entity ?score ?totalHits)
   luc:query ("default" "default" "learning" "" "" 10 10) .
 ```
 

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -29,18 +29,30 @@ Public API rules:
 ### Syntax
 
 ```sparql
-(?hit ?entity ?score ?rank ?totalHits)
+(?hit ?entity ?score ?totalHits)
   luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
 ```
 
-Subject arity may be 1 to 6:
+Subject arity may be 1 to 5:
 
 - `?hit`
 - `?hit ?entity`
 - `?hit ?entity ?score`
-- `?hit ?entity ?score ?rank`
-- `?hit ?entity ?score ?rank ?totalHits`
-- `?hit ?entity ?score ?rank ?totalHits ?graph`
+- `?hit ?entity ?score ?totalHits`
+- `?hit ?entity ?score ?totalHits ?rank`
+
+`?rank` sits last rather than beside `?score`, where it would read more naturally. It was
+added after the earlier positions were already in use, and appending it was the only
+placement that left an existing subject list binding what it already bound.
+
+There is no `?graph` slot. A sixth position briefly existed and never bound a value: a
+SHACL document is assembled from a union view over every graph, so an entity's indexed
+values may come from several graphs at once and there is no single source graph to bind.
+Graph provenance is modelled as a doc-level field instead — see
+[graph filtering target model](2026-04-08-graph-filtering-target-model.md) and
+[source graph indexing](2026-07-31_source_graph_indexing_design.md), both design-only.
+A query still naming the old slot is rejected at build time rather than silently binding
+`?graph` to a rank integer.
 
 Object arity is always exactly 7.
 
@@ -73,8 +85,8 @@ Unknown field IRIs fail fast.
 | `?hit` | blank node | Query-scoped join key for `luc:match` |
 | `?entity` | IRI | Matched entity |
 | `?score` | float | Lucene relevance score; for a sorted search, `1/(1+rank)` (see below) |
-| `?rank` | `xsd:integer` | Position in the whole result set, counting from 0. Continues across pages: `offset 5` starts at rank 5 |
 | `?totalHits` | `xsd:integer` | Total matching hits across the whole result set, independent of `limit` and `offset` |
+| `?rank` | `xsd:integer` | Position in the whole result set, counting from 0. Continues across pages: `offset 5` starts at rank 5 |
 
 `?match` is not part of `luc:query`.
 
@@ -129,7 +141,7 @@ Search a specific field IRI:
 Search with a CQL filter:
 
 ```sparql
-(?hit ?entity ?score ?rank ?totalHits)
+(?hit ?entity ?score ?totalHits)
   luc:query (
     "default"
     "default"
@@ -176,7 +188,7 @@ Multi-sort:
 `limit` and `offset` form a page window. Fetch the second page of 10 results:
 
 ```sparql
-(?hit ?entity ?score ?rank ?totalHits)
+(?hit ?entity ?score ?totalHits)
   luc:query ("default" "default" "learning" "" "" 10 10) .
 ```
 

--- a/docs/2026-04-08-graph-filtering-target-model.md
+++ b/docs/2026-04-08-graph-filtering-target-model.md
@@ -2,6 +2,10 @@
 
 Status: design only
 
+Refined by [2026-07-31_source_graph_indexing_design.md](2026-07-31_source_graph_indexing_design.md),
+which settles the index-time flag, the multi-valued semantics, and where collection has to
+happen. The `?graph` slot this note rules out was removed from `luc:query` on 2026-07-31.
+
 ## Decision
 
 Do not add graph-specific slots to the SHACL property-function signatures.

--- a/docs/2026-07-31_source_graph_indexing_design.md
+++ b/docs/2026-07-31_source_graph_indexing_design.md
@@ -1,0 +1,177 @@
+---
+title: "source graph indexing"
+date: "2026-07-31"
+---
+
+# 2026-07-31 Source Graph Indexing
+
+## Status
+
+**Designed, not built.** Nothing in this note is implemented.
+
+Refines [2026-04-08-graph-filtering-target-model.md](2026-04-08-graph-filtering-target-model.md),
+which chose the shape — graph scoping is a doc-level field, not a result slot — but left
+"indexing support to collect source graphs while traversing fields" as a future note. This
+note settles the three things that were open: what turns it on, what the field contains
+when an entity spans graphs, and where the collection actually has to happen.
+
+It also records why `?graph` was removed from `luc:query` on 2026-07-31, which is the part
+already carried out.
+
+## What exists today
+
+Nothing. Graph provenance is inert end to end, in a way that reads as implemented:
+
+| Surface | State |
+|---|---|
+| `SearchHit.graph` | **Removed 2026-07-31.** Its one construction site passed `null` unconditionally |
+| `?graph` slot on `luc:query` | **Removed 2026-07-31.** Subject arity is now 1–5, `?rank` last |
+| `graphURI` parameter on `ShaclTextIndexLucene.searchWithHitIds` | Accepted and never read. Threaded down from `SearchExecution` to match the classic signature |
+| `EntityDefinition.graphField` | Classic mode only. Populated in `TextIndexLucene`, never in the SHACL path |
+
+The classic (triple-per-document) index does support a graph field, and does filter on it
+by appending `graphField:<iri>` to the query string. That mechanism does not carry over,
+for the reason in the next section.
+
+### Why `?graph` was removed rather than populated
+
+`ShaclTextDocProducer.allGraphsView()` builds a `GraphUnionRead` over the default graph
+plus every named graph, and the entity document is assembled from that union. An entity's
+indexed values can therefore originate in several graphs at once — which is not an edge
+case but the normal shape whenever description is split across graphs, e.g. a base record
+in one graph and a curation or enrichment layer in another.
+
+So a per-hit `?graph` binding has no defensible value. Binding the first graph seen would
+be arbitrary; binding one row per contributing graph would multiply hits and quietly break
+`?totalHits` and paging. The slot was removed, and this design puts the provenance where it
+can be multi-valued without distorting the result set: on the document.
+
+`luc:query`'s subject list is now `(?hit ?entity ?score ?totalHits ?rank)`, and a six-element
+list is rejected at build time so a query written against the old shape fails loudly rather
+than binding `?graph` to a rank integer.
+
+## Decision
+
+Add an **opt-in index-time flag** that records, per entity document, **every graph that
+contributed an indexed value**, as a multi-valued KEYWORD field under the reserved IRI the
+2026-04-08 note already named:
+
+```text
+urn:jena:lucene:field#sourceGraph
+```
+
+Assembler flag, on the index config rather than per shape:
+
+```turtle
+<#index> a text:TextIndexLucene ;
+    text:shapes <#shapes> ;
+    idx:storeGraph true ;      # default false
+    .
+```
+
+### Multi-valued, not single
+
+An entity spanning graphs A and B gets both. The alternative — a single "the graph",
+defined as whichever graph holds the `rdf:type` triple that matched the shape target — is
+rejected. It is defensible in isolation and it is exactly wrong in the case that motivates
+asking: an entity typed in a base graph but enriched from a curation graph would report
+only the base graph, and a filter for the curation graph would not return it. A field that
+is accurate until the data gets interesting is worse than no field, because it is trusted.
+
+Multi-valued means the filter semantics are "this entity has at least one indexed value
+sourced from graph X", as the 2026-04-08 note specified. That is an honest reading of a
+union-built document. It is not "this entity lives in graph X", and the documentation must
+not imply that it is, because for a split entity no such statement exists.
+
+### Opt-in, not always on
+
+Three reasons the flag defaults to false:
+
+- It costs index size on every document, and multi-valued means the cost scales with how
+  split the data is.
+- Collecting it requires the value traversal to track provenance per value (see below),
+  which is work the common single-graph deployment has no use for.
+- For a single-graph dataset the field is a constant, and a constant field is worse than
+  absent: it invites filters that look meaningful and always match everything.
+
+## Where the collection has to happen
+
+This is the part the 2026-04-08 note deferred, and it is the bulk of the work.
+
+`ShaclEntityBuilder.buildEntity` receives the union `Graph` and resolves each field's
+values through it. A `GraphUnionRead` does not report which member graph produced a triple,
+so provenance cannot be recovered after the fact from the union view. Two options:
+
+1. **Resolve per graph.** Iterate the contributing graphs and run value resolution against
+   each, unioning the results and recording which pass produced values. Straightforward and
+   obviously correct, but multiplies traversal cost by the graph count, which is the wrong
+   trade for a deployment with many small graphs.
+2. **Ask the quad store per resolved value.** Resolve as now, then for each resolved value
+   look up the quad(s) that produced it via `baseDataset.find(ANY, s, p, o)` and collect
+   their graph nodes. One extra lookup per indexed value, and it degrades gracefully — the
+   flag being off means none of it runs.
+
+Option 2 is preferred, with the caveat that a value reached through a multi-step join path
+has more than one contributing triple; the honest answer is to collect the graphs of every
+triple along the path, not just the last hop. That is what makes the field mean "contributed
+to", which is what the filter semantics need.
+
+### Cases that need a decision when built
+
+- **`idx:externalSource` children.** Nested records built from a CSV/TSV file have no source
+  graph at all. They should contribute nothing to `sourceGraph`, not a placeholder IRI.
+- **The default graph.** Needs a stable, documented representation. `urn:x-arq:DefaultGraph`
+  is what Jena already uses internally and is the least surprising choice, but it must be
+  written down, since users will type it into filters by hand.
+- **Nested documents.** Whether the field lands on the parent only, or on child documents
+  too. Parent-only is enough for the stated filtering use case and avoids widening the
+  block-join surface.
+- **Incremental update.** `ShaclTextDocProducer` rebuilds the whole entity document on
+  change, so the field is recomputed wholesale and needs no delta logic — but that also
+  means a graph deletion only drops out of `sourceGraph` once something triggers a rebuild
+  of that entity.
+
+## What this buys
+
+Because it lands as a normal KEYWORD `FieldDef` rather than a special case, the existing
+machinery applies unchanged:
+
+- **CQL filtering** — restrict a search to entities with content from a graph:
+
+  ```json
+  {"op":"=","args":[{"property":"urn:jena:lucene:field#sourceGraph"},"http://example.org/graph/A"]}
+  ```
+
+- **Faceting** — `luc:facet` over `sourceGraph` gives hit counts per contributing graph,
+  which is the more useful shape of the original question: not "where did this one hit come
+  from" but "how is this result set distributed across graphs".
+
+Neither needs new query-side code, which is the main argument for this shape over reviving
+a result slot.
+
+## Non-goals
+
+- No `?graph` result slot on `luc:query`, `luc:match`, or `luc:nestedMatch`. This reaffirms
+  the 2026-04-08 decision; the slot that existed until 2026-07-31 was contrary to it.
+- No per-match or per-value graph provenance in results. The field is doc-level.
+- No index-time graph restriction (indexing only selected graphs). That remains the separate
+  mechanism the 2026-04-08 note describes, and the two compose: with indexing restricted to
+  one graph, `sourceGraph` reflects only that graph anyway.
+- No use of the dead `graphURI` parameter on `searchWithHitIds`. If this is built, that
+  parameter should be deleted rather than wired up — filtering goes through CQL like every
+  other field.
+
+## Testing notes
+
+Per the repo's test discipline, the shape that must be tested is the one that would be
+recommended, at real cardinality:
+
+- An entity whose values come from **two** graphs reports both. This is the case the
+  single-valued design would have got wrong, so it is the test that has to exist.
+- A filter on graph B returns an entity typed in graph A but enriched from B.
+- With `idx:storeGraph` absent or false, no `sourceGraph` field is written and a filter
+  naming it fails as an unknown field rather than silently matching nothing.
+- Default-graph-only data reports the documented default-graph IRI, not an absent field.
+- Faceting on `sourceGraph` counts an entity spanning A and B once under each — and the
+  facet counts therefore sum to more than `?totalHits`, which needs to be stated in the
+  docs or it will be read as a bug.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,12 +17,14 @@ This doc set covers the SHACL/entity-per-document search model in `jena-text`.
 | External content (CSV/TSV) | Done | `idx:externalSource` builds nested children from a tabular file; bulk build only |
 | External delta endpoint | Designed | NDJSON deltas over HTTP, via opt-in retained rows. Not built — at reduced volume, load the values as RDF instead |
 | Graph scoping model | Designed | Reserved synthetic field `urn:jena:lucene:field#sourceGraph`; implementation deferred |
+| Source graph indexing | Designed | `idx:storeGraph` flag writing multi-valued `sourceGraph`. Not built — `?graph` was removed from `luc:query` instead, since a union-built document has no single source graph |
 | Highlight API | Deferred | Reserved for later, not active in the current `luc:query` signature |
 
 ## Core Rules
 
 - `luc:query` object arguments are exactly `(indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)`.
 - `luc:facet` object arguments are exactly `(indexSelector fieldSpec queryString facetFields cqlFilter maxValues minCount)`.
+- `luc:query`'s subject list is 1 to 5 of `(?hit ?entity ?score ?totalHits ?rank)`; there is no `?graph` slot.
 - `luc:query` does not expose `?match`.
 - `luc:match` is the only match-detail API.
 - Use `""` placeholders for unused `cqlFilter` and `sortSpec`.

--- a/jena-text/src/main/java/org/apache/jena/query/text/SearchHit.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SearchHit.java
@@ -39,17 +39,15 @@ public class SearchHit {
     private final int rank;
     private final Node entityNode;
     private final float score;
-    private final Node graph;
     private final int luceneDocId;
     private List<FieldMatch> fieldMatches;
     private List<NestedMatch> nestedMatches;
 
-    public SearchHit(int index, Node entityNode, float score, Node graph, int luceneDocId) {
+    public SearchHit(int index, Node entityNode, float score, int luceneDocId) {
         this.hitId = NodeFactory.createBlankNode("hit" + index);
         this.rank = index;
         this.entityNode = entityNode;
         this.score = score;
-        this.graph = graph;
         this.luceneDocId = luceneDocId;
     }
 
@@ -65,7 +63,6 @@ public class SearchHit {
 
     public Node getEntityNode() { return entityNode; }
     public float getScore() { return score; }
-    public Node getGraph() { return graph; }
     public int getLuceneDocId() { return luceneDocId; }
 
     public List<FieldMatch> getFieldMatches() {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -659,7 +659,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                 if (uri != null) {
                     Node entityNode = TextQueryFuncs.stringToNode(uri);
                     float score = luceneSort == null ? sd.score : rankScore(idx);
-                    results.add(new SearchHit(idx++, entityNode, score, null, sd.doc));
+                    results.add(new SearchHit(idx++, entityNode, score, sd.doc));
                 }
             }
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextQueryPF.java
@@ -59,13 +59,22 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Supported argument format:
  * <pre>
- * (?hit ?entity ?score ?rank ?totalHits ?graph) luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
+ * (?hit ?entity ?score ?totalHits ?rank) luc:query (indexSelector fieldSpec queryString cqlFilter sortSpec limit offset)
  * </pre>
  * <p>
  * {@code ?rank} is the hit's position in the whole result set, counting from 0. Result
  * order cannot be recovered from {@code ?score}: a match-all query scores every document
  * identically and relevance scores tie, so a consumer that receives an unordered result
  * set — a {@code CONSTRUCT} graph — needs the rank to restore the order.
+ * <p>
+ * It is last, rather than next to {@code ?score} where it reads more naturally, because it
+ * was added after the earlier positions were in use; appending was the only placement that
+ * left an existing subject list binding what it already bound.
+ * <p>
+ * There is deliberately no {@code ?graph} slot. A SHACL-mode document is built from a union
+ * view over every graph, so an entity's indexed values may come from several graphs at once
+ * and no single source graph exists to bind. Graph provenance is instead a doc-level field —
+ * see {@code docs/2026-04-08-graph-filtering-target-model.md}.
  * <p>
  * {@code ?hit} is a query-scoped blank node identifier for joining with {@code luc:match}.
  * The second string literal is the field specification: {@code "default"} searches all
@@ -88,9 +97,9 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
 
         if (argSubject.isList()) {
             int size = argSubject.getArgListSize();
-            if (size == 0 || size > 6) {
-                throw new QueryBuildException("Subject has " + size + " elements, must be 1-6 " +
-                    "(?hit ?entity ?score ?rank ?totalHits ?graph): " + argSubject);
+            if (size == 0 || size > 5) {
+                throw new QueryBuildException("Subject has " + size + " elements, must be 1-5 " +
+                    "(?hit ?entity ?score ?totalHits ?rank): " + argSubject);
             }
         }
 
@@ -157,8 +166,8 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         argSubject = Substitute.substitute(argSubject, binding);
         argObject = Substitute.substitute(argObject, binding);
 
-        // Subject shape: (?hit ?entity ?score ?rank ?totalHits ?graph)
-        Node hit = null, entity = null, score = null, rank = null, totalHitsNode = null, graph = null;
+        // Subject shape: (?hit ?entity ?score ?totalHits ?rank)
+        Node hit = null, entity = null, score = null, rank = null, totalHitsNode = null;
 
         if (argSubject.isList()) {
             hit = argSubject.getArg(0);
@@ -171,19 +180,14 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
                     throw new QueryExecException("Score is not a variable: " + argSubject);
             }
             if (argSubject.getArgListSize() > 3) {
-                rank = argSubject.getArg(3);
-                if (!rank.isVariable())
-                    throw new QueryExecException("Rank is not a variable: " + argSubject);
-            }
-            if (argSubject.getArgListSize() > 4) {
-                totalHitsNode = argSubject.getArg(4);
+                totalHitsNode = argSubject.getArg(3);
                 if (!totalHitsNode.isVariable())
                     throw new QueryExecException("Total hits is not a variable: " + argSubject);
             }
-            if (argSubject.getArgListSize() > 5) {
-                graph = argSubject.getArg(5);
-                if (!graph.isVariable())
-                    throw new QueryExecException("Graph is not a variable: " + argSubject);
+            if (argSubject.getArgListSize() > 4) {
+                rank = argSubject.getArg(4);
+                if (!rank.isVariable())
+                    throw new QueryExecException("Rank is not a variable: " + argSubject);
             }
         } else {
             hit = argSubject.getArg();
@@ -230,14 +234,14 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
 
         long totalHits = totalHitsNode != null ? se.getTotalHits() : -1;
         QueryIterator qIter = resultsToQueryIterator(binding, hit, entity, score, rank,
-            totalHitsNode, totalHits, graph, hits, execCxt);
+            totalHitsNode, totalHits, hits, execCxt);
         return qIter;
     }
 
     private QueryIterator resultsToQueryIterator(Binding binding,
                                                   Node hitNode, Node entityNode, Node scoreNode,
                                                   Node rankNode,
-                                                  Node totalHitsNode, long totalHits, Node graphNode,
+                                                  Node totalHitsNode, long totalHits,
                                                   Collection<SearchHit> results, ExecutionContext execCxt) {
         Var hitVar = Var.isVar(hitNode) ? Var.alloc(hitNode) : null;
         Var entityVar = (entityNode != null && Var.isVar(entityNode)) ? Var.alloc(entityNode) : null;
@@ -246,7 +250,6 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
         Var totalHitsVar = (totalHitsNode == null) ? null : Var.alloc(totalHitsNode);
         Node totalHitsValue = totalHitsVar != null
             ? NodeFactory.createLiteralDT(String.valueOf(totalHits), XSDDatatype.XSDinteger) : null;
-        Var graphVar = (graphNode == null) ? null : Var.alloc(graphNode);
 
         Function<SearchHit, Binding> converter = (SearchHit sh) -> {
             BindingBuilder bmap = Binding.builder(binding);
@@ -255,7 +258,6 @@ public class ShaclTextQueryPF extends PropertyFunctionBase {
             if (scoreVar != null) bmap.add(scoreVar, NodeFactoryExtra.floatToNode(sh.getScore()));
             if (rankVar != null) bmap.add(rankVar, NodeFactoryExtra.intToNode(sh.getRank()));
             if (totalHitsVar != null) bmap.add(totalHitsVar, totalHitsValue);
-            if (graphVar != null && sh.getGraph() != null) bmap.add(graphVar, sh.getGraph());
             return bmap.build();
         };
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestOffsetPaging.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestOffsetPaging.java
@@ -194,7 +194,7 @@ public class TestOffsetPaging {
         String q =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?totalHits WHERE {\n" +
-            "  (?hit ?s ?score ?rank ?totalHits) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 3 5)\n" +
+            "  (?hit ?s ?score ?totalHits) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 3 5)\n" +
             "} LIMIT 1";
         dataset.begin(ReadWrite.READ);
         try {
@@ -220,7 +220,7 @@ public class TestOffsetPaging {
         String q =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?rank WHERE {\n" +
-            "  (?hit ?s ?score ?rank) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 4 0)\n" +
+            "  (?hit ?s ?score ?totalHits ?rank) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 4 0)\n" +
             "}";
         dataset.begin(ReadWrite.READ);
         try (QueryExecution qe = QueryExecutionFactory.create(QueryFactory.create(q), dataset)) {
@@ -241,7 +241,7 @@ public class TestOffsetPaging {
         String q =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?rank WHERE {\n" +
-            "  (?hit ?s ?score ?rank) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 3 5)\n" +
+            "  (?hit ?s ?score ?totalHits ?rank) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 3 5)\n" +
             "}";
         dataset.begin(ReadWrite.READ);
         try (QueryExecution qe = QueryExecutionFactory.create(QueryFactory.create(q), dataset)) {
@@ -256,13 +256,16 @@ public class TestOffsetPaging {
         }
     }
 
-    /** ?rank sits between ?score and ?totalHits, so the later positions still resolve. */
+    /**
+     * ?rank sits last, so ?totalHits keeps the fourth position it held before rank existed
+     * and a subject list written against the older shape still binds it.
+     */
     @Test
-    public void testTotalHitsFollowsRank() {
+    public void testRankFollowsTotalHits() {
         String q =
             "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?rank ?totalHits WHERE {\n" +
-            "  (?hit ?s ?score ?rank ?totalHits) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 3 5)\n" +
+            "  (?hit ?s ?score ?totalHits ?rank) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 3 5)\n" +
             "} LIMIT 1";
         dataset.begin(ReadWrite.READ);
         try (QueryExecution qe = QueryExecutionFactory.create(QueryFactory.create(q), dataset)) {
@@ -279,5 +282,33 @@ public class TestOffsetPaging {
     @Test(expected = QueryExecException.class)
     public void testNegativeOffsetRejected() {
         runQuery(10, -1);
+    }
+
+    /**
+     * Five is the whole subject list. There was a sixth slot, {@code ?graph}, which never
+     * bound a value — a SHACL document is assembled from a union view over every graph, so
+     * a hit has no single source graph. It was removed rather than left as a hole that
+     * pushed ?rank out of position; graph provenance belongs in a doc-level field instead
+     * (docs/2026-04-08-graph-filtering-target-model.md). Rejecting six keeps the removal
+     * loud: a query still naming the old slot fails at build rather than silently binding
+     * ?graph to a rank integer.
+     */
+    @Test
+    public void testSixElementSubjectListRejected() {
+        String q =
+            "PREFIX luc: <urn:jena:lucene:index#>\n" +
+            "SELECT * WHERE {\n" +
+            "  (?hit ?s ?score ?totalHits ?graph ?rank) luc:query (\"default\" \"default\" \"item\" \"\" \"\" 3 0)\n" +
+            "}";
+        dataset.begin(ReadWrite.READ);
+        try (QueryExecution qe = QueryExecutionFactory.create(QueryFactory.create(q), dataset)) {
+            qe.execSelect().hasNext();
+            fail("A six-element subject list should be rejected");
+        } catch (QueryBuildException e) {
+            assertTrue("Message should state the permitted arity: " + e.getMessage(),
+                e.getMessage().contains("must be 1-5"));
+        } finally {
+            dataset.end();
+        }
     }
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextQueryPFFilters.java
@@ -352,7 +352,7 @@ public class TestTextQueryPFFilters {
         // The fourth luc:query slot now binds ?totalHits rather than a raw match literal
         String sparql = "PREFIX luc: <urn:jena:lucene:index#>\n" +
             "SELECT ?s ?score ?totalHits WHERE {\n" +
-            "  (?hit ?s ?score ?rank ?totalHits) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"\" \"\" 10 0)\n" +
+            "  (?hit ?s ?score ?totalHits) luc:query (\"default\" '[\"" + FIELD_IRI_PREFIX + "title\"]' \"machine\" \"\" \"\" 10 0)\n" +
             "}";
 
         dataset.begin(ReadWrite.READ);


### PR DESCRIPTION
`luc:query`'s subject list is now 1 to 5 of `(?hit ?entity ?score ?totalHits ?rank)`.

## The bug

`?rank` was added at position 3, between `?score` and `?totalHits`. That silently changed what a four-element subject list bound — a query asking for `?totalHits` started receiving the rank instead, counting 0, 1, 2, 3 down the page:

```sparql
{ (?hit ?entity ?score ?totalHits) luc:query (...) }   # ?totalHits = 0, 1, 2, 3 ...
```

Moving `?rank` to the end restores `?totalHits` to the fourth position it held before rank existed, so an existing subject list binds what it always bound. `?rank` reads better beside `?score`, but nothing that placement buys is worth re-breaking the earlier positions.

## Why `?graph` is removed rather than left as a hole

It never bound a value. Its only construction site passed `null` unconditionally, so the `sh.getGraph() != null` guard in the property function was live code over a permanently null value.

There is also no single source graph to bind: `ShaclTextDocProducer.allGraphsView()` builds a `GraphUnionRead` over the default graph plus every named graph, and the entity document is assembled from that union. An entity's indexed values can originate in several graphs at once — the normal shape when description is split across a base graph and a curation layer, not an edge case.

The slot was contrary to `docs/2026-04-08-graph-filtering-target-model.md`, which had already ruled out a dedicated `?graph` result slot in favour of a doc-level field. Removing it restores that decision rather than changing direction.

Removing it takes `SearchHit.graph`, its getter and its constructor parameter with it, all of which were dead.

## Design note, not built

`docs/2026-07-31_source_graph_indexing_design.md` records what graph provenance would take: an opt-in `idx:storeGraph` flag writing a **multi-valued** `urn:jena:lucene:field#sourceGraph` keyword field. Multi-valued is the decision — a single-valued "the graph", defined as whichever graph holds the matched `rdf:type`, is accurate until the data gets interesting and is therefore worse than nothing.

It also records the obstacle the April note deferred: `ShaclEntityBuilder` resolves values through a `GraphUnionRead`, which does not report which member graph produced a triple, so provenance cannot be recovered after resolution. Nothing here is implemented.

Related: `graphURI` on `ShaclTextIndexLucene.searchWithHitIds` is accepted and never read. Left alone in this PR; the design note argues it should be deleted rather than wired up, since filtering goes through CQL like every other field.

## Tests

773 pass, up from 772. The new one is `TestOffsetPaging.testSixElementSubjectListRejected`: a six-element subject list now fails at build time, so a query naming the old slot errors loudly instead of binding `?graph` to a rank integer. Nothing previously covered position 5 either way, which is how a permanently unbound variable reached the documentation described as a working binding.

Docs, the user guide and the demo app's CONSTRUCT query are updated to the 5-slot form.