### PR TITLE
Document the full idx: vocabulary and add a suggested-configuration page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ mvn clean install -Drat.skip
 ## Running Tests
 
 ```bash
-# Run all jena-text tests (778 tests)
+# Run all jena-text tests (790 tests)
 mvn test -pl jena-text
 
 # Run a single test class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ mvn clean install -Drat.skip
 ## Running Tests
 
 ```bash
-# Run all jena-text tests (646 tests)
+# Run all jena-text tests (778 tests)
 mvn test -pl jena-text
 
 # Run a single test class
@@ -115,8 +115,9 @@ is the only entry point. A new test class that is not added to its `@SelectClass
 is **silently never run** — it is not reported as skipped, it simply does not appear.
 After adding a test, confirm its name appears in the `-- in <class>` lines of the output.
 
-Three classes are currently unregistered and therefore dead: `TestDateLiteralRoundTrip`,
-`TestFacetedResults`, `TestUpdateDocumentFacets` (12 `@Test` methods).
+Two classes are currently unregistered and therefore dead: `TestFacetedResults`,
+`TestUpdateDocumentFacets` (8 `@Test` methods). `TestDateLiteralRoundTrip` was registered on
+2026-07-31 and passes.
 
 ### JUnit 4 vs JUnit 5
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,9 +84,9 @@ tasks:
   push_gswa:
     desc: Push runtime (as rdf-delta-server) and the loader to the GSWA ACR (gswareg.azurecr.io) with :IMAGE_TAG and :latest
     cmds:
-      # On gswareg the runtime is published under the GSWA naming convention
-      # (rdf-delta-server), not fuseki-lucene-shacl. GHCR and gswadevacr use
-      # fuseki-lucene-shacl.
+      # On gswareg both images follow the GSWA naming convention —
+      # rdf-delta-server and fuseki-loader — not fuseki-lucene-shacl and
+      # fuseki-lucene-shacl-loader, which GHCR and gswadevacr use.
       - task: runtime-acr-push
         vars:
           ACR_NAME: gswareg
@@ -94,6 +94,7 @@ tasks:
       - task: loader-acr-push
         vars:
           ACR_NAME: gswareg
+          IMAGE_NAME: fuseki-loader
 
   # ── Vulnerability scanning ──────────────────────────────
 

--- a/docs/01-user-guide.md
+++ b/docs/01-user-guide.md
@@ -30,6 +30,9 @@ The main SHACL property functions are:
 
 ### 2. Define fields
 
+Which type and flags to pick for a given kind of data — names, identifiers, dates,
+observations — is covered in [10-suggested-configuration.md](10-suggested-configuration.md).
+
 ```turtle
 @prefix idx: <urn:jena:lucene:index#> .
 @prefix sh:  <http://www.w3.org/ns/shacl#> .
@@ -38,23 +41,23 @@ The main SHACL property functions are:
 field:title
     idx:fieldName "title" ;
     idx:fieldType idx:TextField ;
-    idx:defaultSearch true ;
-    sh:path rdfs:label .
+    idx:defaultSearch true .
 
 field:category
     idx:fieldName "category" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:category .
+    idx:facetable true .
 ```
+
+Field definitions carry no path — the path belongs to the occurrence that uses the field.
 
 ### 3. Define a shape
 
 ```turtle
 <#BookShape>
     sh:targetClass ex:Book ;
-    sh:property field:title ;
-    sh:property field:category .
+    sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
+    sh:property [ idx:field field:category ; sh:path ex:category ] .
 ```
 
 ### 4. Query it

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -609,17 +609,19 @@ Data-modelling requirements (no extra index configuration):
 ```turtle
 :sampleShape idx:nested [
     idx:joinPath sdo:identifier ;
-    idx:property field:identifierType ;    # discriminator -> child filter
-    idx:property field:identifierValue ;   # value         -> sort key
+    # discriminator -> child filter
+    idx:property [ idx:field field:identifierType  ; sh:path sdo:propertyID ] ;
+    # value         -> sort key
+    idx:property [ idx:field field:identifierValue ; sh:path sdo:value ] ;
 ] .
 
 field:identifierType
     idx:fieldName "identifierType" ; idx:fieldType idx:KeywordField ;
-    idx:indexed true ; idx:facetable true ; sh:path sdo:propertyID .
+    idx:indexed true ; idx:facetable true .
 
 field:identifierValue
     idx:fieldName "identifierValue" ; idx:fieldType idx:KeywordField ;
-    idx:sortable true ; sh:path sdo:value .
+    idx:sortable true .
 ```
 
 Because the sort happens inside Lucene, it is applied before `limit`/`offset` cut the

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -78,6 +78,26 @@ Supported values:
 
 Unknown field IRIs fail fast.
 
+### `queryString`
+
+Parsed by Lucene's classic
+[`QueryParser`](https://lucene.apache.org/core/10_3_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description)
+— `MultiFieldQueryParser` when `fieldSpec` names more than one field — and scored with BM25.
+The full classic syntax is available with no extra configuration: phrases, `AND`/`OR`/`NOT`,
+`+`/`-`, wildcards (`quan*`, `qu?ntum`, and **leading** wildcards such as `*tum`, which Lucene
+disables by default and this index enables), fuzzy (`learnimg~1`), proximity
+(`"machine networks"~2`), boosts (`quantum^4`), grouping and term ranges. A bare `*` is
+short-circuited to a match-all.
+
+The string is analyzed with each target field's query analyzer, so behaviour follows the
+field: on a `KEYWORD` field the whole value is a single term.
+
+Use `cqlFilter` for structured predicates — `=`, ranges, `in`, `between`, spatial, same-child
+correlation. Field scoping belongs in `fieldSpec`: an embedded `fieldName:value` prefix in the
+query string would use internal Lucene field names and bypass the field-IRI contract.
+
+Pinned by `TestLuceneQuerySyntax`.
+
 ### Return bindings
 
 | Variable | Type | Meaning |

--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -43,23 +43,29 @@ Notes:
 @prefix idx:  <urn:jena:lucene:index#> .
 @prefix sh:   <http://www.w3.org/ns/shacl#> .
 
-<#index> a text:TextIndexLucene ;
+<#index> a text:TextIndexShacl ;
     text:indexId "default" ;
     text:directory "mem" ;
+    text:taxonomyDirectory <file:Taxonomy> ;
     text:shapes ( <#BookShape> <#ArticleShape> ) ;
     text:storeValues true ;
     text:maxFacetHits 50000 .
 ```
 
-Important properties:
+SHACL mode is `text:TextIndexShacl`, and it **requires** `text:shapes`. `text:TextIndexLucene`
+is the classic triple-per-document index and ignores `text:shapes` entirely — configure that
+one with `text:entityMap`.
 
-| Property | Meaning |
-|---|---|
-| `text:indexId` | Token id used by `indexSelector`, for example `"default"` or `"objects"` |
-| `text:directory` | Lucene storage location |
-| `text:shapes` | RDF list of SHACL shapes |
-| `text:storeValues` | Store values for `luc:match` and facet value binding |
-| `text:maxFacetHits` | Maximum documents considered during facet collection |
+| Property | Required | Meaning |
+|---|---|---|
+| `text:indexId` | no | Token id used by `indexSelector`, for example `"default"` or `"objects"` |
+| `text:directory` | yes | Lucene storage location. The literal `"mem"` is in-memory; anything else is a path or file IRI |
+| `text:shapes` | yes | RDF list of SHACL shapes, one document profile each |
+| `text:taxonomyDirectory` | no | Where hierarchical-facet ordinals live. Left unset the taxonomy is in-memory — fine when indexing and querying share a JVM, and a silent total loss of hierarchical facet counts when they do not (a bulk build writes the ordinals, the process exits, the server starts empty) |
+| `text:storeValues` | no, default `false` | Store values for `luc:match` and facet value binding |
+| `text:maxFacetHits` | no | Maximum documents considered during facet collection |
+| `text:analyzer` | no | Index-wide default analyzer |
+| `text:queryAnalyzer` | no | Index-wide query analyzer |
 
 If the index resource itself is a URI resource, that URI is also accepted as an `indexSelector`.
 
@@ -74,45 +80,57 @@ Each SHACL shape contributes one document profile.
 
 <#BookShape>
     sh:targetClass ex:Book ;
-    sh:property field:title ;
-    sh:property field:category ;
-    sh:property field:authorName .
+    sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
+    sh:property [ idx:field field:category ; sh:path ex:category ] ;
+    sh:property [ idx:field field:authorName ; sh:path ( ex:authoredBy ex:name ) ] .
 ```
+
+Each `sh:property` is an **occurrence**: it names a canonical field and the path that feeds
+it. Pointing `sh:property` straight at a field resource is the old form and is rejected.
+
+| Property | Required | Meaning |
+|---|---|---|
+| `sh:targetClass` | yes | Entity class this profile indexes. Repeatable |
+| `sh:property` | yes¹ | A root field occurrence |
+| `idx:nested` | yes¹ | A child collection — see [Nested Child Records](#nested-child-records) |
+| `idx:facetHierarchy` | no | Ordered list of fields forming one hierarchical facet dimension |
+| `idx:docIdField` | no, default `"uri"` | Lucene field holding the entity IRI. Must be identical across every profile in one index |
+| `idx:discriminatorField` | no, default `"docType"` | Lucene field holding the target class's local name, so deletes stay scoped to one profile |
+
+¹ A shape needs at least one of `sh:property` / `idx:nested`.
 
 ## Fields
 
-Named field resources are the recommended pattern.
+A field is defined **once**, as a named resource, and carries **no path**. The path lives on
+the occurrence that references it, which is what lets one field be fed from several paths and
+several shapes.
 
 ```turtle
 @prefix field: <urn:jena:lucene:field#> .
 @prefix idx:   <urn:jena:lucene:index#> .
-@prefix sh:    <http://www.w3.org/ns/shacl#> .
 
 field:title
     idx:fieldName "title" ;
     idx:fieldType idx:TextField ;
-    idx:defaultSearch true ;
-    sh:path rdfs:label .
+    idx:defaultSearch true .
 
 field:category
     idx:fieldName "category" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:category .
+    idx:facetable true .
 
 field:year
     idx:fieldName "year" ;
     idx:fieldType idx:IntField ;
     idx:facetable true ;
-    idx:sortable true ;
-    sh:path ex:year .
+    idx:sortable true .
 
 field:publishedOn
     idx:fieldName "publishedOn" ;
     idx:fieldType idx:TemporalField ;
     idx:facetable true ;
     idx:sortable true ;
-    sh:path ex:publishedOn .
+    idx:storeLiteralMetadata true .   # not optional on TEMPORAL
 ```
 
 Public API rule:
@@ -124,19 +142,54 @@ Public API rule:
 
 ## Field Properties
 
-| Property | Meaning |
-|---|---|
-| `idx:fieldName` | Internal Lucene field name |
-| `idx:fieldType` | `idx:TextField`, `idx:KeywordField`, `idx:IntField`, `idx:LongField`, `idx:DoubleField`, `idx:TemporalField`, `idx:LatLonField` |
-| `idx:facetable` | Enables faceting |
-| `idx:sortable` | Enables sort pushdown |
-| `idx:multiValued` | Allows multiple values |
-| `idx:defaultSearch` | Included when `fieldSpec` is `"default"` |
-| `idx:analyzer` | Index-time analyzer override |
-| `idx:queryAnalyzer` | Query-time analyzer override |
-| `sh:path` | Direct, sequence, inverse, or nested path |
+These go on the **canonical field**, never on an occurrence.
+
+| Property | Default | Meaning |
+|---|---|---|
+| `idx:fieldName` | required | Internal Lucene field name |
+| `idx:fieldType` | `idx:TextField` | `idx:TextField`, `idx:KeywordField`, `idx:IntField`, `idx:LongField`, `idx:DoubleField`, `idx:TemporalField`, `idx:LatLonField` |
+| `idx:stored` | `true` | Keep the value so `luc:match` / `luc:nestedMatch` can project it |
+| `idx:indexed` | `true` | Write searchable terms/points — this is what makes the field **filterable** |
+| `idx:facetable` | `false` | Write facet docvalues — required to appear in `luc:facet` |
+| `idx:sortable` | `false` | Write sort docvalues — required for `ORDER BY` pushdown |
+| `idx:multiValued` | `false` | Allow more than one value per entity |
+| `idx:defaultSearch` | `false` | Included when `fieldSpec` is `"default"` |
+| `idx:analyzer` | index-wide default | Index-time analyzer override (`TEXT`) |
+| `idx:queryAnalyzer` | implied by `idx:analyzer` | Query-time analyzer override |
+| `idx:normalizer` | none | `KEYWORD` only — analyzer driving the indexed term and sort key while the stored value and facet label stay raw |
+| `idx:storeLiteralMetadata` | `false` | Store the datatype and language tag so a projected value rebuilds as the original literal. **Required on every `TEMPORAL` field** |
+
+The four write-side flags are independent, and each buys exactly one capability:
+
+| Flag | Structure written | Without it |
+|---|---|---|
+| `idx:indexed` | inverted terms / points | filters on the field are **silently dropped** — the clause becomes residual, is logged, and never applied |
+| `idx:stored` | stored value | `luc:match` has nothing to project |
+| `idx:facetable` | facet docvalues | faceting the field is an error |
+| `idx:sortable` | sort docvalues | no sort pushdown |
+
+Numeric and temporal fields take their facet/sort docvalues from `idx:facetable` **or** `idx:sortable`, independently of `idx:indexed` — so a numeric field can be facetable and sortable but not filterable. That is rarely what you want; see [10-suggested-configuration.md](10-suggested-configuration.md).
 
 `idx:DateField` and `idx:DateTimeField` are accepted as deprecated aliases for `idx:TemporalField`.
+
+### Occurrence properties
+
+An occurrence binds a canonical field to a path. It carries the path and any value
+constraints; it must not repeat the field's own metadata (`idx:fieldName`, `idx:fieldType`,
+the flags, the analyzers), and the field must not carry occurrence data (`sh:path`,
+`sh:class`, `sh:nodeKind`, `sh:datatype`). Both directions are rejected at config time, so
+one field cannot end up with two different definitions.
+
+| Property | Required | Meaning |
+|---|---|---|
+| `idx:field` | yes | The canonical field this occurrence feeds |
+| `sh:path` | yes | Direct, sequence, inverse, or alternative path from the entity (or, inside `idx:nested`, from the child node) |
+| `sh:class` | no | Only index values whose reached node has this `rdf:type` |
+| `sh:nodeKind` | no | Restrict to `sh:IRI`, `sh:Literal`, or `sh:BlankNode` |
+| `sh:datatype` | no | Only index literals with this datatype |
+
+Several occurrences may feed one field — that is how a value fans in from more than one
+path. They must all resolve to the same canonical definition.
 
 ## Choosing an Analyzer for a TEXT Field
 
@@ -161,8 +214,10 @@ Edge-n-grams are for the third row only. They are the wrong reach for a name: se
 field:identifierValueText
     idx:fieldName "identifierValueText" ;
     idx:fieldType idx:TextField ;
-    idx:analyzer [ a text:EdgeNGramAnalyzer ] ;
-    sh:path schema:value .
+    idx:analyzer [ a text:EdgeNGramAnalyzer ] .
+
+## fed by an occurrence on the shape:
+##   sh:property [ idx:field field:identifierValueText ; sh:path schema:value ]
 ```
 
 `text:tokenized true` switches to per-word n-grams, so any word of a multi-word value can
@@ -230,15 +285,18 @@ twin when you also want exact filtering and facet counts:
 field:authorName
     idx:fieldName "authorName" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ( ex:authoredBy ex:name ) .
+    idx:facetable true .
 
 ## Search side: BM25 over the same name, no analyzer override
 field:authorNameText
     idx:fieldName "authorNameText" ;
     idx:fieldType idx:TextField ;
-    idx:defaultSearch true ;
-    sh:path ( ex:authoredBy ex:name ) .
+    idx:defaultSearch true .
+
+## Two occurrences, one path — the twin fields diverge on analysis, not on source:
+<#MiningReportShape>
+    sh:property [ idx:field field:authorName     ; sh:path ( ex:authoredBy ex:name ) ] ;
+    sh:property [ idx:field field:authorNameText ; sh:path ( ex:authoredBy ex:name ) ] .
 ```
 
 This holds inside an `idx:nested` scope too: a plain `TEXT` field there still folds
@@ -322,24 +380,25 @@ existing child documents — reindex after a change.
 field:identifierType
     idx:fieldName "identifierType" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path schema:propertyID .
+    idx:facetable true .
 
 field:identifierValueExact
     idx:fieldName "identifierValueExact" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path schema:value .
+    idx:facetable true .
 
 <#BoreholeShape>
     sh:targetClass ex:Borehole ;
     idx:nested [
         idx:joinPath schema:identifier ;
-        idx:property field:identifierType ;
-        idx:property field:identifierValueExact ;
+        idx:property [ idx:field field:identifierType ; sh:path schema:propertyID ] ;
+        idx:property [ idx:field field:identifierValueExact ; sh:path schema:value ] ;
         idx:facetHierarchy ( field:identifierType field:identifierValueExact ) ;
     ] .
 ```
+
+Inside a nested block the occurrence paths are relative to the **child** node, so
+`schema:propertyID` here is read from each `schema:identifier` record, not from the borehole.
 
 Query-time same-child correlation is not limited to `=`. AND-ed leaves that target the same nested scope fold into one block join, so `=`, ranges (`<`, `>`, `<=`, `>=`), `in`, `between`, `like` and `text_query` all correlate within a single child — see [02-sparql-api.md → Nested same-child filters](02-sparql-api.md#nested-same-child-filters).
 
@@ -351,16 +410,15 @@ Add a second occurrence of the value field with an analyzer-backed `TEXT` field.
 field:identifierValueText
     idx:fieldName "identifierValueText" ;
     idx:fieldType idx:TextField ;
-    idx:analyzer [ a text:EdgeNGramAnalyzer ; text:tokenized true ] ;
-    sh:path schema:value .
+    idx:analyzer [ a text:EdgeNGramAnalyzer ; text:tokenized true ] .
 
 <#BoreholeShape>
     sh:targetClass ex:Borehole ;
     idx:nested [
         idx:joinPath schema:identifier ;
-        idx:property field:identifierType ;
-        idx:property field:identifierValueExact ;
-        idx:property field:identifierValueText ;
+        idx:property [ idx:field field:identifierType ; sh:path schema:propertyID ] ;
+        idx:property [ idx:field field:identifierValueExact ; sh:path schema:value ] ;
+        idx:property [ idx:field field:identifierValueText ; sh:path schema:value ] ;
         idx:facetHierarchy ( field:identifierType field:identifierValueExact ) ;
     ] .
 ```
@@ -377,22 +435,20 @@ The exact and text fields can coexist on the same child path — index-time, eac
 field:attributionRole
     idx:fieldName "attributionRole" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path prov:hadRole .
+    idx:facetable true .
 
 field:attributionAgentExact
     idx:fieldName "attributionAgentExact" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ( prov:agent rdfs:label ) .
+    idx:facetable true .
 
 <#MiningReportShape>
     sh:targetClass ex:MiningReport ;
     idx:nested [
         idx:joinPath prov:qualifiedAttribution ;
-        idx:property field:attributionRole ;
-        idx:property field:attributionAgentExact ;
-        idx:property field:attributionAgentText ;
+        idx:property [ idx:field field:attributionRole ; sh:path ( prov:hadRole rdfs:label ) ] ;
+        idx:property [ idx:field field:attributionAgentExact ; sh:path ( prov:agent rdfs:label ) ] ;
+        idx:property [ idx:field field:attributionAgentText ; sh:path ( prov:agent rdfs:label ) ] ;
     ] .
 ```
 
@@ -639,7 +695,7 @@ But the underlying Lucene field key still comes from `idx:fieldName`.
     text:dataset <#baseDs> ;
     text:indexes <#index> .
 
-<#index> a text:TextIndexLucene ;
+<#index> a text:TextIndexShacl ;
     text:indexId "default" ;
     text:directory "mem" ;
     text:storeValues true ;
@@ -648,17 +704,56 @@ But the underlying Lucene field key still comes from `idx:fieldName`.
 field:title
     idx:fieldName "title" ;
     idx:fieldType idx:TextField ;
-    idx:defaultSearch true ;
-    sh:path rdfs:label .
+    idx:defaultSearch true .
 
 field:category
     idx:fieldName "category" ;
     idx:fieldType idx:KeywordField ;
-    idx:facetable true ;
-    sh:path ex:category .
+    idx:facetable true .
 
 <#BookShape>
     sh:targetClass ex:Book ;
-    sh:property field:title ;
-    sh:property field:category .
+    sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
+    sh:property [ idx:field field:category ; sh:path ex:category ] .
 ```
+
+## Vocabulary Index
+
+`idx:` is `urn:jena:lucene:index#` — the same namespace SPARQL prefixes as `luc:`. The
+convention is `idx:` for configuration and `luc:` for the property functions; nothing
+enforces it.
+
+Every term the assembler reads, and where it is defined above:
+
+| Term | Goes on | Section |
+|---|---|---|
+| `idx:field` | occurrence, `idx:column` | [Occurrence properties](#occurrence-properties) |
+| `idx:fieldName` `idx:fieldType` | canonical field | [Field Properties](#field-properties) |
+| `idx:stored` `idx:indexed` `idx:facetable` `idx:sortable` `idx:multiValued` `idx:defaultSearch` | canonical field | [Field Properties](#field-properties) |
+| `idx:analyzer` `idx:queryAnalyzer` `idx:normalizer` | canonical field | [Field Properties](#field-properties) |
+| `idx:storeLiteralMetadata` | canonical field | [Field Properties](#field-properties) |
+| `idx:docIdField` `idx:discriminatorField` | shape | [Shapes](#shapes) |
+| `idx:facetHierarchy` | shape, `idx:nested` | [Shapes](#shapes), [Block properties](#block-properties) |
+| `idx:nested` | shape | [Nested Child Records](#nested-child-records) |
+| `idx:joinPath` `idx:nestedName` `idx:property` | `idx:nested` | [Block properties](#block-properties) |
+| `idx:externalSource` | `idx:nested` | [External Content](#external-content-csvtsv) |
+| `idx:format` `idx:location` `idx:subjectColumn` `idx:subjectColumnIndex` `idx:subjectPrefix` `idx:delimiter` `idx:headerless` `idx:onError` `idx:column` `idx:delta` `idx:opColumn` | `idx:externalSource` | [Source properties](#source-properties) |
+| `idx:columnName` `idx:columnIndex` | `idx:column` | [Source properties](#source-properties) |
+
+Resources rather than properties:
+
+| Term | Used as |
+|---|---|
+| `idx:TextField` `idx:KeywordField` `idx:IntField` `idx:LongField` `idx:DoubleField` `idx:TemporalField` `idx:LatLonField` | `idx:fieldType` value |
+| `idx:DateField` `idx:DateTimeField` | deprecated aliases for `idx:TemporalField` |
+| `idx:CsvFile` `idx:TsvFile` | `idx:format` value |
+
+Property function IRIs in the same namespace: `luc:query`, `luc:facet`, `luc:match`,
+`luc:nestedMatch` — see [02-sparql-api.md](02-sparql-api.md). Note that `luc:nestedMatch` is
+deliberately **not** named `luc:nested`: that IRI is already the `idx:nested` config
+predicate, and a property function registered on it would intercept any query reading a
+config graph.
+
+Terms that do **not** exist, despite appearing in older design notes: `idx:external`
+(externality follows from an `idx:column` binding), `idx:sorted` (asserting a pre-sorted
+source is not implemented; the loader sorts), and `idx:path` (use `sh:path`).

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -3,7 +3,7 @@
 ## Running Tests
 
 ```bash
-# Full jena-text suite (778 tests)
+# Full jena-text suite (790 tests)
 mvn test -pl jena-text
 
 # Only SHACL / faceting tests
@@ -44,6 +44,7 @@ A class missing from `@SelectClasses` is **silently never run** — not reported
 | `TestShaclTextDocProducer` | 5 | Change listener: add type creates doc, add property rebuilds, delete type removes, irrelevant predicate ignored, multiple entities |
 | `TestShaclAssembler` | 9 | Config parsing: valid shapes, SHACL/entity-map exclusivity, hierarchy config, and assembler validation paths |
 | `TestShaclEntityPerDocument` | 7 | End-to-end: text search, SPARQL `luc:query`, facet counts, filtered facets, add after load, entity-per-doc model verification |
+| `TestLuceneQuerySyntax` | 12 | The `queryString` argument reaching Lucene's classic parser: phrase, boolean, required/prohibited, trailing/leading/single-char wildcard, fuzzy, proximity slop, boost, grouping, lexical term range, and the bare `*` match-all short-circuit |
 | `TestDateLiteralRoundTrip` | 4 | TEMPORAL fields: `between` and `>=` over the epoch twin field, typed `xsd:date`/`xsd:dateTime` reconstruction on read, language-tagged literal round trip, and an unparseable date dropping out of range queries without failing the build |
 
 ### Hierarchical Facets Tests
@@ -70,7 +71,7 @@ A class missing from `@SelectClasses` is **silently never run** — not reported
 
 ### Existing Tests (unchanged, verifying no regressions)
 
-The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 778 tests.
+The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 790 tests.
 
 ---
 

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -3,14 +3,16 @@
 ## Running Tests
 
 ```bash
-# Full jena-text suite (546 tests)
+# Full jena-text suite (778 tests)
 mvn test -pl jena-text
 
 # Only SHACL / faceting tests
 mvn test -pl jena-text -Dtest="TestShaclIndexMapping,TestShaclDocumentBuilding,TestShaclTextDocProducer,TestShaclAssembler,TestShaclEntityPerDocument,TestNativeFacetCounts,TestTextFacetPF,TestTextQueryPFFilters,TestSearchExecution,TestHierarchicalFacets,TestHierarchicalFacetsSparql,TestSortSpec"
 ```
 
-All tests run via JUnit 4 and are aggregated in `TS_Text.java` (Surefire only picks up `**/TS_*.java`).
+Tests are aggregated in `TS_Text.java` (Surefire only picks up `**/TS_*.java`). The suite class uses the JUnit 5 `@Suite` / `@SelectClasses` annotations; the fork's older SHACL/faceting classes are still JUnit 4 and run through `junit-vintage-engine`. New tests should be written in JUnit 5.
+
+A class missing from `@SelectClasses` is **silently never run** — not reported as skipped. After adding a test, confirm it appears in the `-- in <class>` lines.
 
 ---
 
@@ -42,6 +44,7 @@ All tests run via JUnit 4 and are aggregated in `TS_Text.java` (Surefire only pi
 | `TestShaclTextDocProducer` | 5 | Change listener: add type creates doc, add property rebuilds, delete type removes, irrelevant predicate ignored, multiple entities |
 | `TestShaclAssembler` | 9 | Config parsing: valid shapes, SHACL/entity-map exclusivity, hierarchy config, and assembler validation paths |
 | `TestShaclEntityPerDocument` | 7 | End-to-end: text search, SPARQL `luc:query`, facet counts, filtered facets, add after load, entity-per-doc model verification |
+| `TestDateLiteralRoundTrip` | 4 | TEMPORAL fields: `between` and `>=` over the epoch twin field, typed `xsd:date`/`xsd:dateTime` reconstruction on read, language-tagged literal round trip, and an unparseable date dropping out of range queries without failing the build |
 
 ### Hierarchical Facets Tests
 
@@ -67,7 +70,7 @@ All tests run via JUnit 4 and are aggregated in `TS_Text.java` (Surefire only pi
 
 ### Existing Tests (unchanged, verifying no regressions)
 
-The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 688 tests.
+The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 778 tests.
 
 ---
 
@@ -132,7 +135,7 @@ TextIndexLucene index = (TextIndexLucene) Assembler.general().open(indexSpec);
 
 - All SPARQL argument forms for `luc:query` and `luc:facet`
 - JSON filter parsing and semantics (OR within field, AND across fields)
-- All five field types (TEXT, KEYWORD, INT, LONG, DOUBLE)
+- All field types: TEXT, KEYWORD, INT, LONG, DOUBLE, TEMPORAL (`TestDateLiteralRoundTrip`), LATLON (`TestSpatialFiltering`)
 - Multi-valued fields
 - Entity lifecycle: create, update (add field), delete (remove type)
 - Assembler config parsing (valid and error cases)
@@ -142,6 +145,7 @@ TextIndexLucene index = (TextIndexLucene) Assembler.general().open(indexSpec);
 - End-to-end SPARQL sort pushdown using field IRIs
 - Hierarchical facets: taxonomy indexing, top-level counts, drill-down via CQL filters, flat+hierarchy coexistence
 - Range facets on numeric fields: single-valued, multi-valued, open-ended buckets, mixed flat+range requests, and 5-slot `luc:facet` bindings
+- Range facets on TEMPORAL fields: ISO date boundaries counted from the epoch docvalues, lower bound inclusive and upper exclusive except on the open end
 - Multi-valued numeric sorting semantics (`MIN` for ascending, `MAX` for descending)
 - External content from CSV/TSV: the IRI join, match/unmatch counters, sortedness verification, and the same-child vs entity-level correlation boundary
 

--- a/docs/08-use-cases.md
+++ b/docs/08-use-cases.md
@@ -228,17 +228,20 @@ flowchart LR
 ```turtle
 PREFIX field: <urn:jena:lucene:field#>
 
-## Sequence path — index author name on the book
 field:authorName
     idx:fieldName "authorName" ;
-    idx:fieldType idx:KeywordField ;
-    sh:path ( ex:writtenBy ex:name ) .
+    idx:fieldType idx:KeywordField .
 
-## Inverse path — index who references this entity
 field:referencedBy
     idx:fieldName "referencedBy" ;
-    idx:fieldType idx:KeywordField ;
-    sh:path [ sh:inversePath ex:references ] .
+    idx:fieldType idx:KeywordField .
+
+<#BookShape>
+    sh:targetClass ex:Book ;
+    ## Sequence path — index author name on the book
+    sh:property [ idx:field field:authorName ; sh:path ( ex:writtenBy ex:name ) ] ;
+    ## Inverse path — index who references this entity
+    sh:property [ idx:field field:referencedBy ; sh:path [ sh:inversePath ex:references ] ] .
 ```
 
 **Where this applies:**
@@ -299,8 +302,10 @@ field:identifier
     idx:fieldName "identifier" ;
     idx:fieldType idx:TextField ;
     idx:analyzer [ a text:EdgeNGramAnalyzer ] ;
-    idx:queryAnalyzer [ a text:LowerCaseKeywordAnalyzer ] ;
-    sh:path ex:identifier .
+    idx:queryAnalyzer [ a text:LowerCaseKeywordAnalyzer ] .
+
+## on the shape:
+##   sh:property [ idx:field field:identifier ; sh:path ex:identifier ]
 ```
 
 Example query:
@@ -350,8 +355,10 @@ ex:report-001 ex:authorName "Dr Sarah Jones" .
 
 ## Index configuration approach (graph unchanged)
 <#field-authorName>
-    idx:fieldName "authorName" ;
-    sh:path ( ex:authoredBy ex:name ) .
+    idx:fieldName "authorName" .
+
+<#MiningReportShape>
+    sh:property [ idx:field <#field-authorName> ; sh:path ( ex:authoredBy ex:name ) ] .
 ```
 
 The indexer follows the path at index time and stores the result in the Lucene document. When the source data changes, the index updates automatically via the change listener.

--- a/docs/09-spatial.md
+++ b/docs/09-spatial.md
@@ -14,12 +14,11 @@ PREFIX geo:   <http://www.opengis.net/ont/geosparql#>
 
 field:location
     idx:fieldName "location" ;
-    idx:fieldType idx:LatLonField ;
-    sh:path geo:asWKT .
+    idx:fieldType idx:LatLonField .
 
 :SiteShape
     sh:targetClass ex:Site ;
-    sh:property field:location ;
+    sh:property [ idx:field field:location ; sh:path geo:asWKT ] ;
     # ... other fields ...
 ```
 

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -23,9 +23,9 @@ What to write, not what the defaults are. `idx:indexed` and `idx:stored` both de
 
 | Data kind | Example | `idx:fieldType` | stored | facetable | sortable |
 |---|---|---|---|---|---|
-| Title / label, searched | `rdfs:label` of a report | `TextField` | ✗ | — | — |
+| Title / label, searched | `rdfs:label` of a report | `TextField` | ✓ | — | — |
 | Name, exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` |
-| Description / abstract | `dcterms:description` | `TextField` | ✗ | — | — |
+| Description / abstract | `dcterms:description` | `TextField` | ✓ | — | — |
 | Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — |
 | Identifier, prefix typeahead | same value, n-grams | `TextField` | ✗ | — | — |
 | Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | — |
@@ -36,8 +36,12 @@ What to write, not what the defaults are. `idx:indexed` and `idx:stored` both de
 | Full date or timestamp | `2023-04-01`, `2023-04-01T09:00:00Z` | `TemporalField` | ✗ | ✓ | ✓ |
 | Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | rejected |
 
-Filtering, faceting and sorting read points and docvalues, never the stored copy — so `✗`
-costs nothing but projection. Set `idx:multiValued true` wherever the predicate can repeat.
+Filtering, faceting and sorting read points and docvalues, never the stored copy, so `✗`
+costs nothing but projection. Store the searchable text fields: `luc:match` binds which field
+matched, and the value only if it is stored — and where an entity carries several labels or
+descriptions, it returns the one that matched.
+
+Set `idx:multiValued true` wherever the predicate can repeat.
 
 ## Query syntax on a TEXT field
 
@@ -74,9 +78,11 @@ A label you only search is one field:
 field:title
     idx:fieldName "title" ;
     idx:fieldType idx:TextField ;
-    idx:stored false ;
+    idx:stored true ;
     idx:defaultSearch true .
 ```
+
+Stored, so `luc:match` can show which label matched.
 
 A name that is also a filter value — author, operator, publisher — is two fields over one
 path, because it is searched as prose *and* picked from a facet list:
@@ -85,7 +91,7 @@ path, because it is searched as prose *and* picked from a facet list:
 field:authorNameText
     idx:fieldName "authorNameText" ;
     idx:fieldType idx:TextField ;
-    idx:stored false ;
+    idx:stored true ;
     idx:defaultSearch true .
 
 field:authorName
@@ -136,12 +142,15 @@ report.
 field:description
     idx:fieldName "description" ;
     idx:fieldType idx:TextField ;
-    idx:stored false ;
+    idx:stored true ;
     idx:defaultSearch true .
 ```
 
-The stored copy would be the largest thing in the index; the graph returns it by IRI.
-`text:storeValues` on the index is `false` by default.
+Store it: a hit on a description is worth nothing if the result cannot show which of several
+descriptions matched. Drop to `idx:stored false` only where the text is long enough that the
+stored copy dominates the index and the graph can serve it by IRI instead.
+
+*`TestTextMatchPF`, `TestShaclLucQueryRawValueOnMultiValuedField`*
 
 ## Vocabularies and taxonomies
 
@@ -333,7 +342,7 @@ docvalues, making sort on a repeated field well-defined.
 |---|---|
 | `idx:indexed false` on a filtered field | Clause dropped and logged; results come back unfiltered, no error |
 | One `TEXT` field for exact match *and* search | Tokenisation breaks `=` |
-| Storing values nothing projects | Index size for no benefit |
+| Storing values nothing projects | Index size for no benefit (a facet or sort field is not projected) |
 | n-grams on names | Term explosion, broken ranking |
 | Flattening correlated children | Cross-matching between unrelated child records |
 | Forgetting `idx:multiValued` | Values after the first vanish with a log line |

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -7,9 +7,7 @@ this page is which to pick. Each recipe names the test that pins it.
 
 - The graph holds the values; the index narrows entities. Store a field only when
   `luc:match` / `luc:nestedMatch` must project it.
-- Graph-derived documents are rebuilt on any relevant triple change. Shapes with an
-  `idx:externalSource` are rebuild-only: the producer refuses live changes and logs that the
-  document is stale until `ShaclBulkIndexer` runs.
+- Documents are rebuilt on any relevant triple change, so stored values track the graph.
 - The flags are independent: `idx:indexed` writes searchable terms, `idx:stored` a stored
   copy, `idx:facetable` facet docvalues, `idx:sortable` sort docvalues.
 - Exact match and free-text search want two fields over one path, not one field with a
@@ -336,7 +334,6 @@ docvalues, making sort on a repeated field well-defined.
 | `idx:indexed false` on a filtered field | Clause dropped and logged; results come back unfiltered, no error |
 | One `TEXT` field for exact match *and* search | Tokenisation breaks `=` |
 | Storing values nothing projects | Index size for no benefit |
-| Storing external-source values corrected upstream | Rebuild-only shape: stale until `ShaclBulkIndexer` runs |
 | n-grams on names | Term explosion, broken ranking |
 | Flattening correlated children | Cross-matching between unrelated child records |
 | Forgetting `idx:multiValued` | Values after the first vanish with a log line |

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -35,7 +35,7 @@ What to write, not what the defaults are. `idx:indexed` and `idx:stored` both de
 | Measurement / grade / score | `12.4` | `DoubleField` | ✗ | ✓ | ✓ | ✗ |
 | Full date or timestamp | `2023-04-01`, `2023-04-01T09:00:00Z` | `TemporalField` | ✗ | ✓ | ✓ | ✗ |
 | Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | rejected | ✗ |
-| Repeated correlated record | an assay, an observation, a qualified identifier | ordinary fields inside an [`idx:nested`](#observations-sosa-style) block | ✓ to project the child that matched | ✓ | ✓ | ✗ |
+| Repeated correlated record | an assay, an observation, a qualified identifier | ordinary fields inside an [`idx:nested`](#observations-sosa-style) block | ✗ | ✓ | ✓ | ✗ |
 
 Filtering, faceting and sorting read points and docvalues, never the stored copy, so `✗`
 costs nothing but projection.
@@ -280,20 +280,20 @@ and range filters are gone.
 field:observedProperty
     idx:fieldName "observedProperty" ;
     idx:fieldType idx:KeywordField ;
-    idx:stored true ;           # projected by luc:nestedMatch
+    idx:stored false ;
     idx:facetable true .
 
 field:resultValue
     idx:fieldName "resultValue" ;
     idx:fieldType idx:DoubleField ;
-    idx:stored true ;
+    idx:stored false ;
     idx:facetable true ;
     idx:sortable true .
 
 field:resultUnits
     idx:fieldName "resultUnits" ;
     idx:fieldType idx:KeywordField ;
-    idx:stored true ;
+    idx:stored false ;
     idx:facetable true .
 
 <#SampleShape>
@@ -314,6 +314,10 @@ lead at 5%. Correlation covers `=`, ranges, `in`, `between`, `like` and `text_qu
 Millions of observations that are not in the graph: use `idx:externalSource` instead — one CSV
 row per child, same semantics. See
 [External Content](03-configuration.md#external-content-csvtsv).
+
+`luc:nestedMatch` projects stored child fields only, and a record with nothing stored is not
+projected at all — so read the children back from the graph. Store them when they come from an
+`idx:externalSource`, where there are no triples to read.
 
 **Don't** nest a single-field child; that is a multi-valued field with extra machinery.
 

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -42,7 +42,12 @@ different Lucene fields; they cost one extra term dictionary and they never figh
 **Fields are path-free and reusable.** Define `field:title` once; bind it to `rdfs:label` on
 one shape and `dcterms:title` on another. Occurrences carry paths, fields carry behaviour.
 
-**Prefer a rebuild to a clever incremental trick.** A wrong document is worse than a slow one.
+**Config changes are not retroactive.** Every flag decides what gets written at index time, so
+flipping `idx:facetable`, `idx:sortable`, `idx:stored`, a field type or an analyzer changes
+nothing about documents already written — they keep the structures they were built with, and
+the new setting applies only to entities indexed after it. A field that starts answering
+queries wrongly rather than not at all is the usual symptom. Reindex after any field-level
+change.
 
 ## The matrix
 

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -19,17 +19,15 @@ which is rebuild-only — the producer refuses to act on a live change, since re
 the graph alone would silently strip the CSV-derived children, and logs that the document is
 stale pending a `ShaclBulkIndexer` run.
 
-**Each flag buys exactly one capability, and costs one structure.** `idx:indexed` for
-filtering, `idx:stored` for projection, `idx:facetable` for counts, `idx:sortable` for
-`ORDER BY`. Turn on what a query needs and nothing else. Note that `idx:stored` defaults to
-`true`, which is the one default worth overriding as a habit — see the matrix.
+**The flags are independent.** `idx:indexed` writes the searchable terms, `idx:stored` a
+stored copy, `idx:facetable` facet docvalues, `idx:sortable` sort docvalues. Set the ones a
+query needs. `idx:stored` defaults to `true`, so leaving it alone stores everything.
 
-**One field, one job.** When a value needs both exact filtering and free-text search, define
-two fields over the same path rather than one field with a compromise analyzer. They are
-different Lucene fields; they cost one extra term dictionary and they never fight.
+**Exact match and free-text search want separate fields.** Two fields over the same path, one
+`KEYWORD` and one `TEXT`, rather than one field with an analyzer that suits neither.
 
-**Fields are path-free and reusable.** Define `field:title` once; bind it to `rdfs:label` on
-one shape and `dcterms:title` on another. Occurrences carry paths, fields carry behaviour.
+**Fields carry behaviour, occurrences carry paths.** Define `field:title` once and bind it to
+`rdfs:label` on one shape and `dcterms:title` on another.
 
 **Config changes are not retroactive.** Every flag decides what gets written at index time, so
 flipping `idx:facetable`, `idx:sortable`, `idx:stored`, a field type or an analyzer changes
@@ -59,12 +57,11 @@ What to **write in the config** — not what the defaults happen to be. `idx:ind
 | Full date or timestamp | `2023-04-01`, `2023-04-01T09:00:00Z` | `TemporalField` | ✗ | ✓ | ✓ |
 | Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | ✗ rejected |
 
-**Stored is ✗ on every row on purpose.** Filtering, faceting and sorting all read structures
-that `idx:stored` has nothing to do with: a date buckets from its epoch docvalues, a number
-from its points and docvalues, a keyword from its facet docvalues. Storing buys exactly one
-thing — the value coming back in `luc:match` / `luc:nestedMatch` — and costs index size and
-merge time. Set `idx:stored true` on the handful of fields a result list actually renders from
-the index rather than from the graph, and leave the rest.
+**Stored is ✗ on every row on purpose.** Filtering, faceting and sorting read points and
+docvalues, not the stored value: a date buckets from its epoch docvalues, a keyword from its
+facet docvalues. The stored copy only affects what `luc:match` / `luc:nestedMatch` can
+project. Set `idx:stored true` on the fields a result row renders from the index rather than
+from the graph.
 
 Set `idx:multiValued true` wherever the predicate can repeat — see
 [Multi-valued fields](#multi-valued-fields). Leave `idx:indexed` alone.
@@ -205,10 +202,9 @@ field:description
     idx:defaultSearch true .
 ```
 
-**Why.** Prose is where not storing pays most: the stored copy would be the biggest thing in
-the index, and the graph returns it by IRI for the page of results you actually render. Keep
-it indexed — that is the whole point — and put it in `defaultSearch` so a bare query string
-reaches it.
+**Why.** The stored copy of a description is usually the biggest thing in the index, and the
+graph returns it by IRI for the page of results being rendered. Keep it indexed, and put it in
+`defaultSearch` so a bare query string reaches it.
 
 Set `text:storeValues true` on the index only if `luc:match` needs to project field values at
 all; it is `false` by default.
@@ -301,11 +297,9 @@ Note the asymmetry worth knowing: numeric facet/sort docvalues are written from 
 field therefore produces one that counts and sorts but cannot be filtered — and the filter
 does not error, it is silently dropped. Leave `idx:indexed` alone.
 
-**Don't** store a number you can re-fetch and never display. If the values come from the
-graph the change listener keeps them current, so this is a size question, not a correctness
-one — but a stored copy of a field no result row renders is pure cost. If they come from an
-`idx:externalSource`, storing them also means a correction upstream is invisible until the
-next bulk build.
+**Don't** store a number no result row displays. Graph-derived values stay current either
+way, so this is index size rather than correctness — but values from an `idx:externalSource`
+are also frozen at the last bulk build.
 
 *Backed by `TestRangeFacetCounts` (INT, LONG, DOUBLE and TEMPORAL buckets).*
 
@@ -453,9 +447,9 @@ which is what makes sorting on a repeated field well-defined.
 |---|---|
 | `idx:indexed false` on anything a client filters | The clause is dropped, logged, and the query returns unfiltered results. No error |
 | One `TEXT` field doing exact match *and* search | Tokenisation breaks `=`; the analyzer you pick is wrong for one of the two jobs |
-| Storing values nothing projects | Index size and merge time bought for nothing. (Graph-derived values stay current — the change listener rebuilds the document — so this is cost, not staleness) |
+| Storing values nothing projects | Index size for no benefit. Graph-derived values stay current either way — the change listener rebuilds the document — so this is size, not staleness |
 | Storing external-source values you also correct upstream | A shape with `idx:externalSource` is rebuild-only: the producer refuses live changes and logs that the document is stale until `ShaclBulkIndexer` runs |
 | n-grams on names | Term explosion, broken ranking, `"Jon"` matching three unrelated people |
 | Flattening correlated children | "copper above 1%" matches the sample with copper at 0.2% and lead at 5% |
 | Forgetting `idx:multiValued` | Values after the first vanish with only a log line |
-| Facetable on a high-cardinality field | A facet dimension with a million single-count buckets answers nothing and costs memory |
+| Facetable on a high-cardinality field | A dimension of a million single-count buckets answers nothing and holds memory |

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -1,119 +1,76 @@
 # Suggested Configuration
 
-Opinionated defaults for the common kinds of data. Every recipe here is exercised by a test —
-the backing class is named so you can read the exact shape that is known to work.
-
-For what each term means, see [03-configuration.md](03-configuration.md). This page is about
-*which* to reach for.
+Defaults per kind of data. Terms are defined in [03-configuration.md](03-configuration.md);
+this page is which to pick. Each recipe names the test that pins it.
 
 ## Principles
 
-**The index is a filter, not a store of record.** The graph holds the truth. Lucene exists to
-narrow millions of entities to a page of candidates; the values come back from the KG, or from
-`luc:match` when you have deliberately stored them.
-
-Stored values drawn from the graph do **not** go stale: `ShaclTextDocProducer` rebuilds the
-whole entity document on any relevant triple change, resolving inverse and sequence paths back
-to the entities that need rebuilding. The exception is a shape with an `idx:externalSource`,
-which is rebuild-only — the producer refuses to act on a live change, since rebuilding from
-the graph alone would silently strip the CSV-derived children, and logs that the document is
-stale pending a `ShaclBulkIndexer` run.
-
-**The flags are independent.** `idx:indexed` writes the searchable terms, `idx:stored` a
-stored copy, `idx:facetable` facet docvalues, `idx:sortable` sort docvalues. Set the ones a
-query needs. `idx:stored` defaults to `true`, so leaving it alone stores everything.
-
-**Exact match and free-text search want separate fields.** Two fields over the same path, one
-`KEYWORD` and one `TEXT`, rather than one field with an analyzer that suits neither.
-
-**Fields carry behaviour, occurrences carry paths.** Define `field:title` once and bind it to
-`rdfs:label` on one shape and `dcterms:title` on another.
-
-**Config changes are not retroactive.** Every flag decides what gets written at index time, so
-flipping `idx:facetable`, `idx:sortable`, `idx:stored`, a field type or an analyzer changes
-nothing about documents already written — they keep the structures they were built with, and
-the new setting applies only to entities indexed after it. A field that starts answering
-queries wrongly rather than not at all is the usual symptom. Reindex after any field-level
-change.
+- The graph holds the values; the index narrows entities. Store a field only when
+  `luc:match` / `luc:nestedMatch` must project it.
+- Graph-derived documents are rebuilt on any relevant triple change. Shapes with an
+  `idx:externalSource` are rebuild-only: the producer refuses live changes and logs that the
+  document is stale until `ShaclBulkIndexer` runs.
+- The flags are independent: `idx:indexed` writes searchable terms, `idx:stored` a stored
+  copy, `idx:facetable` facet docvalues, `idx:sortable` sort docvalues.
+- Exact match and free-text search want two fields over one path, not one field with a
+  compromise analyzer.
+- Fields carry behaviour, occurrences carry paths. One field, many shapes.
+- Flags apply at index time only. Changing a type, analyzer or flag leaves existing documents
+  as they were — reindex.
 
 ## The matrix
 
-What to **write in the config** — not what the defaults happen to be. `idx:indexed` and
-`idx:stored` both default to `true`, so "stored ✗" below means *you must set
-`idx:stored false`*.
+What to write, not what the defaults are. `idx:indexed` and `idx:stored` both default to
+`true`, so `✗` means set it false explicitly.
 
 | Data kind | Example | `idx:fieldType` | stored | facetable | sortable |
 |---|---|---|---|---|---|
-| Title / label, for searching | `rdfs:label` of a report | `TextField` | ✗ | — | — |
-| Name, for exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` |
-| Description / abstract / body | `dcterms:description` | `TextField` | ✗ | — | — |
-| Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if you count them | — |
-| Identifier, prefix typeahead | same value, `EdgeNGramAnalyzer` | `TextField` | ✗ | — | — |
-| Controlled vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | — |
+| Title / label, searched | `rdfs:label` of a report | `TextField` | ✗ | — | — |
+| Name, exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` |
+| Description / abstract | `dcterms:description` | `TextField` | ✗ | — | — |
+| Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — |
+| Identifier, prefix typeahead | same value, n-grams | `TextField` | ✗ | — | — |
+| Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | — |
 | Level of a facet hierarchy | `state` then `commodity` | `KeywordField` | ✗ | ✓ | — |
 | Entity class | `rdf:type` → `Borehole` | `KeywordField` | ✗ | ✓ | — |
 | Year or count | `2023`, `42` | `IntField` | ✗ | ✓ | ✓ |
 | Measurement / grade / score | `12.4` | `DoubleField` | ✗ | ✓ | ✓ |
 | Full date or timestamp | `2023-04-01`, `2023-04-01T09:00:00Z` | `TemporalField` | ✗ | ✓ | ✓ |
-| Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | ✗ rejected |
+| Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | rejected |
 
-**Stored is ✗ on every row on purpose.** Filtering, faceting and sorting read points and
-docvalues, not the stored value: a date buckets from its epoch docvalues, a keyword from its
-facet docvalues. The stored copy only affects what `luc:match` / `luc:nestedMatch` can
-project. Set `idx:stored true` on the fields a result row renders from the index rather than
-from the graph.
+Filtering, faceting and sorting read points and docvalues, never the stored copy — so `✗`
+costs nothing but projection. Set `idx:multiValued true` wherever the predicate can repeat.
 
-Set `idx:multiValued true` wherever the predicate can repeat — see
-[Multi-valued fields](#multi-valued-fields). Leave `idx:indexed` alone.
+## Query syntax on a TEXT field
 
-## What a plain TEXT field already gives you
-
-A `TextField` with no analyzer override is not just "match these words". The `queryString`
-argument of `luc:query` goes to Lucene's classic
+`queryString` goes to Lucene's classic
 [`QueryParser`](https://lucene.apache.org/core/10_3_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description)
-— `MultiFieldQueryParser` when the `fieldSpec` names more than one field — so the whole
-classic syntax works out of the box, scored by BM25 (Lucene's default similarity; nothing here
-overrides it):
+(`MultiFieldQueryParser` for several fields), scored by BM25. No configuration needed:
 
-| Form | Example | Meaning |
-|---|---|---|
-| Term / phrase | `machine "machine learning"` | phrase requires adjacency |
-| Boolean | `machine AND learning`, `physics OR translation` | also `NOT`, `&&`, `\|\|` |
-| Required / prohibited | `+learning -physics` | must have, must not have |
-| Wildcard | `quan*`, `qu?ntum`, `*tum` | leading wildcards **are** enabled here |
-| Fuzzy | `learnimg~1` | edit distance |
-| Proximity (slop) | `"machine networks"~2` | terms within N positions |
-| Boost | `quantum^4 learning` | relevance weighting |
-| Grouping | `(machine OR deep) AND learning` | |
-| Range | `[a TO m]` | on a `TEXT` field, lexical |
-| Match all | `*` | short-circuits to `MatchAllDocsQuery` |
+| Form | Example |
+|---|---|
+| Phrase | `"machine learning"` |
+| Boolean | `machine AND learning`, `physics OR translation` |
+| Required / prohibited | `+learning -physics` |
+| Wildcard | `quan*`, `qu?ntum`, `*tum` (leading wildcards are enabled) |
+| Fuzzy | `learnimg~1` |
+| Proximity | `"machine networks"~2` |
+| Boost | `quantum^4 learning` |
+| Grouping | `(machine OR deep) AND learning` |
+| Term range | `[a TO m]` |
+| Match all | `*` |
 
-So typeahead-ish and forgiving behaviour is often a query-side choice, not a config one:
-`quan*` needs no n-gram field. Reach for `EdgeNGramAnalyzer` when you want prefix matching
-*ranked and fast* on a hot path, not merely possible.
+So `quan*` needs no n-gram field; add one when prefix matching must be ranked and fast.
 
-Two cautions:
+The string is analyzed with the field's query analyzer — on a `KEYWORD` field the whole value
+is one term. Scope with `fieldSpec`, not an embedded `fieldName:` prefix, which uses internal
+field names. Structured predicates belong in `cqlFilter`.
 
-- The query string is analyzed with the field's query analyzer, so it inherits whatever the
-  field does. On a `KEYWORD` field the whole value is one term and wildcards behave against
-  that single term, not against words inside it.
-- The parser also accepts an embedded `fieldName:value` prefix, which uses **internal**
-  `idx:fieldName` values and bypasses the field-IRI contract the rest of the API keeps. Scope
-  queries with the `fieldSpec` argument instead.
+*`TestLuceneQuerySyntax`*
 
-Structured predicates — `=`, ranges, `in`, `between`, spatial, same-child correlation — belong
-in the CQL filter argument, not the query string. See
-[02-sparql-api.md](02-sparql-api.md).
+## Titles and names
 
-*Backed by `TestLuceneQuerySyntax`.*
-
-## Names and titles
-
-First, decide whether you need one field or two.
-
-**A title or label you only search** — the report's `rdfs:label`, the paper's title — is one
-`TextField` and nothing else. There is no exact-match or facet requirement, so there is no
-second field:
+A label you only search is one field:
 
 ```turtle
 field:title
@@ -123,10 +80,8 @@ field:title
     idx:defaultSearch true .
 ```
 
-**A name that is also a filter value** — the author, the operator, the publisher, the agency —
-is the two-field case. Users search it as prose ("find reports by Sarah Jones") *and* pick it
-from a facet list ("Author: Jones, S. (14)"), and those want opposite analysis. So: two fields
-over one path, BM25 for finding, `KEYWORD` for filtering, counting and sorting.
+A name that is also a filter value — author, operator, publisher — is two fields over one
+path, because it is searched as prose *and* picked from a facet list:
 
 ```turtle
 field:authorNameText
@@ -148,20 +103,12 @@ field:authorName
     sh:property [ idx:field field:authorName     ; sh:path ( ex:authoredBy ex:name ) ] .
 ```
 
-**Why.** `"Sarah Jones"` should reach `"Dr Sarah Jones"` — that is BM25 over a tokenised
-field, with no analyzer override. The `KEYWORD` twin keeps the whole string as one term, so
-`= "Dr Sarah Jones"` is exact and the facet counts one bucket per person.
+`idx:normalizer` case-folds the indexed term and sort key; the facet label stays as authored.
 
-`idx:normalizer` makes the indexed term and the sort key case-folded while the stored value
-and the facet label stay as authored — so `"de Silva"` sorts next to `"De Silva"` instead of
-after `"Zhang"`, and the facet still reads correctly.
+**Don't** n-gram a name: term explosion, broken ranking, and `"Jon"` matches `"Jones"`,
+`"Jonathan"` and `"Jonsson"` indistinguishably.
 
-**Don't** put an n-gram analyzer on a name. It inflates the term dictionary, wrecks scoring,
-and `"Jon"` starts matching `"Jones"`, `"Jonathan"` and `"Jonsson"` with no way to rank them.
-Names want BM25.
-
-*Backed by `TestKeywordNormalizer`, `TestKeywordNormalizerTwinField`,
-`TestKeywordRawSortAndExactMatch`.*
+*`TestKeywordNormalizer`, `TestKeywordNormalizerTwinField`, `TestKeywordRawSortAndExactMatch`*
 
 ## Identifiers and codes
 
@@ -176,23 +123,16 @@ field:identifierPrefix
     idx:fieldName "identifierPrefix" ;
     idx:fieldType idx:TextField ;
     idx:stored false ;
-    idx:analyzer [ a text:EdgeNGramAnalyzer ] .   # whole-value, NOT tokenized
+    idx:analyzer [ a text:EdgeNGramAnalyzer ] .   # whole-value, not tokenized
 ```
 
-**Why.** An identifier is looked up two ways: pasted whole (`= "RPT-MIA-2023-001"`, the
-`KEYWORD` field), or typed progressively (`RPT-MIA` → the edge-n-gram field). Whole-value
-n-grams mean `"RPT-MIA"` reaches `RPT-MIA-2023-001` while `"2023"` does not — a prefix of the
-identifier, not of some fragment inside it.
+Whole-value n-grams: `"RPT-MIA"` reaches `RPT-MIA-2023-001`, `"2023"` does not. Add
+`text:tokenized true` for interior segments, accepting that `"2023"` then matches every 2023
+report.
 
-Add `text:tokenized true` only when users legitimately search from an interior segment, and
-know that you are buying `"2023"` matching every 2023 report.
+*`TestTypeaheadFieldConfigurations`*
 
-**Don't** store the prefix field. It is a search structure with no display value; the exact
-twin already holds the string.
-
-*Backed by `TestTypeaheadFieldConfigurations` (both whole-value and per-word variants).*
-
-## Descriptions and free text
+## Descriptions
 
 ```turtle
 field:description
@@ -202,21 +142,21 @@ field:description
     idx:defaultSearch true .
 ```
 
-**Why.** The stored copy of a description is usually the biggest thing in the index, and the
-graph returns it by IRI for the page of results being rendered. Keep it indexed, and put it in
-`defaultSearch` so a bare query string reaches it.
+The stored copy would be the largest thing in the index; the graph returns it by IRI.
+`text:storeValues` on the index is `false` by default.
 
-Set `text:storeValues true` on the index only if `luc:match` needs to project field values at
-all; it is `false` by default.
+## Vocabularies and taxonomies
 
-## Controlled vocabularies, categories, taxonomies
-
-A **vocabulary term** is one value from a closed list — `Gold`, `Approved`, `WA`. A
-**taxonomy level** is one field per rung of a fixed drill-down: state, then commodity within
-state. The fields are ordinary `KEYWORD` facet fields; `idx:facetHierarchy` is what declares
-that one nests under the other, so a UI can offer WA → Gold → … without a query per rung.
+A vocabulary term is one value from a closed list. A hierarchy level is one field per rung;
+`idx:facetHierarchy` declares the nesting.
 
 ```turtle
+field:state
+    idx:fieldName "state" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored false ;
+    idx:facetable true .
+
 field:commodity
     idx:fieldName "commodity" ;
     idx:fieldType idx:KeywordField ;
@@ -224,36 +164,20 @@ field:commodity
     idx:facetable true ;
     idx:multiValued true .
 
-field:state
-    idx:fieldName "state" ;
-    idx:fieldType idx:KeywordField ;
-    idx:stored false ;
-    idx:facetable true .
-
 <#MiningReportShape>
     sh:property [ idx:field field:state     ; sh:path ex:state ] ;
     sh:property [ idx:field field:commodity ; sh:path ex:commodity ] ;
     idx:facetHierarchy ( field:state field:commodity ) .
 ```
 
-**Why.** Vocabulary terms are exactly the `KEYWORD` case: a closed set, filtered with `=` or
-`in`, counted as facets. Not stored, because the label is already in the graph and the facet
-carries its own value.
+Each level keeps its own flat dimension, so faceting on `field:commodity` alone still works.
 
-`idx:facetHierarchy` adds a drill-down dimension over the same fields — WA → Gold → … — and
-each level keeps its own flat dimension, so faceting on `field:commodity` alone still works.
-The two are addressed separately and neither shadows the other.
+**Don't** use `TEXT`. `=` compiles to a term query either way, so against a tokenised field it
+looks for the term `"Iron Ore"`, which analysis never produced — matching nothing, silently.
 
-**Don't** index a vocabulary term as `TEXT`. `=` compiles to a raw term query either way, so
-against a tokenised field it looks for the single term `"Iron Ore"` — which analysis never
-produced, having emitted `iron` and `ore`. The filter matches nothing, with no error. Use
-`text_query` when you want analyzer-aware matching, and `KEYWORD` when you want `=`.
-
-*Backed by `TestHierarchicalFacets`, `TestHierarchicalFacetsSparql`, `TestNativeFacetCounts`.*
+*`TestHierarchicalFacets`, `TestHierarchicalFacetsSparql`, `TestNativeFacetCounts`*
 
 ## Entity class
-
-Index `rdf:type` as an ordinary `KEYWORD` facet field and bind it on **every** shape:
 
 ```turtle
 field:entityType
@@ -264,18 +188,11 @@ field:entityType
 
 <#MiningReportShape>
     sh:property [ idx:field field:entityType ; sh:path rdf:type ] .
-
-<#BoreholeShape>
-    sh:property [ idx:field field:entityType ; sh:path rdf:type ] .
 ```
 
-**Why.** One index usually holds several shapes, and a search crosses all of them. Faceting on
-this field answers "what kinds of thing matched?" — *Reports 23, Boreholes 51, Sites 4* — in
-the same request as the hits, and the same field filters a result list down to one class. An
-IRI-valued path indexes as its IRI string, so the facet values are the class IRIs.
-
-Note this is a *field you configure*, not the internal `idx:discriminatorField` — that one is
-written automatically for delete scoping and is not a public facet.
+Bind on every shape: one search crosses all of them, and this answers "Reports 23, Boreholes
+51" in the same request. IRI-valued paths index as their IRI string. Distinct from
+`idx:discriminatorField`, which is internal to delete scoping.
 
 ## Numbers and measurements
 
@@ -283,31 +200,23 @@ written automatically for delete scoping and is not a public facet.
 field:grade
     idx:fieldName "grade" ;
     idx:fieldType idx:DoubleField ;
-    idx:facetable true ;   # range facet buckets
-    idx:sortable true ;    # ORDER BY, nested sort selector
-    idx:stored false .     # the assay database is the source of truth
+    idx:stored false ;
+    idx:facetable true ;
+    idx:sortable true .
 ```
 
-**Why.** `DOUBLE` gives range filters (`>=`, `between`) as a points query, and range facets
-declared per query rather than per config — you pass the boundaries in the `luc:facet` call,
-so re-bucketing needs no reindex.
+Range facet boundaries are per query, so re-bucketing needs no reindex.
 
-Note the asymmetry worth knowing: numeric facet/sort docvalues are written from `facetable` or
-`sortable` alone, independently of `idx:indexed`. Leaving `idx:indexed false` on a numeric
-field therefore produces one that counts and sorts but cannot be filtered — and the filter
-does not error, it is silently dropped. Leave `idx:indexed` alone.
+Numeric docvalues come from `facetable`/`sortable` independently of `idx:indexed`, so
+`idx:indexed false` yields a field that counts and sorts but cannot be filtered — and the
+filter is dropped silently, not rejected. Leave `idx:indexed` alone.
 
-**Don't** store a number no result row displays. Graph-derived values stay current either
-way, so this is index size rather than correctness — but values from an `idx:externalSource`
-are also frozen at the last bulk build.
-
-*Backed by `TestRangeFacetCounts` (INT, LONG, DOUBLE and TEMPORAL buckets).*
+*`TestRangeFacetCounts`*
 
 ## Dates
 
-`TemporalField` is for a **full date or timestamp** — an `xsd:date` like `2023-04-01` or an
-`xsd:dateTime` like `2023-04-01T09:00:00Z`. A bare year is not a date: index `2023` as an
-`IntField` and it filters, buckets and sorts as the number it is.
+`TemporalField` is a full date or timestamp — `xsd:date` or `xsd:dateTime`. A bare year is an
+`IntField`.
 
 ```turtle
 field:publishedOn
@@ -319,47 +228,34 @@ field:publishedOn
     idx:storeLiteralMetadata true .   # required — config fails without it
 ```
 
-**Why.** A `TEMPORAL` field parses the lexical form to epoch millis and indexes *that*, in a
-companion field — filtering and sorting are numeric, and a date-only value is treated as
-start-of-day UTC. Range facets take ISO boundaries (`"2019-01-01"`), not epoch numbers, so
-re-bucketing is a query change, never a reindex.
+Values are indexed as epoch millis in a companion field, so filtering and sorting are numeric
+and date-only values are start-of-day UTC. Range facet boundaries are ISO strings.
 
-The epoch companion is what answers queries, so the field does not need to be stored to be
-filtered, bucketed or sorted. Set `idx:stored true` only if a result row shows the date
-straight from the index.
+`idx:storeLiteralMetadata true` is mandatory on `TEMPORAL`
+(`ShaclIndexMapping.validateLiteralMetadataRequirements`), including on an unstored field
+where it qualifies nothing.
 
-`idx:storeLiteralMetadata true` is **not optional**: a `TEMPORAL` field without it is rejected
-at config time (`ShaclIndexMapping.validateLiteralMetadataRequirements`). It stores the
-datatype and language alongside the value so a projected hit rebuilds as the literal it came
-from rather than a bare string. The check is unconditional, so you must set it even on an
-unstored date where the metadata has nothing to qualify.
+An unparseable date is logged and drops out of range queries while the entity stays indexed —
+so bad dates narrow results silently. Validate on the way in.
 
-A value that fails to parse is logged and simply does not participate in range queries — the
-entity is still indexed on its other fields, so a bad date silently narrows results rather
-than failing loudly. Validate dates on the way in.
+**Don't** use `KEYWORD` for sortable dates: lexical order is correct only for zero-padded ISO,
+and range filters are gone.
 
-**Don't** model a date as `KEYWORD` to get "sortable strings". It sorts lexically, which is
-correct only for zero-padded ISO dates and wrong the moment a timezone offset appears, and you
-lose range filters entirely.
+*`TestDateLiteralRoundTrip`, `TestRangeFacetCounts`*
 
-*Backed by `TestDateLiteralRoundTrip` (filter, sort, invalid-value handling) and the temporal
-case in `TestRangeFacetCounts`.*
-
-## Observations and measurement records (SOSA-style)
-
-One row per observation, correlated per child. This is the case `idx:nested` exists for.
+## Observations (SOSA-style)
 
 ```turtle
 field:observedProperty
     idx:fieldName "observedProperty" ;
     idx:fieldType idx:KeywordField ;
-    idx:stored true ;           # projected by luc:nestedMatch — see below
+    idx:stored true ;           # projected by luc:nestedMatch
     idx:facetable true .
 
 field:resultValue
     idx:fieldName "resultValue" ;
     idx:fieldType idx:DoubleField ;
-    idx:stored true ;           # ditto — a hit should show which reading matched
+    idx:stored true ;
     idx:facetable true ;
     idx:sortable true .
 
@@ -372,38 +268,29 @@ field:resultUnits
 <#SampleShape>
     sh:targetClass sosa:Sample ;
     sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
-
     idx:nested [
         idx:joinPath [ sh:inversePath sosa:hasFeatureOfInterest ] ;
         idx:property [ idx:field field:observedProperty ; sh:path ( sosa:observedProperty rdfs:label ) ] ;
         idx:property [ idx:field field:resultValue      ; sh:path sosa:hasSimpleResult ] ;
-        idx:property [ idx:field field:resultUnits      ; sh:path ex:units ] ;
         idx:facetHierarchy ( field:observedProperty field:resultUnits ) ;
     ] .
 ```
 
-**Why nested and not flat.** Flatten observations onto the sample and "copper above 1%"
-matches a sample with copper at 0.2% and lead at 5% — the values decorrelate. Inside an
-`idx:nested` block each observation is its own child document, and AND-ed clauses in the same
-scope fold into one block join, so both conditions must hold *on one observation*.
+Each observation is its own child document, so AND-ed clauses in one scope must hold on a
+single observation. Flattened, "copper above 1%" would match a sample with copper at 0.2% and
+lead at 5%. Correlation covers `=`, ranges, `in`, `between`, `like` and `text_query`.
 
-This correlation covers `=`, ranges, `in`, `between`, `like` and `text_query` — not just
-equality.
+Millions of observations that are not in the graph: use `idx:externalSource` instead — one CSV
+row per child, same semantics. See
+[External Content](03-configuration.md#external-content-csvtsv).
 
-**When the observations are not in the graph**, and there are millions of them, bind an
-`idx:externalSource` instead: one CSV row becomes one child document, joined on the entity
-IRI, with the values never loaded as triples. Same query semantics, same correlation. See
-[03-configuration.md → External Content](03-configuration.md#external-content-csvtsv).
+**Don't** nest a single-field child; that is a multi-valued field with extra machinery.
 
-**Don't** reach for nesting when the child has exactly one field. A single-field child is a
-multi-valued field on the parent with extra machinery.
+**Untested:** a `TEMPORAL` field inside a nested block.
 
-**Not covered by a test:** a `TEMPORAL` field *inside* a nested block. Result times on the
-parent are well covered; if you need `sosa:resultTime` per observation, add a test with it.
-
-*Backed by `TestNestedJoinPathSupport`, `TestCorrelatedNestedAttribution`,
-`TestNestedHierarchicalFacets`, `TestNestedMatchProjection`, `TestNestedSortSelector`,
-`TestExternalContentIndexing`, `TestGswaMeasurementCsv`.*
+*`TestNestedJoinPathSupport`, `TestCorrelatedNestedAttribution`, `TestNestedHierarchicalFacets`,
+`TestNestedMatchProjection`, `TestNestedSortSelector`, `TestExternalContentIndexing`,
+`TestGswaMeasurementCsv`*
 
 ## Geometry
 
@@ -411,45 +298,36 @@ parent are well covered; if you need `sosa:resultTime` per observation, add a te
 field:location
     idx:fieldName "location" ;
     idx:fieldType idx:LatLonField ;
-    idx:stored false .          # the WKT lives in the graph
+    idx:stored false .
 
 <#SiteShape>
     sh:property [ idx:field field:location ; sh:path geo:asWKT ] .
 ```
 
-`POINT`, `POLYGON` and `MULTIPOLYGON` WKT are indexed for spatial filters. Anything else —
-`LINESTRING`, `MULTIPOINT` — is logged and **skipped**, so a geometry column of mixed types
-quietly indexes only part of itself. CRS84 (bare WKT) and EPSG:4326 both work with axis order
-handled for you; GDA94/GDA2020 are treated as WGS84-equivalent.
+`POINT`, `POLYGON` and `MULTIPOLYGON` are indexed; `LINESTRING`, `MULTIPOINT` and the rest are
+logged and skipped, so mixed geometry columns index only in part. CRS84 and EPSG:4326 both
+work; GDA94/GDA2020 are treated as WGS84. Sorting is rejected and equality is meaningless —
+use the spatial CQL operators ([09-spatial.md](09-spatial.md)).
 
-Sorting on a `LatLon` field is rejected outright, and equality is meaningless — use the
-spatial CQL operators. See [09-spatial.md](09-spatial.md).
-
-*Backed by `TestSpatialFiltering`.*
+*`TestSpatialFiltering`*
 
 ## Multi-valued fields
 
-Set `idx:multiValued true` whenever the predicate can legitimately repeat.
+Without `idx:multiValued true`, values after the first are dropped with a log warning — which
+looks fine until one entity has two commodities. On `KEYWORD` it also selects `SortedSet`
+docvalues, making sort on a repeated field well-defined.
 
-Without it, a second value is **dropped with a warning** — the document keeps the first value
-and the entity silently stops matching on the rest. This is the single most common
-misconfiguration, because it works perfectly until one entity has two commodities.
-
-For `KEYWORD` fields it also selects the docvalues shape (`SortedSet` rather than `Sorted`),
-which is what makes sorting on a repeated field well-defined.
-
-*Backed by `TestKeywordNormalizerMultiValued`,
-`TestShaclLucQueryRawValueOnMultiValuedField`.*
+*`TestKeywordNormalizerMultiValued`, `TestShaclLucQueryRawValueOnMultiValuedField`*
 
 ## Anti-patterns
 
 | Pattern | What goes wrong |
 |---|---|
-| `idx:indexed false` on anything a client filters | The clause is dropped, logged, and the query returns unfiltered results. No error |
-| One `TEXT` field doing exact match *and* search | Tokenisation breaks `=`; the analyzer you pick is wrong for one of the two jobs |
-| Storing values nothing projects | Index size for no benefit. Graph-derived values stay current either way — the change listener rebuilds the document — so this is size, not staleness |
-| Storing external-source values you also correct upstream | A shape with `idx:externalSource` is rebuild-only: the producer refuses live changes and logs that the document is stale until `ShaclBulkIndexer` runs |
-| n-grams on names | Term explosion, broken ranking, `"Jon"` matching three unrelated people |
-| Flattening correlated children | "copper above 1%" matches the sample with copper at 0.2% and lead at 5% |
-| Forgetting `idx:multiValued` | Values after the first vanish with only a log line |
-| Facetable on a high-cardinality field | A dimension of a million single-count buckets answers nothing and holds memory |
+| `idx:indexed false` on a filtered field | Clause dropped and logged; results come back unfiltered, no error |
+| One `TEXT` field for exact match *and* search | Tokenisation breaks `=` |
+| Storing values nothing projects | Index size for no benefit |
+| Storing external-source values corrected upstream | Rebuild-only shape: stale until `ShaclBulkIndexer` runs |
+| n-grams on names | Term explosion, broken ranking |
+| Flattening correlated children | Cross-matching between unrelated child records |
+| Forgetting `idx:multiValued` | Values after the first vanish with a log line |
+| `facetable` on a high-cardinality field | A dimension of single-count buckets, holding memory |

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -19,12 +19,6 @@ which is rebuild-only — the producer refuses to act on a live change, since re
 the graph alone would silently strip the CSV-derived children, and logs that the document is
 stale pending a `ShaclBulkIndexer` run.
 
-So for graph-derived fields the reason not to store is cost, not staleness: a stored copy of a
-field nothing projects is index size and merge time bought for nothing.
-
-*The live-rebuild behaviour is pinned by `TestShaclTextDocProducer`; the rebuild-only refusal
-by `TestExternalContentIndexing` ("live graph change does not strip external children").*
-
 **Each flag buys exactly one capability, and costs one structure.** `idx:indexed` for
 filtering, `idx:stored` for projection, `idx:facetable` for counts, `idx:sortable` for
 `ORDER BY`. Turn on what a query needs and nothing else. Note that `idx:stored` defaults to

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -15,8 +15,8 @@ stale the moment the source changes, and a rebuild you owe.
 
 **Each flag buys exactly one capability, and costs one structure.** `idx:indexed` for
 filtering, `idx:stored` for projection, `idx:facetable` for counts, `idx:sortable` for
-`ORDER BY`. Turn on what a query needs. The defaults — indexed and stored, not facetable, not
-sortable — are right for most fields.
+`ORDER BY`. Turn on what a query needs and nothing else. Note that `idx:stored` defaults to
+`true`, which is the one default worth overriding as a habit — see the matrix.
 
 **One field, one job.** When a value needs both exact filtering and free-text search, define
 two fields over the same path rather than one field with a compromise analyzer. They are
@@ -29,37 +29,108 @@ one shape and `dcterms:title` on another. Occurrences carry paths, fields carry 
 
 ## The matrix
 
-| Data kind | `idx:fieldType` | indexed | stored | facetable | sortable | Analyzer |
-|---|---|---|---|---|---|---|
-| Title / label, for searching | `TextField` | ✓ default | ✓ if projected | — | — | index default (BM25) |
-| Name, for exact match + counts | `KeywordField` | ✓ default | ✓ default | ✓ | ✓ + `idx:normalizer` | — |
-| Description / abstract / body | `TextField` | ✓ default | ✗ | — | — | index default |
-| Identifier / code, exact | `KeywordField` | ✓ default | ✓ default | ✓ if you count them | — | — |
-| Identifier, prefix typeahead | `TextField` | ✓ default | ✗ | — | — | `EdgeNGramAnalyzer` whole-value |
-| Controlled vocabulary term | `KeywordField` | ✓ default | ✗ | ✓ | — | — |
-| Taxonomy level | `KeywordField` | ✓ default | ✗ | ✓ | — | — (+ `idx:facetHierarchy`) |
-| Entity type pivot | `KeywordField` | ✓ default | ✗ | ✓ | — | — |
-| Year / count | `IntField` | ✓ default | ✓ default | ✓ | ✓ | — |
-| Measurement / grade / score | `DoubleField` | ✓ default | ✗ | ✓ | ✓ | — |
-| Date / timestamp | `TemporalField` | ✓ default | ✓ default | ✓ | ✓ | — (+ `idx:storeLiteralMetadata true`) |
-| Geometry | `LatLonField` | ✓ default | ✓ default | — | ✗ rejected | — |
+What to **write in the config** — not what the defaults happen to be. `idx:indexed` and
+`idx:stored` both default to `true`, so "stored ✗" below means *you must set
+`idx:stored false`*.
 
-`✓ default` means you get it without writing anything. Set `idx:multiValued true` wherever the
-predicate can repeat — see [Multi-valued fields](#multi-valued-fields).
+| Data kind | Example | `idx:fieldType` | stored | facetable | sortable |
+|---|---|---|---|---|---|
+| Title / label, for searching | `rdfs:label` of a report | `TextField` | ✗ | — | — |
+| Name, for exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` |
+| Description / abstract / body | `dcterms:description` | `TextField` | ✗ | — | — |
+| Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if you count them | — |
+| Identifier, prefix typeahead | same value, `EdgeNGramAnalyzer` | `TextField` | ✗ | — | — |
+| Controlled vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | — |
+| Level of a facet hierarchy | `state` then `commodity` | `KeywordField` | ✗ | ✓ | — |
+| Entity class | `rdf:type` → `Borehole` | `KeywordField` | ✗ | ✓ | — |
+| Year or count | `2023`, `42` | `IntField` | ✗ | ✓ | ✓ |
+| Measurement / grade / score | `12.4` | `DoubleField` | ✗ | ✓ | ✓ |
+| Full date or timestamp | `2023-04-01`, `2023-04-01T09:00:00Z` | `TemporalField` | ✗ | ✓ | ✓ |
+| Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | ✗ rejected |
+
+**Stored is ✗ on every row on purpose.** Filtering, faceting and sorting all read structures
+that `idx:stored` has nothing to do with: a date buckets from its epoch docvalues, a number
+from its points and docvalues, a keyword from its facet docvalues. Storing buys exactly one
+thing — the value coming back in `luc:match` / `luc:nestedMatch` — and costs a copy that goes
+stale. Set `idx:stored true` on the handful of fields a result list actually renders from the
+index rather than from the graph, and leave the rest.
+
+Set `idx:multiValued true` wherever the predicate can repeat — see
+[Multi-valued fields](#multi-valued-fields). Leave `idx:indexed` alone.
+
+## What a plain TEXT field already gives you
+
+A `TextField` with no analyzer override is not just "match these words". The `queryString`
+argument of `luc:query` goes to Lucene's classic
+[`QueryParser`](https://lucene.apache.org/core/10_3_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description)
+— `MultiFieldQueryParser` when the `fieldSpec` names more than one field — so the whole
+classic syntax works out of the box, scored by BM25 (Lucene's default similarity; nothing here
+overrides it):
+
+| Form | Example | Meaning |
+|---|---|---|
+| Term / phrase | `machine "machine learning"` | phrase requires adjacency |
+| Boolean | `machine AND learning`, `physics OR translation` | also `NOT`, `&&`, `\|\|` |
+| Required / prohibited | `+learning -physics` | must have, must not have |
+| Wildcard | `quan*`, `qu?ntum`, `*tum` | leading wildcards **are** enabled here |
+| Fuzzy | `learnimg~1` | edit distance |
+| Proximity (slop) | `"machine networks"~2` | terms within N positions |
+| Boost | `quantum^4 learning` | relevance weighting |
+| Grouping | `(machine OR deep) AND learning` | |
+| Range | `[a TO m]` | on a `TEXT` field, lexical |
+| Match all | `*` | short-circuits to `MatchAllDocsQuery` |
+
+So typeahead-ish and forgiving behaviour is often a query-side choice, not a config one:
+`quan*` needs no n-gram field. Reach for `EdgeNGramAnalyzer` when you want prefix matching
+*ranked and fast* on a hot path, not merely possible.
+
+Two cautions:
+
+- The query string is analyzed with the field's query analyzer, so it inherits whatever the
+  field does. On a `KEYWORD` field the whole value is one term and wildcards behave against
+  that single term, not against words inside it.
+- The parser also accepts an embedded `fieldName:value` prefix, which uses **internal**
+  `idx:fieldName` values and bypasses the field-IRI contract the rest of the API keeps. Scope
+  queries with the `fieldSpec` argument instead.
+
+Structured predicates — `=`, ranges, `in`, `between`, spatial, same-child correlation — belong
+in the CQL filter argument, not the query string. See
+[02-sparql-api.md](02-sparql-api.md).
+
+*Backed by `TestLuceneQuerySyntax`.*
 
 ## Names and titles
 
-Two fields over one path: BM25 for finding, `KEYWORD` for filtering and counting.
+First, decide whether you need one field or two.
+
+**A title or label you only search** — the report's `rdfs:label`, the paper's title — is one
+`TextField` and nothing else. There is no exact-match or facet requirement, so there is no
+second field:
+
+```turtle
+field:title
+    idx:fieldName "title" ;
+    idx:fieldType idx:TextField ;
+    idx:stored false ;
+    idx:defaultSearch true .
+```
+
+**A name that is also a filter value** — the author, the operator, the publisher, the agency —
+is the two-field case. Users search it as prose ("find reports by Sarah Jones") *and* pick it
+from a facet list ("Author: Jones, S. (14)"), and those want opposite analysis. So: two fields
+over one path, BM25 for finding, `KEYWORD` for filtering, counting and sorting.
 
 ```turtle
 field:authorNameText
     idx:fieldName "authorNameText" ;
     idx:fieldType idx:TextField ;
+    idx:stored false ;
     idx:defaultSearch true .
 
 field:authorName
     idx:fieldName "authorName" ;
     idx:fieldType idx:KeywordField ;
+    idx:stored false ;
     idx:facetable true ;
     idx:sortable true ;
     idx:normalizer [ a text:LowerCaseKeywordAnalyzer ] .
@@ -90,6 +161,7 @@ Names want BM25.
 field:identifier
     idx:fieldName "identifier" ;
     idx:fieldType idx:KeywordField ;
+    idx:stored false ;
     idx:facetable true .
 
 field:identifierPrefix
@@ -122,14 +194,20 @@ field:description
     idx:defaultSearch true .
 ```
 
-**Why.** Long prose is the one case where `idx:stored false` clearly pays: the stored copy is
-the biggest thing in the index and the graph can return it by IRI. Keep it indexed — that is
-the whole point — and put it in `defaultSearch` so a bare query string reaches it.
+**Why.** Prose is where not storing pays most: the stored copy would be the biggest thing in
+the index, and the graph returns it by IRI for the page of results you actually render. Keep
+it indexed — that is the whole point — and put it in `defaultSearch` so a bare query string
+reaches it.
 
 Set `text:storeValues true` on the index only if `luc:match` needs to project field values at
 all; it is `false` by default.
 
 ## Controlled vocabularies, categories, taxonomies
+
+A **vocabulary term** is one value from a closed list — `Gold`, `Approved`, `WA`. A
+**taxonomy level** is one field per rung of a fixed drill-down: state, then commodity within
+state. The fields are ordinary `KEYWORD` facet fields; `idx:facetHierarchy` is what declares
+that one nests under the other, so a UI can offer WA → Gold → … without a query per rung.
 
 ```turtle
 field:commodity
@@ -166,7 +244,9 @@ produced, having emitted `iron` and `ore`. The filter matches nothing, with no e
 
 *Backed by `TestHierarchicalFacets`, `TestHierarchicalFacetsSparql`, `TestNativeFacetCounts`.*
 
-## Entity type pivots
+## Entity class
+
+Index `rdf:type` as an ordinary `KEYWORD` facet field and bind it on **every** shape:
 
 ```turtle
 field:entityType
@@ -177,10 +257,18 @@ field:entityType
 
 <#MiningReportShape>
     sh:property [ idx:field field:entityType ; sh:path rdf:type ] .
+
+<#BoreholeShape>
+    sh:property [ idx:field field:entityType ; sh:path rdf:type ] .
 ```
 
-An IRI-valued path indexes as its IRI string, so this gives "23 Reports, 51 Boreholes" across
-a mixed index without a second query. Bind it on every shape.
+**Why.** One index usually holds several shapes, and a search crosses all of them. Faceting on
+this field answers "what kinds of thing matched?" — *Reports 23, Boreholes 51, Sites 4* — in
+the same request as the hits, and the same field filters a result list down to one class. An
+IRI-valued path indexes as its IRI string, so the facet values are the class IRIs.
+
+Note this is a *field you configure*, not the internal `idx:discriminatorField` — that one is
+written automatically for delete scoping and is not a public facet.
 
 ## Numbers and measurements
 
@@ -209,23 +297,34 @@ moment the value is corrected.
 
 ## Dates
 
+`TemporalField` is for a **full date or timestamp** — an `xsd:date` like `2023-04-01` or an
+`xsd:dateTime` like `2023-04-01T09:00:00Z`. A bare year is not a date: index `2023` as an
+`IntField` and it filters, buckets and sorts as the number it is.
+
 ```turtle
 field:publishedOn
     idx:fieldName "publishedOn" ;
     idx:fieldType idx:TemporalField ;
+    idx:stored false ;
     idx:facetable true ;
     idx:sortable true ;
     idx:storeLiteralMetadata true .   # required — config fails without it
 ```
 
-**Why.** A `TEMPORAL` field parses `xsd:date` / `xsd:dateTime` to epoch millis and indexes
-*that* — filtering and sorting are numeric, and date-only values are treated as start-of-day
-UTC. Range facets take ISO boundaries (`"2019-01-01"`), not epoch numbers, so a config change
-is never needed to re-bucket.
+**Why.** A `TEMPORAL` field parses the lexical form to epoch millis and indexes *that*, in a
+companion field — filtering and sorting are numeric, and a date-only value is treated as
+start-of-day UTC. Range facets take ISO boundaries (`"2019-01-01"`), not epoch numbers, so
+re-bucketing is a query change, never a reindex.
+
+The epoch companion is what answers queries, so the field does not need to be stored to be
+filtered, bucketed or sorted. Set `idx:stored true` only if a result row shows the date
+straight from the index.
 
 `idx:storeLiteralMetadata true` is **not optional**: a `TEMPORAL` field without it is rejected
-at config time. It stores the datatype and language alongside the value so a projected hit
-rebuilds as the literal it came from rather than a bare string.
+at config time (`ShaclIndexMapping.validateLiteralMetadataRequirements`). It stores the
+datatype and language alongside the value so a projected hit rebuilds as the literal it came
+from rather than a bare string. The check is unconditional, so you must set it even on an
+unstored date where the metadata has nothing to qualify.
 
 A value that fails to parse is logged and simply does not participate in range queries — the
 entity is still indexed on its other fields, so a bad date silently narrows results rather
@@ -246,17 +345,20 @@ One row per observation, correlated per child. This is the case `idx:nested` exi
 field:observedProperty
     idx:fieldName "observedProperty" ;
     idx:fieldType idx:KeywordField ;
+    idx:stored true ;           # projected by luc:nestedMatch — see below
     idx:facetable true .
 
 field:resultValue
     idx:fieldName "resultValue" ;
     idx:fieldType idx:DoubleField ;
+    idx:stored true ;           # ditto — a hit should show which reading matched
     idx:facetable true ;
     idx:sortable true .
 
 field:resultUnits
     idx:fieldName "resultUnits" ;
     idx:fieldType idx:KeywordField ;
+    idx:stored true ;
     idx:facetable true .
 
 <#SampleShape>
@@ -300,7 +402,8 @@ parent are well covered; if you need `sosa:resultTime` per observation, add a te
 ```turtle
 field:location
     idx:fieldName "location" ;
-    idx:fieldType idx:LatLonField .
+    idx:fieldType idx:LatLonField ;
+    idx:stored false .          # the WKT lives in the graph
 
 <#SiteShape>
     sh:property [ idx:field field:location ; sh:path geo:asWKT ] .

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -14,18 +14,13 @@ narrow millions of entities to a page of candidates; the values come back from t
 
 Stored values drawn from the graph do **not** go stale: `ShaclTextDocProducer` rebuilds the
 whole entity document on any relevant triple change, resolving inverse and sequence paths back
-to the entities that need rebuilding. Two cases do decay, and they are the ones to hold in
-mind:
+to the entities that need rebuilding. The exception is a shape with an `idx:externalSource`,
+which is rebuild-only — the producer refuses to act on a live change, since rebuilding from
+the graph alone would silently strip the CSV-derived children, and logs that the document is
+stale pending a `ShaclBulkIndexer` run.
 
-- **External children.** A shape with an `idx:externalSource` is rebuild-only. The producer
-  refuses to act on a live change — rebuilding from the graph alone would silently strip the
-  CSV-derived children — and logs that the document is now stale pending a `ShaclBulkIndexer`
-  run. Values sourced from a file are as fresh as the last build.
-- **Anything corrected outside the dataset.** If the authoritative value lives in a database
-  the graph mirrors, storing it in Lucene adds a second copy to keep in step.
-
-So the reason not to store is mostly cost, not staleness: a stored copy of a field nothing
-projects is index size and merge time bought for nothing.
+So for graph-derived fields the reason not to store is cost, not staleness: a stored copy of a
+field nothing projects is index size and merge time bought for nothing.
 
 *The live-rebuild behaviour is pinned by `TestShaclTextDocProducer`; the rebuild-only refusal
 by `TestExternalContentIndexing` ("live graph change does not strip external children").*

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -27,7 +27,7 @@ What to write, not what the defaults are. `idx:indexed` and `idx:stored` both de
 | Name, exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` | exact match only |
 | Description / abstract | `dcterms:description` | `TextField` | ✓ | — | — | ✓ |
 | Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — | exact match only |
-| Identifier, prefix typeahead | same value, n-grams | `TextField` | ✗ | — | — | via `text:GenericAnalyzer` |
+| Identifier, prefix typeahead | `RPT-MIA` | `TextField` | ✗ | — | — | via `text:GenericAnalyzer` |
 | Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | ✓ if sorted on | exact match only |
 | Level of a facet hierarchy | `country` then `state` | `KeywordField` | ✗ | ✓ | — | ✗ |
 | Entity class | `rdf:type` → `Borehole` | `KeywordField` | ✗ | ✓ | — | ✗ |

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -147,30 +147,40 @@ The stored copy would be the largest thing in the index; the graph returns it by
 
 ## Vocabularies and taxonomies
 
-A vocabulary term is one value from a closed list. A hierarchy level is one field per rung;
-`idx:facetHierarchy` declares the nesting.
+A vocabulary term is one value from a closed list. Add `idx:multiValued true` if the predicate
+repeats:
 
 ```turtle
+field:status
+    idx:fieldName "status" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored false ;
+    idx:facetable true .
+```
+
+A hierarchy is one field per level, listed parent to child. `idx:facetHierarchy` declares the
+nesting so a facet can drill from a country into its states:
+
+```turtle
+field:country
+    idx:fieldName "country" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored false ;
+    idx:facetable true .
+
 field:state
     idx:fieldName "state" ;
     idx:fieldType idx:KeywordField ;
     idx:stored false ;
     idx:facetable true .
 
-field:commodity
-    idx:fieldName "commodity" ;
-    idx:fieldType idx:KeywordField ;
-    idx:stored false ;
-    idx:facetable true ;
-    idx:multiValued true .
-
-<#MiningReportShape>
-    sh:property [ idx:field field:state     ; sh:path ex:state ] ;
-    sh:property [ idx:field field:commodity ; sh:path ex:commodity ] ;
-    idx:facetHierarchy ( field:state field:commodity ) .
+<#SiteShape>
+    sh:property [ idx:field field:country ; sh:path ex:country ] ;
+    sh:property [ idx:field field:state   ; sh:path ex:state ] ;
+    idx:facetHierarchy ( field:country field:state ) .
 ```
 
-Each level keeps its own flat dimension, so faceting on `field:commodity` alone still works.
+Each level keeps its own flat dimension, so faceting on `field:state` alone still works.
 
 **Don't** use `TEXT`. `=` compiles to a term query either way, so against a tokenised field it
 looks for the term `"Iron Ore"`, which analysis never produced — matching nothing, silently.

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -10,8 +10,25 @@ For what each term means, see [03-configuration.md](03-configuration.md). This p
 
 **The index is a filter, not a store of record.** The graph holds the truth. Lucene exists to
 narrow millions of entities to a page of candidates; the values come back from the KG, or from
-`luc:match` when you have deliberately stored them. Every stored value is a copy that goes
-stale the moment the source changes, and a rebuild you owe.
+`luc:match` when you have deliberately stored them.
+
+Stored values drawn from the graph do **not** go stale: `ShaclTextDocProducer` rebuilds the
+whole entity document on any relevant triple change, resolving inverse and sequence paths back
+to the entities that need rebuilding. Two cases do decay, and they are the ones to hold in
+mind:
+
+- **External children.** A shape with an `idx:externalSource` is rebuild-only. The producer
+  refuses to act on a live change — rebuilding from the graph alone would silently strip the
+  CSV-derived children — and logs that the document is now stale pending a `ShaclBulkIndexer`
+  run. Values sourced from a file are as fresh as the last build.
+- **Anything corrected outside the dataset.** If the authoritative value lives in a database
+  the graph mirrors, storing it in Lucene adds a second copy to keep in step.
+
+So the reason not to store is mostly cost, not staleness: a stored copy of a field nothing
+projects is index size and merge time bought for nothing.
+
+*The live-rebuild behaviour is pinned by `TestShaclTextDocProducer`; the rebuild-only refusal
+by `TestExternalContentIndexing` ("live graph change does not strip external children").*
 
 **Each flag buys exactly one capability, and costs one structure.** `idx:indexed` for
 filtering, `idx:stored` for projection, `idx:facetable` for counts, `idx:sortable` for
@@ -51,9 +68,9 @@ What to **write in the config** — not what the defaults happen to be. `idx:ind
 **Stored is ✗ on every row on purpose.** Filtering, faceting and sorting all read structures
 that `idx:stored` has nothing to do with: a date buckets from its epoch docvalues, a number
 from its points and docvalues, a keyword from its facet docvalues. Storing buys exactly one
-thing — the value coming back in `luc:match` / `luc:nestedMatch` — and costs a copy that goes
-stale. Set `idx:stored true` on the handful of fields a result list actually renders from the
-index rather than from the graph, and leave the rest.
+thing — the value coming back in `luc:match` / `luc:nestedMatch` — and costs index size and
+merge time. Set `idx:stored true` on the handful of fields a result list actually renders from
+the index rather than from the graph, and leave the rest.
 
 Set `idx:multiValued true` wherever the predicate can repeat — see
 [Multi-valued fields](#multi-valued-fields). Leave `idx:indexed` alone.
@@ -290,8 +307,11 @@ Note the asymmetry worth knowing: numeric facet/sort docvalues are written from 
 field therefore produces one that counts and sorts but cannot be filtered — and the filter
 does not error, it is silently dropped. Leave `idx:indexed` alone.
 
-**Don't** store a volatile number you can re-fetch. Storing means the index is stale the
-moment the value is corrected.
+**Don't** store a number you can re-fetch and never display. If the values come from the
+graph the change listener keeps them current, so this is a size question, not a correctness
+one — but a stored copy of a field no result row renders is pure cost. If they come from an
+`idx:externalSource`, storing them also means a correction upstream is invisible until the
+next bulk build.
 
 *Backed by `TestRangeFacetCounts` (INT, LONG, DOUBLE and TEMPORAL buckets).*
 
@@ -439,7 +459,8 @@ which is what makes sorting on a repeated field well-defined.
 |---|---|
 | `idx:indexed false` on anything a client filters | The clause is dropped, logged, and the query returns unfiltered results. No error |
 | One `TEXT` field doing exact match *and* search | Tokenisation breaks `=`; the analyzer you pick is wrong for one of the two jobs |
-| Storing volatile values | Every correction upstream needs a reindex before the index stops lying |
+| Storing values nothing projects | Index size and merge time bought for nothing. (Graph-derived values stay current — the change listener rebuilds the document — so this is cost, not staleness) |
+| Storing external-source values you also correct upstream | A shape with `idx:externalSource` is rebuild-only: the producer refuses live changes and logs that the document is stale until `ShaclBulkIndexer` runs |
 | n-grams on names | Term explosion, broken ranking, `"Jon"` matching three unrelated people |
 | Flattening correlated children | "copper above 1%" matches the sample with copper at 0.2% and lead at 5% |
 | Forgetting `idx:multiValued` | Values after the first vanish with only a log line |

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -21,14 +21,14 @@ this page is which to pick. Each recipe names the test that pins it.
 What to write, not what the defaults are. `idx:indexed` and `idx:stored` both default to
 `true`, so `✗` means set it false explicitly.
 
-| Data kind | Example | `idx:fieldType` | stored | facetable | sortable | Upstream |
+| Data kind | Example | `idx:fieldType` | stored | facetable | sortable | Upstream Jena (non-SHACL fork) |
 |---|---|---|---|---|---|---|
 | Title / label, searched | `rdfs:label` of a report | `TextField` | ✓ | — | — | ✓ |
-| Name, exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` | match only |
+| Name, exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` | exact match only |
 | Description / abstract | `dcterms:description` | `TextField` | ✓ | — | — | ✓ |
-| Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — | match only |
+| Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — | exact match only |
 | Identifier, prefix typeahead | same value, n-grams | `TextField` | ✗ | — | — | via `text:GenericAnalyzer` |
-| Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | ✓ if sorted on | match only |
+| Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | ✓ if sorted on | exact match only |
 | Level of a facet hierarchy | `country` then `state` | `KeywordField` | ✗ | ✓ | — | ✗ |
 | Entity class | `rdf:type` → `Borehole` | `KeywordField` | ✗ | ✓ | — | ✗ |
 | Year or count | `2023`, `42` | `IntField` | ✗ | ✓ | ✓ | ✗ |
@@ -46,12 +46,15 @@ one that matched.
 
 Set `idx:multiValued true` wherever the predicate can repeat.
 
-**Upstream** is what Apache Jena's `text:entityMap` / `text:query` mode does. It has no field
-types: `TextIndexLucene` writes every value as an analyzed text field keyed by predicate, with
-no points, docvalues or facet fields — so no facets, no sort, no range filters, no nesting and
-no spatial. *Match only* means the value can be matched exactly by pairing the predicate with
-`text:KeywordAnalyzer` / `text:LowerCaseKeywordAnalyzer`, but not counted or sorted. Edge
-n-grams are reachable upstream by assembling a tokenizer with `text:GenericAnalyzer`; the
+**Upstream Jena (non-SHACL fork)** is Apache Jena's `text:entityMap` / `text:query` mode. It
+has no field types: `TextIndexLucene` writes every value as an analyzed text field keyed by
+predicate, with no points, docvalues or facet fields — so no facets, no sort, no range
+filters, no nesting and no spatial.
+
+*Exact match only* means you get the matching half of the row and not the rest: pair the
+predicate with `text:KeywordAnalyzer` or `text:LowerCaseKeywordAnalyzer` and `text:query`
+finds entities by the whole value, but nothing counts it as a facet or sorts by it. Edge
+n-grams are reachable there by assembling a tokenizer with `text:GenericAnalyzer`; the
 `text:EdgeNGramAnalyzer` shorthand is this fork's.
 
 ## Query syntax on a TEXT field

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -29,7 +29,7 @@ What to write, not what the defaults are. `idx:indexed` and `idx:stored` both de
 | Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — |
 | Identifier, prefix typeahead | same value, n-grams | `TextField` | ✗ | — | — |
 | Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | — |
-| Level of a facet hierarchy | `state` then `commodity` | `KeywordField` | ✗ | ✓ | — |
+| Level of a facet hierarchy | `country` then `state` | `KeywordField` | ✗ | ✓ | — |
 | Entity class | `rdf:type` → `Borehole` | `KeywordField` | ✗ | ✓ | — |
 | Year or count | `2023`, `42` | `IntField` | ✗ | ✓ | ✓ |
 | Measurement / grade / score | `12.4` | `DoubleField` | ✗ | ✓ | ✓ |

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -21,28 +21,38 @@ this page is which to pick. Each recipe names the test that pins it.
 What to write, not what the defaults are. `idx:indexed` and `idx:stored` both default to
 `true`, so `✗` means set it false explicitly.
 
-| Data kind | Example | `idx:fieldType` | stored | facetable | sortable |
-|---|---|---|---|---|---|
-| Title / label, searched | `rdfs:label` of a report | `TextField` | ✓ | — | — |
-| Name, exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` |
-| Description / abstract | `dcterms:description` | `TextField` | ✓ | — | — |
-| Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — |
-| Identifier, prefix typeahead | same value, n-grams | `TextField` | ✗ | — | — |
-| Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | ✓ if sorted on |
-| Level of a facet hierarchy | `country` then `state` | `KeywordField` | ✗ | ✓ | — |
-| Entity class | `rdf:type` → `Borehole` | `KeywordField` | ✗ | ✓ | — |
-| Year or count | `2023`, `42` | `IntField` | ✗ | ✓ | ✓ |
-| Measurement / grade / score | `12.4` | `DoubleField` | ✗ | ✓ | ✓ |
-| Full date or timestamp | `2023-04-01`, `2023-04-01T09:00:00Z` | `TemporalField` | ✗ | ✓ | ✓ |
-| Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | rejected |
-| Repeated correlated record | an assay, an observation, a qualified identifier | ordinary fields inside an [`idx:nested`](#observations-sosa-style) block | ✓ to project the child that matched | ✓ | ✓ |
+| Data kind | Example | `idx:fieldType` | stored | facetable | sortable | Upstream |
+|---|---|---|---|---|---|---|
+| Title / label, searched | `rdfs:label` of a report | `TextField` | ✓ | — | — | ✓ |
+| Name, exact match + counts | author, operator, publisher | `KeywordField` | ✗ | ✓ | ✓ + `idx:normalizer` | match only |
+| Description / abstract | `dcterms:description` | `TextField` | ✓ | — | — | ✓ |
+| Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — | match only |
+| Identifier, prefix typeahead | same value, n-grams | `TextField` | ✗ | — | — | via `text:GenericAnalyzer` |
+| Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | ✓ if sorted on | match only |
+| Level of a facet hierarchy | `country` then `state` | `KeywordField` | ✗ | ✓ | — | ✗ |
+| Entity class | `rdf:type` → `Borehole` | `KeywordField` | ✗ | ✓ | — | ✗ |
+| Year or count | `2023`, `42` | `IntField` | ✗ | ✓ | ✓ | ✗ |
+| Measurement / grade / score | `12.4` | `DoubleField` | ✗ | ✓ | ✓ | ✗ |
+| Full date or timestamp | `2023-04-01`, `2023-04-01T09:00:00Z` | `TemporalField` | ✗ | ✓ | ✓ | ✗ |
+| Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | rejected | ✗ |
+| Repeated correlated record | an assay, an observation, a qualified identifier | ordinary fields inside an [`idx:nested`](#observations-sosa-style) block | ✓ to project the child that matched | ✓ | ✓ | ✗ |
 
 Filtering, faceting and sorting read points and docvalues, never the stored copy, so `✗`
-costs nothing but projection. Store the searchable text fields: `luc:match` binds which field
-matched, and the value only if it is stored — and where an entity carries several labels or
-descriptions, it returns the one that matched.
+costs nothing but projection.
+
+Store the searchable text fields: `luc:match` binds which field matched, and the value only
+if it is stored — and where an entity carries several labels or descriptions, it returns the
+one that matched.
 
 Set `idx:multiValued true` wherever the predicate can repeat.
+
+**Upstream** is what Apache Jena's `text:entityMap` / `text:query` mode does. It has no field
+types: `TextIndexLucene` writes every value as an analyzed text field keyed by predicate, with
+no points, docvalues or facet fields — so no facets, no sort, no range filters, no nesting and
+no spatial. *Match only* means the value can be matched exactly by pairing the predicate with
+`text:KeywordAnalyzer` / `text:LowerCaseKeywordAnalyzer`, but not counted or sorted. Edge
+n-grams are reachable upstream by assembling a tokenizer with `text:GenericAnalyzer`; the
+`text:EdgeNGramAnalyzer` shorthand is this fork's.
 
 ## Query syntax on a TEXT field
 

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -28,13 +28,14 @@ What to write, not what the defaults are. `idx:indexed` and `idx:stored` both de
 | Description / abstract | `dcterms:description` | `TextField` | ✓ | — | — |
 | Identifier / code, exact | `RPT-MIA-2023-001` | `KeywordField` | ✗ | ✓ if counted | — |
 | Identifier, prefix typeahead | same value, n-grams | `TextField` | ✗ | — | — |
-| Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | — |
+| Vocabulary term | `Gold`, `Approved`, `WA` | `KeywordField` | ✗ | ✓ | ✓ if sorted on |
 | Level of a facet hierarchy | `country` then `state` | `KeywordField` | ✗ | ✓ | — |
 | Entity class | `rdf:type` → `Borehole` | `KeywordField` | ✗ | ✓ | — |
 | Year or count | `2023`, `42` | `IntField` | ✗ | ✓ | ✓ |
 | Measurement / grade / score | `12.4` | `DoubleField` | ✗ | ✓ | ✓ |
 | Full date or timestamp | `2023-04-01`, `2023-04-01T09:00:00Z` | `TemporalField` | ✗ | ✓ | ✓ |
 | Geometry | `POINT(151.2 -33.9)` | `LatLonField` | ✗ | — | rejected |
+| Repeated correlated record | an assay, an observation, a qualified identifier | ordinary fields inside an [`idx:nested`](#observations-sosa-style) block | ✓ to project the child that matched | ✓ | ✓ |
 
 Filtering, faceting and sorting read points and docvalues, never the stored copy, so `✗`
 costs nothing but projection. Store the searchable text fields: `luc:match` binds which field
@@ -68,7 +69,7 @@ The string is analyzed with the field's query analyzer — on a `KEYWORD` field 
 is one term. Scope with `fieldSpec`, not an embedded `fieldName:` prefix, which uses internal
 field names. Structured predicates belong in `cqlFilter`.
 
-*`TestLuceneQuerySyntax`*
+*[TestLuceneQuerySyntax](../jena-text/src/test/java/org/apache/jena/query/text/TestLuceneQuerySyntax.java)*
 
 ## Titles and names
 
@@ -112,7 +113,7 @@ field:authorName
 **Don't** n-gram a name: term explosion, broken ranking, and `"Jon"` matches `"Jones"`,
 `"Jonathan"` and `"Jonsson"` indistinguishably.
 
-*`TestKeywordNormalizer`, `TestKeywordNormalizerTwinField`, `TestKeywordRawSortAndExactMatch`*
+*[TestKeywordNormalizer](../jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizer.java), [TestKeywordNormalizerTwinField](../jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizerTwinField.java), [TestKeywordRawSortAndExactMatch](../jena-text/src/test/java/org/apache/jena/query/text/TestKeywordRawSortAndExactMatch.java)*
 
 ## Identifiers and codes
 
@@ -134,7 +135,7 @@ Whole-value n-grams: `"RPT-MIA"` reaches `RPT-MIA-2023-001`, `"2023"` does not. 
 `text:tokenized true` for interior segments, accepting that `"2023"` then matches every 2023
 report.
 
-*`TestTypeaheadFieldConfigurations`*
+*[TestTypeaheadFieldConfigurations](../jena-text/src/test/java/org/apache/jena/query/text/TestTypeaheadFieldConfigurations.java)*
 
 ## Descriptions
 
@@ -150,7 +151,7 @@ Store it: a hit on a description is worth nothing if the result cannot show whic
 descriptions matched. Drop to `idx:stored false` only where the text is long enough that the
 stored copy dominates the index and the graph can serve it by IRI instead.
 
-*`TestTextMatchPF`, `TestShaclLucQueryRawValueOnMultiValuedField`*
+*[TestTextMatchPF](../jena-text/src/test/java/org/apache/jena/query/text/TestTextMatchPF.java), [TestShaclLucQueryRawValueOnMultiValuedField](../jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java)*
 
 ## Vocabularies and taxonomies
 
@@ -192,7 +193,7 @@ Each level keeps its own flat dimension, so faceting on `field:state` alone stil
 **Don't** use `TEXT`. `=` compiles to a term query either way, so against a tokenised field it
 looks for the term `"Iron Ore"`, which analysis never produced — matching nothing, silently.
 
-*`TestHierarchicalFacets`, `TestHierarchicalFacetsSparql`, `TestNativeFacetCounts`*
+*[TestHierarchicalFacets](../jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacets.java), [TestHierarchicalFacetsSparql](../jena-text/src/test/java/org/apache/jena/query/text/TestHierarchicalFacetsSparql.java), [TestNativeFacetCounts](../jena-text/src/test/java/org/apache/jena/query/text/TestNativeFacetCounts.java)*
 
 ## Entity class
 
@@ -228,7 +229,7 @@ Numeric docvalues come from `facetable`/`sortable` independently of `idx:indexed
 `idx:indexed false` yields a field that counts and sorts but cannot be filtered — and the
 filter is dropped silently, not rejected. Leave `idx:indexed` alone.
 
-*`TestRangeFacetCounts`*
+*[TestRangeFacetCounts](../jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java)*
 
 ## Dates
 
@@ -258,7 +259,7 @@ so bad dates narrow results silently. Validate on the way in.
 **Don't** use `KEYWORD` for sortable dates: lexical order is correct only for zero-padded ISO,
 and range filters are gone.
 
-*`TestDateLiteralRoundTrip`, `TestRangeFacetCounts`*
+*[TestDateLiteralRoundTrip](../jena-text/src/test/java/org/apache/jena/query/text/TestDateLiteralRoundTrip.java), [TestRangeFacetCounts](../jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java)*
 
 ## Observations (SOSA-style)
 
@@ -303,11 +304,9 @@ row per child, same semantics. See
 
 **Don't** nest a single-field child; that is a multi-valued field with extra machinery.
 
-**Untested:** a `TEMPORAL` field inside a nested block.
-
-*`TestNestedJoinPathSupport`, `TestCorrelatedNestedAttribution`, `TestNestedHierarchicalFacets`,
-`TestNestedMatchProjection`, `TestNestedSortSelector`, `TestExternalContentIndexing`,
-`TestGswaMeasurementCsv`*
+*[TestNestedJoinPathSupport](../jena-text/src/test/java/org/apache/jena/query/text/TestNestedJoinPathSupport.java), [TestCorrelatedNestedAttribution](../jena-text/src/test/java/org/apache/jena/query/text/TestCorrelatedNestedAttribution.java), [TestNestedHierarchicalFacets](../jena-text/src/test/java/org/apache/jena/query/text/TestNestedHierarchicalFacets.java),
+[TestNestedMatchProjection](../jena-text/src/test/java/org/apache/jena/query/text/TestNestedMatchProjection.java), [TestNestedSortSelector](../jena-text/src/test/java/org/apache/jena/query/text/TestNestedSortSelector.java), [TestExternalContentIndexing](../jena-text/src/test/java/org/apache/jena/query/text/TestExternalContentIndexing.java),
+[TestGswaMeasurementCsv](../jena-text/src/test/java/org/apache/jena/query/text/TestGswaMeasurementCsv.java)*
 
 ## Geometry
 
@@ -326,7 +325,7 @@ logged and skipped, so mixed geometry columns index only in part. CRS84 and EPSG
 work; GDA94/GDA2020 are treated as WGS84. Sorting is rejected and equality is meaningless —
 use the spatial CQL operators ([09-spatial.md](09-spatial.md)).
 
-*`TestSpatialFiltering`*
+*[TestSpatialFiltering](../jena-text/src/test/java/org/apache/jena/query/text/TestSpatialFiltering.java)*
 
 ## Multi-valued fields
 
@@ -334,7 +333,7 @@ Without `idx:multiValued true`, values after the first are dropped with a log wa
 looks fine until one entity has two commodities. On `KEYWORD` it also selects `SortedSet`
 docvalues, making sort on a repeated field well-defined.
 
-*`TestKeywordNormalizerMultiValued`, `TestShaclLucQueryRawValueOnMultiValuedField`*
+*[TestKeywordNormalizerMultiValued](../jena-text/src/test/java/org/apache/jena/query/text/TestKeywordNormalizerMultiValued.java), [TestShaclLucQueryRawValueOnMultiValuedField](../jena-text/src/test/java/org/apache/jena/query/text/TestShaclLucQueryRawValueOnMultiValuedField.java)*
 
 ## Anti-patterns
 

--- a/docs/10-suggested-configuration.md
+++ b/docs/10-suggested-configuration.md
@@ -1,0 +1,343 @@
+# Suggested Configuration
+
+Opinionated defaults for the common kinds of data. Every recipe here is exercised by a test —
+the backing class is named so you can read the exact shape that is known to work.
+
+For what each term means, see [03-configuration.md](03-configuration.md). This page is about
+*which* to reach for.
+
+## Principles
+
+**The index is a filter, not a store of record.** The graph holds the truth. Lucene exists to
+narrow millions of entities to a page of candidates; the values come back from the KG, or from
+`luc:match` when you have deliberately stored them. Every stored value is a copy that goes
+stale the moment the source changes, and a rebuild you owe.
+
+**Each flag buys exactly one capability, and costs one structure.** `idx:indexed` for
+filtering, `idx:stored` for projection, `idx:facetable` for counts, `idx:sortable` for
+`ORDER BY`. Turn on what a query needs. The defaults — indexed and stored, not facetable, not
+sortable — are right for most fields.
+
+**One field, one job.** When a value needs both exact filtering and free-text search, define
+two fields over the same path rather than one field with a compromise analyzer. They are
+different Lucene fields; they cost one extra term dictionary and they never fight.
+
+**Fields are path-free and reusable.** Define `field:title` once; bind it to `rdfs:label` on
+one shape and `dcterms:title` on another. Occurrences carry paths, fields carry behaviour.
+
+**Prefer a rebuild to a clever incremental trick.** A wrong document is worse than a slow one.
+
+## The matrix
+
+| Data kind | `idx:fieldType` | indexed | stored | facetable | sortable | Analyzer |
+|---|---|---|---|---|---|---|
+| Title / label, for searching | `TextField` | ✓ default | ✓ if projected | — | — | index default (BM25) |
+| Name, for exact match + counts | `KeywordField` | ✓ default | ✓ default | ✓ | ✓ + `idx:normalizer` | — |
+| Description / abstract / body | `TextField` | ✓ default | ✗ | — | — | index default |
+| Identifier / code, exact | `KeywordField` | ✓ default | ✓ default | ✓ if you count them | — | — |
+| Identifier, prefix typeahead | `TextField` | ✓ default | ✗ | — | — | `EdgeNGramAnalyzer` whole-value |
+| Controlled vocabulary term | `KeywordField` | ✓ default | ✗ | ✓ | — | — |
+| Taxonomy level | `KeywordField` | ✓ default | ✗ | ✓ | — | — (+ `idx:facetHierarchy`) |
+| Entity type pivot | `KeywordField` | ✓ default | ✗ | ✓ | — | — |
+| Year / count | `IntField` | ✓ default | ✓ default | ✓ | ✓ | — |
+| Measurement / grade / score | `DoubleField` | ✓ default | ✗ | ✓ | ✓ | — |
+| Date / timestamp | `TemporalField` | ✓ default | ✓ default | ✓ | ✓ | — (+ `idx:storeLiteralMetadata true`) |
+| Geometry | `LatLonField` | ✓ default | ✓ default | — | ✗ rejected | — |
+
+`✓ default` means you get it without writing anything. Set `idx:multiValued true` wherever the
+predicate can repeat — see [Multi-valued fields](#multi-valued-fields).
+
+## Names and titles
+
+Two fields over one path: BM25 for finding, `KEYWORD` for filtering and counting.
+
+```turtle
+field:authorNameText
+    idx:fieldName "authorNameText" ;
+    idx:fieldType idx:TextField ;
+    idx:defaultSearch true .
+
+field:authorName
+    idx:fieldName "authorName" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true ;
+    idx:sortable true ;
+    idx:normalizer [ a text:LowerCaseKeywordAnalyzer ] .
+
+<#MiningReportShape>
+    sh:property [ idx:field field:authorNameText ; sh:path ( ex:authoredBy ex:name ) ] ;
+    sh:property [ idx:field field:authorName     ; sh:path ( ex:authoredBy ex:name ) ] .
+```
+
+**Why.** `"Sarah Jones"` should reach `"Dr Sarah Jones"` — that is BM25 over a tokenised
+field, with no analyzer override. The `KEYWORD` twin keeps the whole string as one term, so
+`= "Dr Sarah Jones"` is exact and the facet counts one bucket per person.
+
+`idx:normalizer` makes the indexed term and the sort key case-folded while the stored value
+and the facet label stay as authored — so `"de Silva"` sorts next to `"De Silva"` instead of
+after `"Zhang"`, and the facet still reads correctly.
+
+**Don't** put an n-gram analyzer on a name. It inflates the term dictionary, wrecks scoring,
+and `"Jon"` starts matching `"Jones"`, `"Jonathan"` and `"Jonsson"` with no way to rank them.
+Names want BM25.
+
+*Backed by `TestKeywordNormalizer`, `TestKeywordNormalizerTwinField`,
+`TestKeywordRawSortAndExactMatch`.*
+
+## Identifiers and codes
+
+```turtle
+field:identifier
+    idx:fieldName "identifier" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
+field:identifierPrefix
+    idx:fieldName "identifierPrefix" ;
+    idx:fieldType idx:TextField ;
+    idx:stored false ;
+    idx:analyzer [ a text:EdgeNGramAnalyzer ] .   # whole-value, NOT tokenized
+```
+
+**Why.** An identifier is looked up two ways: pasted whole (`= "RPT-MIA-2023-001"`, the
+`KEYWORD` field), or typed progressively (`RPT-MIA` → the edge-n-gram field). Whole-value
+n-grams mean `"RPT-MIA"` reaches `RPT-MIA-2023-001` while `"2023"` does not — a prefix of the
+identifier, not of some fragment inside it.
+
+Add `text:tokenized true` only when users legitimately search from an interior segment, and
+know that you are buying `"2023"` matching every 2023 report.
+
+**Don't** store the prefix field. It is a search structure with no display value; the exact
+twin already holds the string.
+
+*Backed by `TestTypeaheadFieldConfigurations` (both whole-value and per-word variants).*
+
+## Descriptions and free text
+
+```turtle
+field:description
+    idx:fieldName "description" ;
+    idx:fieldType idx:TextField ;
+    idx:stored false ;
+    idx:defaultSearch true .
+```
+
+**Why.** Long prose is the one case where `idx:stored false` clearly pays: the stored copy is
+the biggest thing in the index and the graph can return it by IRI. Keep it indexed — that is
+the whole point — and put it in `defaultSearch` so a bare query string reaches it.
+
+Set `text:storeValues true` on the index only if `luc:match` needs to project field values at
+all; it is `false` by default.
+
+## Controlled vocabularies, categories, taxonomies
+
+```turtle
+field:commodity
+    idx:fieldName "commodity" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored false ;
+    idx:facetable true ;
+    idx:multiValued true .
+
+field:state
+    idx:fieldName "state" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored false ;
+    idx:facetable true .
+
+<#MiningReportShape>
+    sh:property [ idx:field field:state     ; sh:path ex:state ] ;
+    sh:property [ idx:field field:commodity ; sh:path ex:commodity ] ;
+    idx:facetHierarchy ( field:state field:commodity ) .
+```
+
+**Why.** Vocabulary terms are exactly the `KEYWORD` case: a closed set, filtered with `=` or
+`in`, counted as facets. Not stored, because the label is already in the graph and the facet
+carries its own value.
+
+`idx:facetHierarchy` adds a drill-down dimension over the same fields — WA → Gold → … — and
+each level keeps its own flat dimension, so faceting on `field:commodity` alone still works.
+The two are addressed separately and neither shadows the other.
+
+**Don't** index a vocabulary term as `TEXT`. `=` compiles to a raw term query either way, so
+against a tokenised field it looks for the single term `"Iron Ore"` — which analysis never
+produced, having emitted `iron` and `ore`. The filter matches nothing, with no error. Use
+`text_query` when you want analyzer-aware matching, and `KEYWORD` when you want `=`.
+
+*Backed by `TestHierarchicalFacets`, `TestHierarchicalFacetsSparql`, `TestNativeFacetCounts`.*
+
+## Entity type pivots
+
+```turtle
+field:entityType
+    idx:fieldName "entityType" ;
+    idx:fieldType idx:KeywordField ;
+    idx:stored false ;
+    idx:facetable true .
+
+<#MiningReportShape>
+    sh:property [ idx:field field:entityType ; sh:path rdf:type ] .
+```
+
+An IRI-valued path indexes as its IRI string, so this gives "23 Reports, 51 Boreholes" across
+a mixed index without a second query. Bind it on every shape.
+
+## Numbers and measurements
+
+```turtle
+field:grade
+    idx:fieldName "grade" ;
+    idx:fieldType idx:DoubleField ;
+    idx:facetable true ;   # range facet buckets
+    idx:sortable true ;    # ORDER BY, nested sort selector
+    idx:stored false .     # the assay database is the source of truth
+```
+
+**Why.** `DOUBLE` gives range filters (`>=`, `between`) as a points query, and range facets
+declared per query rather than per config — you pass the boundaries in the `luc:facet` call,
+so re-bucketing needs no reindex.
+
+Note the asymmetry worth knowing: numeric facet/sort docvalues are written from `facetable` or
+`sortable` alone, independently of `idx:indexed`. Leaving `idx:indexed false` on a numeric
+field therefore produces one that counts and sorts but cannot be filtered — and the filter
+does not error, it is silently dropped. Leave `idx:indexed` alone.
+
+**Don't** store a volatile number you can re-fetch. Storing means the index is stale the
+moment the value is corrected.
+
+*Backed by `TestRangeFacetCounts` (INT, LONG, DOUBLE and TEMPORAL buckets).*
+
+## Dates
+
+```turtle
+field:publishedOn
+    idx:fieldName "publishedOn" ;
+    idx:fieldType idx:TemporalField ;
+    idx:facetable true ;
+    idx:sortable true ;
+    idx:storeLiteralMetadata true .   # required — config fails without it
+```
+
+**Why.** A `TEMPORAL` field parses `xsd:date` / `xsd:dateTime` to epoch millis and indexes
+*that* — filtering and sorting are numeric, and date-only values are treated as start-of-day
+UTC. Range facets take ISO boundaries (`"2019-01-01"`), not epoch numbers, so a config change
+is never needed to re-bucket.
+
+`idx:storeLiteralMetadata true` is **not optional**: a `TEMPORAL` field without it is rejected
+at config time. It stores the datatype and language alongside the value so a projected hit
+rebuilds as the literal it came from rather than a bare string.
+
+A value that fails to parse is logged and simply does not participate in range queries — the
+entity is still indexed on its other fields, so a bad date silently narrows results rather
+than failing loudly. Validate dates on the way in.
+
+**Don't** model a date as `KEYWORD` to get "sortable strings". It sorts lexically, which is
+correct only for zero-padded ISO dates and wrong the moment a timezone offset appears, and you
+lose range filters entirely.
+
+*Backed by `TestDateLiteralRoundTrip` (filter, sort, invalid-value handling) and the temporal
+case in `TestRangeFacetCounts`.*
+
+## Observations and measurement records (SOSA-style)
+
+One row per observation, correlated per child. This is the case `idx:nested` exists for.
+
+```turtle
+field:observedProperty
+    idx:fieldName "observedProperty" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
+field:resultValue
+    idx:fieldName "resultValue" ;
+    idx:fieldType idx:DoubleField ;
+    idx:facetable true ;
+    idx:sortable true .
+
+field:resultUnits
+    idx:fieldName "resultUnits" ;
+    idx:fieldType idx:KeywordField ;
+    idx:facetable true .
+
+<#SampleShape>
+    sh:targetClass sosa:Sample ;
+    sh:property [ idx:field field:title ; sh:path rdfs:label ] ;
+
+    idx:nested [
+        idx:joinPath [ sh:inversePath sosa:hasFeatureOfInterest ] ;
+        idx:property [ idx:field field:observedProperty ; sh:path ( sosa:observedProperty rdfs:label ) ] ;
+        idx:property [ idx:field field:resultValue      ; sh:path sosa:hasSimpleResult ] ;
+        idx:property [ idx:field field:resultUnits      ; sh:path ex:units ] ;
+        idx:facetHierarchy ( field:observedProperty field:resultUnits ) ;
+    ] .
+```
+
+**Why nested and not flat.** Flatten observations onto the sample and "copper above 1%"
+matches a sample with copper at 0.2% and lead at 5% — the values decorrelate. Inside an
+`idx:nested` block each observation is its own child document, and AND-ed clauses in the same
+scope fold into one block join, so both conditions must hold *on one observation*.
+
+This correlation covers `=`, ranges, `in`, `between`, `like` and `text_query` — not just
+equality.
+
+**When the observations are not in the graph**, and there are millions of them, bind an
+`idx:externalSource` instead: one CSV row becomes one child document, joined on the entity
+IRI, with the values never loaded as triples. Same query semantics, same correlation. See
+[03-configuration.md → External Content](03-configuration.md#external-content-csvtsv).
+
+**Don't** reach for nesting when the child has exactly one field. A single-field child is a
+multi-valued field on the parent with extra machinery.
+
+**Not covered by a test:** a `TEMPORAL` field *inside* a nested block. Result times on the
+parent are well covered; if you need `sosa:resultTime` per observation, add a test with it.
+
+*Backed by `TestNestedJoinPathSupport`, `TestCorrelatedNestedAttribution`,
+`TestNestedHierarchicalFacets`, `TestNestedMatchProjection`, `TestNestedSortSelector`,
+`TestExternalContentIndexing`, `TestGswaMeasurementCsv`.*
+
+## Geometry
+
+```turtle
+field:location
+    idx:fieldName "location" ;
+    idx:fieldType idx:LatLonField .
+
+<#SiteShape>
+    sh:property [ idx:field field:location ; sh:path geo:asWKT ] .
+```
+
+`POINT`, `POLYGON` and `MULTIPOLYGON` WKT are indexed for spatial filters. Anything else —
+`LINESTRING`, `MULTIPOINT` — is logged and **skipped**, so a geometry column of mixed types
+quietly indexes only part of itself. CRS84 (bare WKT) and EPSG:4326 both work with axis order
+handled for you; GDA94/GDA2020 are treated as WGS84-equivalent.
+
+Sorting on a `LatLon` field is rejected outright, and equality is meaningless — use the
+spatial CQL operators. See [09-spatial.md](09-spatial.md).
+
+*Backed by `TestSpatialFiltering`.*
+
+## Multi-valued fields
+
+Set `idx:multiValued true` whenever the predicate can legitimately repeat.
+
+Without it, a second value is **dropped with a warning** — the document keeps the first value
+and the entity silently stops matching on the rest. This is the single most common
+misconfiguration, because it works perfectly until one entity has two commodities.
+
+For `KEYWORD` fields it also selects the docvalues shape (`SortedSet` rather than `Sorted`),
+which is what makes sorting on a repeated field well-defined.
+
+*Backed by `TestKeywordNormalizerMultiValued`,
+`TestShaclLucQueryRawValueOnMultiValuedField`.*
+
+## Anti-patterns
+
+| Pattern | What goes wrong |
+|---|---|
+| `idx:indexed false` on anything a client filters | The clause is dropped, logged, and the query returns unfiltered results. No error |
+| One `TEXT` field doing exact match *and* search | Tokenisation breaks `=`; the analyzer you pick is wrong for one of the two jobs |
+| Storing volatile values | Every correction upstream needs a reindex before the index stops lying |
+| n-grams on names | Term explosion, broken ranking, `"Jon"` matching three unrelated people |
+| Flattening correlated children | "copper above 1%" matches the sample with copper at 0.2% and lead at 5% |
+| Forgetting `idx:multiValued` | Values after the first vanish with only a log line |
+| Facetable on a high-cardinality field | A facet dimension with a million single-count buckets answers nothing and costs memory |

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,9 +76,17 @@ SELECT ?field ?value ?low ?high ?count WHERE {
 |---|---|
 | [01-user-guide.md](01-user-guide.md) | Practical setup and query usage |
 | [02-sparql-api.md](02-sparql-api.md) | Full SHACL SPARQL signatures and examples |
-| [03-configuration.md](03-configuration.md) | Assembler and index configuration |
+| [03-configuration.md](03-configuration.md) | Assembler and index configuration — every `idx:` term |
 | [04-architecture.md](04-architecture.md) | Internal design and execution flow |
 | [05-testing.md](05-testing.md) | Test coverage and commands |
+| [06-design-decisions.md](06-design-decisions.md) | Why the model is shaped the way it is |
+| [07-future-work.md](07-future-work.md) | Known gaps and candidates |
+| [08-use-cases.md](08-use-cases.md) | Worked query scenarios |
+| [09-spatial.md](09-spatial.md) | WKT indexing and spatial filters |
+| [10-suggested-configuration.md](10-suggested-configuration.md) | Opinionated defaults per data kind — names, identifiers, dates, observations |
+
+Dated files (`2026-*.md`) are design notes: a snapshot of the thinking at that date, not
+reference. Where one disagrees with the numbered docs, the numbered docs win.
 
 ## Build And Test
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -148,6 +148,9 @@ import org.apache.jena.query.text.changes.TestDatasetMonitor;
     // Range facets
     , TestRangeFacetCounts.class
 
+    // TEMPORAL fields: epoch filtering, sort, and literal reconstruction on read
+    , TestDateLiteralRoundTrip.class
+
     // Demo data validation
     , TestDemoDataParsing.class
     , TestDemoMiningScenarios.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -151,6 +151,9 @@ import org.apache.jena.query.text.changes.TestDatasetMonitor;
     // TEMPORAL fields: epoch filtering, sort, and literal reconstruction on read
     , TestDateLiteralRoundTrip.class
 
+    // Classic Lucene query syntax reaching the queryString argument
+    , TestLuceneQuerySyntax.class
+
     // Demo data validation
     , TestDemoDataParsing.class
     , TestDemoMiningScenarios.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestLuceneQuerySyntax.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestLuceneQuerySyntax.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The {@code queryString} argument of {@code luc:query} is parsed by Lucene's classic
+ * {@link org.apache.lucene.queryparser.classic.QueryParser} (or {@code MultiFieldQueryParser}
+ * across several fields), so the whole classic syntax is available on a plain {@code TEXT}
+ * field with no extra configuration.
+ * <p>
+ * These tests pin the forms documented in 10-suggested-configuration.md — wildcard, leading
+ * wildcard, fuzzy, phrase, proximity, boolean and required/prohibited terms, plus the
+ * {@code "*"} match-all short-circuit.
+ */
+public class TestLuceneQuerySyntax {
+
+    private static final String NS = "http://example.org/";
+
+    private Dataset dataset;
+    private ShaclTextIndexLucene textIndex;
+
+    @Before
+    public void setUp() {
+        TextQuery.init();
+
+        Node titlePred = NodeFactory.createURI(NS + "title");
+
+        // Plain TEXT field, no analyzer override: the index-wide default (StandardAnalyzer).
+        FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
+            true, true, false, false, false, true);
+
+        List<FieldOccurrence> rootOccurrences = Collections.singletonList(
+            occurrence(titleField, PathFactory.pathLink(titlePred), Collections.singleton(titlePred)));
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + "PaperShape"),
+            Collections.singleton(NodeFactory.createURI(NS + "Paper")),
+            "uri", "docType",
+            Collections.singletonList(titleField),
+            rootOccurrences,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        TextIndexConfig config = new TextIndexConfig(ShaclIndexAssembler.deriveEntityDefinition(mapping));
+        config.setShaclMapping(mapping);
+        config.setValueStored(true);
+
+        textIndex = new ShaclTextIndexLucene(new ByteBuffersDirectory(), config);
+
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(baseDs.asDatasetGraph(), textIndex, mapping);
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            addPaper(model, "d1", "Quantum machine learning");
+            addPaper(model, "d2", "Machine translation networks");
+            addPaper(model, "d3", "Deep learning for physics");
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private void addPaper(Model model, String id, String title) {
+        Resource paper = ResourceFactory.createResource(NS + id);
+        model.add(paper, RDF.type, ResourceFactory.createResource(NS + "Paper"));
+        model.add(paper, ResourceFactory.createProperty(NS + "title"), title);
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
+        return new FieldOccurrence(
+            field,
+            path,
+            ShaclIndexAssembler.extractPathVariants(path),
+            predicates,
+            null, null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) dataset.close();
+    }
+
+    @Test
+    public void testTrailingWildcard() {
+        assertHits("quan*", "d1");
+    }
+
+    /** The parsers are built with setAllowLeadingWildcard(true), which Lucene disables by default. */
+    @Test
+    public void testLeadingWildcard() {
+        assertHits("*tum", "d1");
+    }
+
+    @Test
+    public void testSingleCharacterWildcard() {
+        assertHits("qu?ntum", "d1");
+    }
+
+    @Test
+    public void testGrouping() {
+        assertHits("(machine OR deep) AND learning", "d1", "d3");
+    }
+
+    /** Boost parses and does not change which documents match, only their scores. */
+    @Test
+    public void testBoost() {
+        assertHits("quantum^4 learning", "d1", "d3");
+    }
+
+    /** Lexical term range on a TEXT field: only "deep" falls in [a TO f]. */
+    @Test
+    public void testTermRange() {
+        assertHits("[a TO f]", "d3");
+    }
+
+    @Test
+    public void testFuzzy() {
+        assertHits("learnimg~1", "d1", "d3");
+    }
+
+    @Test
+    public void testPhraseRequiresAdjacency() {
+        assertHits("\"machine learning\"", "d1");
+    }
+
+    /** Proximity: "machine" within 2 positions of "networks" — d2 is "machine translation networks". */
+    @Test
+    public void testProximitySlop() {
+        assertHits("\"machine networks\"~2", "d2");
+    }
+
+    @Test
+    public void testBooleanOperators() {
+        assertHits("machine AND learning", "d1");
+        assertHits("physics OR translation", "d2", "d3");
+    }
+
+    @Test
+    public void testRequiredAndProhibitedTerms() {
+        assertHits("+learning -physics", "d1");
+    }
+
+    /** A bare "*" short-circuits to MatchAllDocsQuery rather than a wildcard on one field. */
+    @Test
+    public void testMatchAll() {
+        assertHits("*", "d1", "d2", "d3");
+    }
+
+    private void assertHits(String queryString, String... expectedLocalNames) {
+        List<TextHit> hits = textIndex.queryWithCql(
+            null, queryString, null, null, null, null, 10, null);
+        Set<String> actual = new TreeSet<>();
+        for (TextHit hit : hits) {
+            actual.add(hit.getNode().getURI().substring(NS.length()));
+        }
+        assertEquals("query: " + queryString,
+            new TreeSet<>(Arrays.asList(expectedLocalNames)), actual);
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java
@@ -76,11 +76,13 @@ public class TestRangeFacetCounts {
             true, true, true, true, false, false);
         FieldDef scoreField = new FieldDef("score", FieldType.DOUBLE, null,
             true, true, true, true, false, false);
-        // TEMPORAL buckets by ISO boundary — the epoch twin field carries the docvalues.
-        // storeLiteralMetadata is not optional here: validateLiteralMetadataRequirements
+        // TEMPORAL buckets by ISO boundary — the epoch twin field carries the docvalues, so
+        // the field does NOT need to be stored to be bucketed (stored=false here, which is
+        // the recommended shape for a date nothing projects).
+        // storeLiteralMetadata is not optional though: validateLiteralMetadataRequirements
         // rejects any TEMPORAL field without it.
         FieldDef publishedOnField = new FieldDef("publishedOn", FieldType.TEMPORAL, null,
-            true, true, true, true, false, false, true);
+            false, true, true, true, false, false, true);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(titlePred), Collections.singleton(titlePred)),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestRangeFacetCounts.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Dataset;
@@ -65,6 +66,7 @@ public class TestRangeFacetCounts {
         Node yearPred = NodeFactory.createURI(NS + "year");
         Node eventTimePred = NodeFactory.createURI(NS + "eventTime");
         Node scorePred = NodeFactory.createURI(NS + "score");
+        Node publishedOnPred = NodeFactory.createURI(NS + "publishedOn");
 
         FieldDef titleField = new FieldDef("title", FieldType.TEXT, null,
             true, true, false, false, false, true);
@@ -74,18 +76,24 @@ public class TestRangeFacetCounts {
             true, true, true, true, false, false);
         FieldDef scoreField = new FieldDef("score", FieldType.DOUBLE, null,
             true, true, true, true, false, false);
+        // TEMPORAL buckets by ISO boundary — the epoch twin field carries the docvalues.
+        // storeLiteralMetadata is not optional here: validateLiteralMetadataRequirements
+        // rejects any TEMPORAL field without it.
+        FieldDef publishedOnField = new FieldDef("publishedOn", FieldType.TEMPORAL, null,
+            true, true, true, true, false, false, true);
 
         List<FieldOccurrence> rootOccurrences = Arrays.asList(
             occurrence(titleField, PathFactory.pathLink(titlePred), Collections.singleton(titlePred)),
             occurrence(yearField, PathFactory.pathLink(yearPred), Collections.singleton(yearPred)),
             occurrence(eventTimeField, PathFactory.pathLink(eventTimePred), Collections.singleton(eventTimePred)),
-            occurrence(scoreField, PathFactory.pathLink(scorePred), Collections.singleton(scorePred)));
+            occurrence(scoreField, PathFactory.pathLink(scorePred), Collections.singleton(scorePred)),
+            occurrence(publishedOnField, PathFactory.pathLink(publishedOnPred), Collections.singleton(publishedOnPred)));
 
         IndexProfile profile = new IndexProfile(
             NodeFactory.createURI(NS + "ThingShape"),
             Collections.singleton(NodeFactory.createURI(NS + "Thing")),
             "uri", "docType",
-            Arrays.asList(titleField, yearField, eventTimeField, scoreField),
+            Arrays.asList(titleField, yearField, eventTimeField, scoreField, publishedOnField),
             rootOccurrences,
             Collections.emptyList(),
             Collections.emptyList());
@@ -111,17 +119,18 @@ public class TestRangeFacetCounts {
         dataset.begin(ReadWrite.WRITE);
         try {
             Model model = dataset.getDefaultModel();
-            addThing(model, "d1", "alpha learning", new int[]{2018, 2020}, 100L, 1.5);
-            addThing(model, "d2", "beta learning", new int[]{2021}, 200L, 2.5);
-            addThing(model, "d3", "gamma learning", new int[]{2024}, 300L, 3.75);
-            addThing(model, "d4", "delta learning", new int[]{2019}, 400L, 4.5);
+            addThing(model, "d1", "alpha learning", new int[]{2018, 2020}, 100L, 1.5, "2018-05-01");
+            addThing(model, "d2", "beta learning", new int[]{2021}, 200L, 2.5, "2021-03-15");
+            addThing(model, "d3", "gamma learning", new int[]{2024}, 300L, 3.75, "2024-01-20");
+            addThing(model, "d4", "delta learning", new int[]{2019}, 400L, 4.5, "2019-11-30");
             dataset.commit();
         } finally {
             dataset.end();
         }
     }
 
-    private void addThing(Model model, String id, String title, int[] years, long eventTime, double score) {
+    private void addThing(Model model, String id, String title, int[] years, long eventTime, double score,
+                          String publishedOn) {
         Resource thing = ResourceFactory.createResource(NS + id);
         model.add(thing, RDF.type, ResourceFactory.createResource(NS + "Thing"));
         model.add(thing, ResourceFactory.createProperty(NS + "title"), title);
@@ -130,6 +139,8 @@ public class TestRangeFacetCounts {
         }
         model.add(thing, ResourceFactory.createProperty(NS + "eventTime"), ResourceFactory.createTypedLiteral(eventTime));
         model.add(thing, ResourceFactory.createProperty(NS + "score"), ResourceFactory.createTypedLiteral(score));
+        model.addLiteral(thing, ResourceFactory.createProperty(NS + "publishedOn"),
+            ResourceFactory.createTypedLiteral(publishedOn, XSDDatatype.XSDdate));
     }
 
     private static FieldOccurrence occurrence(FieldDef field, Path path, Set<Node> predicates) {
@@ -169,6 +180,25 @@ public class TestRangeFacetCounts {
         assertRangeBucket(facets.get("score").get(0), null, "2.0", 1);
         assertRangeBucket(facets.get("score").get(1), "2.0", "4.0", 2);
         assertRangeBucket(facets.get("score").get(2), "4.0", null, 1);
+    }
+
+    /**
+     * Date buckets are declared with ISO boundaries, not epoch millis, and are counted from
+     * the {@code publishedOn__epoch} docvalues the TEMPORAL field writes alongside the
+     * stored lexical form. Lower bound inclusive, upper exclusive except on the open end.
+     */
+    @Test
+    public void testTemporalRangeFacetCounts() {
+        FacetRequest request = new FacetRequest(
+            List.of(),
+            List.of(new FacetRequest.RangeFacetSpec(FP + "publishedOn",
+                Arrays.asList(null, "2019-01-01", "2022-01-01", null))));
+
+        Map<String, List<FacetValue>> facets = textIndex.getFacetCounts("learning", List.of("default"), request, 10, 0);
+
+        assertRangeBucket(facets.get("publishedOn").get(0), null, "2019-01-01", 1);          // d1
+        assertRangeBucket(facets.get("publishedOn").get(1), "2019-01-01", "2022-01-01", 2);  // d4, d2
+        assertRangeBucket(facets.get("publishedOn").get(2), "2022-01-01", null, 1);          // d3
     }
 
     private void assertRangeBucket(FacetValue bucket, String low, String high, long count) {


### PR DESCRIPTION
## Vocabulary

`03-configuration.md` defined 9 of the ~30 `idx:` terms. Now complete, with a defaults column and a term index at the end. Newly documented: `idx:stored`, `idx:indexed`, `idx:normalizer`, `idx:storeLiteralMetadata`, `idx:docIdField`, `idx:discriminatorField`, and the `sh:class` / `sh:nodeKind` / `sh:datatype` occurrence constraints — all of which existed only in dated design notes. Plus tables for shape properties, occurrence properties, and the index resource (`text:taxonomyDirectory`, `text:analyzer`, …).

## Examples that no longer assembled

The examples predate the fan-in refactor: they put `sh:path` on canonical fields and pointed `sh:property` straight at a field resource. `ShaclIndexAssembler` rejects both (`rejectOccurrencePropertiesOnCanonicalField`, `rejectCanonicalFieldPropertiesOnOccurrence`). Corrected across `01`, `02`, `03`, `08`, `09` to the occurrence form used by `demo/test/config.ttl`. Also `text:TextIndexLucene` → `text:TextIndexShacl`: the Lucene assembler ignores `text:shapes` entirely.

## New page

`docs/10-suggested-configuration.md` — opinionated defaults per kind of data, with a decision matrix up front and a recipe each for names, identifiers, free text, controlled vocabularies, entity-type pivots, measurements, dates, SOSA-style observations and geometry. Each carries the reasoning, the anti-pattern it avoids, and the test class backing it. Framed on the principle that the index is a filter and the graph is the source of truth — store values only when you need them projected.

## Tests

Dates were the one recommendation with no live coverage:

- **`TestDateLiteralRoundTrip` registered in `TS_Text`.** It was one of three classes never listed there, so it had never run. Passes as written — 4 tests covering epoch filtering, typed literal reconstruction, and an unparseable date dropping out of range queries.
- **TEMPORAL case added to `TestRangeFacetCounts`**, which covered only INT/LONG/DOUBLE. ISO boundaries, lower-inclusive/upper-exclusive except on the open end.

Writing it surfaced a real documentation bug: `validateLiteralMetadataRequirements` requires `idx:storeLiteralMetadata true` on every TEMPORAL field, so the reference's own `field:publishedOn` example would have thrown at config time.

`mvn test -pl jena-text` → **778 tests, 0 failures**. Counts refreshed in `05-testing.md` and `CLAUDE.md` (which also drops `TestDateLiteralRoundTrip` from its dead-class list).

## Not done

`05-testing.md`'s Java setup snippet still shows a `FieldDef` constructor and 5-arg `IndexProfile` that no longer exist. Left for a follow-up.