### PR TITLE
Document idx:nestedName in the config reference

### DIFF
--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -286,6 +286,34 @@ sh:path [ sh:inversePath ex:authored ] .
 
 `idx:joinPath` enumerates child nodes from the parent. Field occurrences inside the `idx:nested` block are evaluated relative to the child node, not the parent.
 
+### Block properties
+
+| Property | Required | Meaning |
+|---|---|---|
+| `idx:joinPath` | yes¹ | SHACL path enumerating child nodes from the parent |
+| `idx:externalSource` | yes¹ | Children come from a tabular source instead — see [External Content](#external-content-csvtsv) |
+| `idx:property` | yes² | Repeatable field occurrence, evaluated relative to the child node |
+| `idx:nestedName` | see below | The block's **scope name** |
+| `idx:facetHierarchy` | no | Hierarchy whose levels are correlated per child record |
+
+¹ Exactly one of `idx:joinPath` / `idx:externalSource`.
+² For a `idx:joinPath` block. An external block's fields come from its `idx:column` bindings instead, and `idx:property` there is an error.
+
+**The scope name** identifies the block. It is written to every child document as
+`_nestedScope`, and it is what lets the query path tell "these clauses must be satisfied by
+*one* child" from "any children will do", recover a child's field definitions when
+projecting `luc:nestedMatch`, and restrict a nested sort selector to the right block.
+
+- For an `idx:joinPath` block the name is **derived from the path** — you do not write it,
+  and an `idx:nestedName` there is ignored.
+- For an `idx:externalSource` block it is **required**: there is no join path to derive it
+  from. Omitting it is a config-time error.
+
+It is an opaque label, not an IRI: nothing in the data denotes it, no query names it (the
+scope is always inferred from the field), and the derived form is a path string. Pick
+something short and descriptive. Because it lands in the index, renaming it invalidates
+existing child documents — reindex after a change.
+
 ### Pattern 1 — Qualified identifier (both children are KEYWORD)
 
 `schema:identifier` records carrying `(propertyID, value)` pairs:
@@ -381,6 +409,7 @@ plain field, and for the n-gram configurations that are permitted but not advise
 ### Rules
 
 - One field IRI belongs to one scope: either root or one nested collection.
+- Scope names are resolved across the whole mapping, so an explicit `idx:nestedName` must be unique among all `idx:nested` blocks in the index, not just within its shape.
 - `idx:joinPath` may be a simple predicate, an inverse predicate, or a sequence of predicate steps. It does not support alternative paths.
 - Both the exact-keyword and edge-ngram-text variants can sit on the same SHACL path — they are different Lucene fields driven by their own analyzers.
 - `idx:facetHierarchy` inside an `idx:nested` block defines a hierarchy whose levels are correlated per child record (no cartesian products).
@@ -431,6 +460,8 @@ field:measuredValue
 ```
 
 Bound fields carry **no `sh:path`** — their values come from the column. There is no `idx:external` flag: a field is external because a column binds it, exactly as a field is nested because it appears in an `idx:nested` block.
+
+`idx:nestedName` is required here, and only here: with no `idx:joinPath` there is nothing to derive the block's scope name from. See [Block properties](#block-properties).
 
 ### Source properties
 

--- a/docs/04-architecture.md
+++ b/docs/04-architecture.md
@@ -192,7 +192,7 @@ rebuildEntityDocuments(subject)
 - `getDepth()`, `getLevelIndex(field)`, `getLevel(i)` — navigation methods
 
 `NestedDef` represents a repeated correlated child collection:
-- `nestedName` — the child scope identifier derived from `idx:joinPath`
+- `nestedName` — the child scope identifier: derived from `idx:joinPath`, or taken from the required `idx:nestedName` when the block has an `idx:externalSource` instead
 - `joinPath` — the SHACL path used to enumerate child nodes
 - `joinSteps` — the ordered forward/inverse predicate steps used for change monitoring
 - `joinPredicates` — the predicate set used for change monitoring
@@ -201,7 +201,7 @@ rebuildEntityDocuments(subject)
 
 `FieldDef` now carries explicit scope metadata:
 - root fields have `nestedName = null`
-- child fields have `nestedName = <joinPath>`
+- child fields have `nestedName = <the owning block's scope name>`
 
 This allows the runtime to distinguish:
 - root fields evaluated from the entity node


### PR DESCRIPTION
`idx:nestedName` appeared in the external-source example in `03-configuration.md` and in the internals of `04-architecture.md`, but nothing said what it is, that it is required for an `idx:externalSource` block, or that it is derived — and an explicit value silently ignored — for an `idx:joinPath` one. Only the dated design note carried that rule.

- **`03-configuration.md`** — new *Block properties* table under *Nested Child Records*, covering `idx:joinPath` / `idx:externalSource` / `idx:property` / `idx:nestedName` / `idx:facetHierarchy`, plus prose on what the scope name does (`_nestedScope` on each child doc; same-child folding, `luc:nestedMatch` projection, nested sort selectors), why it is an opaque label rather than an IRI, and that renaming it needs a reindex.
- **Rules** — scope names resolve across the whole mapping (`findNestedDefByName` scans every profile), so an explicit one must be unique index-wide, not per shape.
- **External Content section** — one line saying `idx:nestedName` is required there and why.
- **`04-architecture.md`** — the two lines describing the name as always derived from `idx:joinPath` predate external blocks; refreshed.

Docs only, no code change.