### PR TITLE
Skip image and Maven builds for documentation-only changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,10 +6,38 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      ## Documentation and agent config cannot change build or image output.
+      ## Deliberately NOT ignored: demo/** (TestDemoDataParsing parses those
+      ## files), build-files/**, Taskfile.yml, and .github/** itself.
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
+      - '.gitattributes'
   push:
     branches:
       - main
+    paths-ignore:
+      ## Documentation and agent config cannot change build or image output.
+      ## Deliberately NOT ignored: demo/** (TestDemoDataParsing parses those
+      ## files), build-files/**, Taskfile.yml, and .github/** itself.
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
+      - '.gitattributes'
   workflow_dispatch:
+
+## A docs commit used to leave earlier image builds running alongside the new
+## one; superseded runs are now cancelled, as they already are for pr.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,18 @@ on:
       - reopened
     branches:
       - 'main'
-      
+    paths-ignore:
+      ## Documentation and agent config cannot change build or image output.
+      ## Deliberately NOT ignored: demo/** (TestDemoDataParsing parses those
+      ## files), build-files/**, Taskfile.yml, and .github/** itself.
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
+      - '.gitattributes'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
#140 is docs-only and each of its commits triggered a two-image buildx with trivy scans (~3m13s) plus a full `mvn install`. Neither workflow filtered paths.

## Changes

- `docker.yml` and `pr.yml` gain `paths-ignore` for `docs/**`, `**/*.md`, `.claude/**`, `LICENSE`, `NOTICE`, `.gitignore`, `.gitattributes`.
- `docker.yml` gains a `concurrency` group with `cancel-in-progress`, which `pr.yml` already had. Without it, successive commits left superseded image builds running side by side — three at once on #140.

## Why it's safe

- `main` is unprotected (`gh api repos/Kurrawong/jena/branches/main/protection` → 404), so there are no required status checks that a skipped run could leave pending forever.
- RAT excludes `**/*.md` (`build-files/rat-exclusions.txt:83`), so a markdown change cannot fail the licence check that `mvn install` runs.
- Image content is built from the Maven sources and `build-files/docker`, neither of which a docs edit touches.

## Deliberately not ignored

`demo/**` — `TestDemoDataParsing` parses `demo/test/data` and `TestDemoMiningScenarios` models the same dataset, so demo edits must still run the build. Also excluded from the ignore list: `build-files/**`, `Taskfile.yml`, and `.github/**` itself, so workflow changes always validate.

A PR touching code and docs together still runs everything — `paths-ignore` skips only when every changed file matches.