### PR TITLE
Rename the nested sort selector key from 'filter' to 'selector'

### DIFF
--- a/demo/app-static/app.js
+++ b/demo/app-static/app.js
@@ -160,7 +160,7 @@ function buildSortSpec(sortField, sortDirection, fieldIRIs) {
     if (childValue && discriminator) {
         // Order parents by the value on the child whose discriminator matches, e.g. the
         // anumber rather than whichever identifier happens to sort first.
-        spec.filter = { field: fieldIri(fieldIRIs, discriminator, discriminator), eq: childValue };
+        spec.selector = { field: fieldIri(fieldIRIs, discriminator, discriminator), eq: childValue };
         spec.missing = 'last';
     }
     return JSON.stringify(spec);

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -597,6 +597,11 @@ child supplies the key and never removes entities: those with no matching child 
 place in the results and are positioned by `missing`. To also restrict *which* entities
 appear, state that independently in `cqlFilter` — the two compose.
 
+> **Renamed from `filter`.** This key was called `filter` in earlier commits. It is not
+> accepted as an alias — a sort spec carrying `filter` (or any other unrecognised key) is
+> rejected with an error naming `selector`, rather than being silently ignored and
+> returning plausible-looking rows in the wrong order.
+
 When an entity has several matching children the parent key collapses MIN (ascending) /
 MAX (descending). The normal one-record-per-type case makes MIN = MAX.
 

--- a/docs/02-sparql-api.md
+++ b/docs/02-sparql-api.md
@@ -571,38 +571,38 @@ value for the sort field. Omit it to keep Lucene's own default placement.
 ### Nested Sort Selector
 
 To order by a value drawn from one specific nested child record — "sort by the identifier
-value *where* `identifierType = companyID`" — add a `filter` to the sort object:
+value *where* `identifierType = companyID`" — add a `selector` to the sort object:
 
 ```json
 {
-  "field":  "urn:jena:lucene:field#identifierValue",
-  "filter": {"field":"urn:jena:lucene:field#identifierType","eq":"companyID"},
-  "order":  "asc",
-  "missing": "last"
+  "field":    "urn:jena:lucene:field#identifierValue",
+  "selector": {"field":"urn:jena:lucene:field#identifierType","eq":"companyID"},
+  "order":    "asc",
+  "missing":  "last"
 }
 ```
 
 | Key | Meaning |
 |-----|---------|
 | `field` | the child value field to sort on; must be `idx:sortable` |
-| `filter.field` | the co-located discriminator on the same child document |
-| `filter.eq` | the value that discriminator must equal |
+| `selector.field` | the co-located discriminator on the same child document |
+| `selector.eq` | the value that discriminator must equal |
 | `order` | `asc` (default) / `desc`, as for a flat sort |
 | `missing` | `first` \| `last` — placement of entities with no matching child. Default `last` |
 
 The nested scope is inferred from `field`; it is not part of the wire format.
 
-The `filter` is a **sort selector, not a result filter**. It chooses which child supplies
-the sort key and never removes entities: those with no matching child keep their place in
-the result set and are positioned by `missing`. To also restrict *which* entities appear,
-state that independently in `cqlFilter` — the two compose.
+The `selector` **chooses a sort key; it does not restrict the result set**. It picks which
+child supplies the key and never removes entities: those with no matching child keep their
+place in the results and are positioned by `missing`. To also restrict *which* entities
+appear, state that independently in `cqlFilter` — the two compose.
 
 When an entity has several matching children the parent key collapses MIN (ascending) /
 MAX (descending). The normal one-record-per-type case makes MIN = MAX.
 
-#### Why filter in two places?
+#### Why select and filter separately?
 
-Because the two filters act on different things. `cqlFilter` decides *which documents*
+Because the two act on different things. `cqlFilter` decides *which documents*
 come back; a sort reads its key from doc-values on a document that has already been
 picked. Filtering on the discriminator therefore does nothing at all to the sort key.
 
@@ -613,15 +613,15 @@ the parent, the sort collapses the entity's whole bag: an entity whose companyID
 `C-200` but whose govID is `A-000` sorts on `A-000`. The filter chose the entity; the
 sort key still came from the wrong record.
 
-The sort's own `filter` is what keeps the child identity long enough to say "take the
+The sort's `selector` is what keeps the child identity long enough to say "take the
 value from *this* child". The same split exists elsewhere: Elasticsearch's nested sort
 takes its own `nested.filter` independent of the query, and in SQL the discriminator
 belongs in the `LEFT JOIN ... ON` clause — move it to `WHERE` and the outer join
 collapses, dropping the very rows you wanted to keep.
 
 The selector is nested-only. A flat multivalued field is a decorrelated bag with no
-surviving per-value discriminator, so a `filter` on a root-scoped field is an error
-(`sort filter requires a nested field`). Both fields must belong to the *same*
+surviving per-value discriminator, so a `selector` on a root-scoped field is an error
+(`Sort selector requires a nested field`). Both fields must belong to the *same*
 `idx:nested` block — that is what puts them on one child document.
 
 Data-modelling requirements (no extra index configuration):
@@ -629,7 +629,7 @@ Data-modelling requirements (no extra index configuration):
 ```turtle
 :sampleShape idx:nested [
     idx:joinPath sdo:identifier ;
-    # discriminator -> child filter
+    # discriminator -> sort selector
     idx:property [ idx:field field:identifierType  ; sh:path sdo:propertyID ] ;
     # value         -> sort key
     idx:property [ idx:field field:identifierValue ; sh:path sdo:value ] ;

--- a/docs/2026-07-02_nested_sort_selector_design.md
+++ b/docs/2026-07-02_nested_sort_selector_design.md
@@ -12,6 +12,14 @@ API, and `TestNestedSortSelector` / `TestSortSpec` for the behaviour this note s
 The named-sort-preset variant below was **not** implemented — the inline form covers the
 requirement and a preset adds config surface for no new capability.
 
+**Superseded on 2026-07-31: the key is `selector`, not `filter`.** The spelling below is
+kept as the record of what was designed; it is no longer accepted. `luc:query` already
+takes a `filter` that restricts the result set, so the same word named two unrelated
+operations in one API — exactly the confusion this note's "sort selector, not a result
+filter" paragraph was written to pre-empt. `SortSpec.filterField` / `filterValue` are
+likewise now `selectorField` / `selectorValue`. Unknown sort-spec keys are rejected, so
+the old spelling errors rather than being ignored.
+
 This note records the design for ordering parent
 (entity-per-document) search results by a value drawn from a specific nested
 child record — e.g. "sort by the identifier value **where** identifierType =

--- a/docs/presentations/external-content-indexing.html
+++ b/docs/presentations/external-content-indexing.html
@@ -653,13 +653,13 @@ analyteValue  [1 – 5)     <span class="n">  842</span></pre>
         <h3>Sort by one analyte's value</h3>
         <p>"Order these holes by their gold value, highest first" — where each hole has dozens of measurements and only one of them is gold.</p>
 <pre class="tight">{
-  <span class="p">"field"</span>:  <span class="s">"…#analyteValue"</span>,
-  <span class="p">"filter"</span>: {<span class="p">"field"</span>:<span class="s">"…#analyte"</span>, <span class="p">"eq"</span>:<span class="s">"Au"</span>},
-  <span class="p">"order"</span>:  <span class="s">"desc"</span>,
-  <span class="p">"missing"</span>:<span class="s">"last"</span>
+  <span class="p">"field"</span>:    <span class="s">"…#analyteValue"</span>,
+  <span class="p">"selector"</span>: {<span class="p">"field"</span>:<span class="s">"…#analyte"</span>, <span class="p">"eq"</span>:<span class="s">"Au"</span>},
+  <span class="p">"order"</span>:    <span class="s">"desc"</span>,
+  <span class="p">"missing"</span>:  <span class="s">"last"</span>
 }</pre>
         <ul class="clean">
-          <li>The <code>filter</code> <b style="color:var(--ink)">picks which measurement supplies the sort key</b> — it doesn't remove holes</li>
+          <li>The <code>selector</code> <b style="color:var(--ink)">picks which measurement supplies the sort key</b> — it doesn't remove holes</li>
           <li>Holes with no gold result keep their place, positioned by <code>missing</code></li>
           <li>Sorting happens before paging, so page 7 is still correct</li>
         </ul>

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -2614,7 +2614,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
     /**
      * Build the {@link ToParentBlockJoinSortField} for a nested sort selector: order parent
      * docs by {@code spec.field()} taken from the child docs where the co-located
-     * discriminator {@code spec.filterField()} equals {@code spec.filterValue()}, collapsing
+     * discriminator {@code spec.selectorField()} equals {@code spec.selectorValue()}, collapsing
      * MIN (ascending) / MAX (descending) when an entity has several matching children.
      * <p>
      * The selector chooses the sort key only — it never removes entities. Parents with no
@@ -2628,30 +2628,30 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
         }
         ShaclIndexMapping.NestedDef scope = shaclMapping.findNestedDefForFieldName(fd.getFieldName());
         if (scope == null) {
-            throw new TextIndexException("Sort filter requires a nested field: '" + spec.field()
+            throw new TextIndexException("Sort selector requires a nested field: '" + spec.field()
                 + "' is not part of an idx:nested block. A flat multivalued field keeps no "
-                + "per-value discriminator to filter on.");
+                + "per-value discriminator to select on.");
         }
         if (!fd.isSortable()) {
             throw new TextIndexException("Sort field '" + spec.field()
                 + "' is not idx:sortable, so it has no sort doc-values to select from.");
         }
 
-        ShaclIndexMapping.FieldDef filterFd = shaclMapping.findField(spec.filterField());
-        if (filterFd == null) {
-            throw new TextIndexException("Unknown sort filter field: '" + spec.filterField() + "'. "
-                + "Available fields: " + shaclMapping.getAllFieldNames());
+        ShaclIndexMapping.FieldDef selectorFd = shaclMapping.findField(spec.selectorField());
+        if (selectorFd == null) {
+            throw new TextIndexException("Unknown sort selector field: '" + spec.selectorField()
+                + "'. Available fields: " + shaclMapping.getAllFieldNames());
         }
-        ShaclIndexMapping.NestedDef filterScope =
-            shaclMapping.findNestedDefForFieldName(filterFd.getFieldName());
-        if (filterScope == null || !filterScope.getNestedName().equals(scope.getNestedName())) {
-            throw new TextIndexException("Sort filter field '" + spec.filterField()
+        ShaclIndexMapping.NestedDef selectorScope =
+            shaclMapping.findNestedDefForFieldName(selectorFd.getFieldName());
+        if (selectorScope == null || !selectorScope.getNestedName().equals(scope.getNestedName())) {
+            throw new TextIndexException("Sort selector field '" + spec.selectorField()
                 + "' must belong to the same idx:nested block as sort field '" + spec.field()
                 + "' (block '" + scope.getNestedName() + "'); the type/value correlation only "
                 + "survives on a single child document.");
         }
 
-        BitSetProducer childFilter = childSortFilter(scope, filterFd, spec.filterValue());
+        BitSetProducer childFilter = childSortFilter(scope, selectorFd, spec.selectorValue());
         SortField sortField = new ToParentBlockJoinSortField(
             luceneFieldName, sortType, spec.descending(), PARENTS_FILTER, childFilter);
         SortSpec.MissingPlacement missing =
@@ -2671,8 +2671,8 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
      * stops admitting entries once full rather than growing with query traffic.
      */
     private BitSetProducer childSortFilter(ShaclIndexMapping.NestedDef scope,
-            ShaclIndexMapping.FieldDef filterFd, String value) {
-        String key = scope.getNestedName() + ' ' + filterFd.getFieldName() + ' ' + value;
+            ShaclIndexMapping.FieldDef selectorFd, String value) {
+        String key = scope.getNestedName() + '\0' + selectorFd.getFieldName() + '\0' + value;
         BitSetProducer cached = childSortFilterCache.get(key);
         if (cached != null) {
             return cached;
@@ -2680,7 +2680,7 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         builder.add(new TermQuery(new Term(NESTED_SCOPE_FIELD, scope.getNestedName())),
             BooleanClause.Occur.FILTER);
-        builder.add(childDiscriminatorQuery(filterFd, value), BooleanClause.Occur.MUST);
+        builder.add(childDiscriminatorQuery(selectorFd, value), BooleanClause.Occur.MUST);
         BitSetProducer producer = new QueryBitSetProducer(builder.build());
         if (childSortFilterCache.size() >= MAX_CHILD_SORT_FILTERS) {
             return producer;
@@ -2690,18 +2690,18 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
     }
 
     /** Exact-match query for a sort selector's discriminator value on a child doc. */
-    private static Query childDiscriminatorQuery(ShaclIndexMapping.FieldDef filterFd, String value) {
-        String fieldName = filterFd.getFieldName();
-        if (!filterFd.isIndexed()) {
-            throw new TextIndexException("Sort filter field '" + fieldName
+    private static Query childDiscriminatorQuery(ShaclIndexMapping.FieldDef selectorFd, String value) {
+        String fieldName = selectorFd.getFieldName();
+        if (!selectorFd.isIndexed()) {
+            throw new TextIndexException("Sort selector field '" + fieldName
                 + "' is not idx:indexed, so it cannot be matched.");
         }
         try {
-            return switch (filterFd.getFieldType()) {
+            return switch (selectorFd.getFieldType()) {
                 // KEYWORD with a normalizer indexes the normalized term, so normalize the
                 // comparison value the same way (mirrors the CQL compiler's = handling).
                 case KEYWORD, TEXT -> {
-                    Analyzer norm = filterFd.getNormalizer();
+                    Analyzer norm = selectorFd.getNormalizer();
                     BytesRef term = norm != null ? norm.normalize(fieldName, value) : new BytesRef(value);
                     yield new TermQuery(new Term(fieldName, term));
                 }
@@ -2709,12 +2709,12 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
                 case LONG -> LongPoint.newExactQuery(fieldName, Long.parseLong(value));
                 case DOUBLE -> DoublePoint.newExactQuery(fieldName, Double.parseDouble(value));
                 case TEMPORAL, LATLON -> throw new TextIndexException(
-                    "Sort filter field '" + fieldName + "' has unsupported type "
-                        + filterFd.getFieldType() + "; use a KEYWORD discriminator.");
+                    "Sort selector field '" + fieldName + "' has unsupported type "
+                        + selectorFd.getFieldType() + "; use a KEYWORD discriminator.");
             };
         } catch (NumberFormatException ex) {
-            throw new TextIndexException("Sort filter value '" + value + "' is not a valid "
-                + filterFd.getFieldType() + " for field '" + fieldName + "'");
+            throw new TextIndexException("Sort selector value '" + value + "' is not a valid "
+                + selectorFd.getFieldType() + " for field '" + fieldName + "'");
         }
     }
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/SortSpec.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SortSpec.java
@@ -32,18 +32,18 @@ import java.util.Locale;
  * sort-key chooser, not a result filter: entities with no matching child stay in the
  * result set and are placed per {@link #missing()}.
  *
- * @param field       the field identifier (IRI) to sort by; for a selector spec this is
- *                    the child value field
- * @param descending  true for descending order, false for ascending
- * @param filterField the co-located child discriminator field identifier (IRI), or null
- *                    for a flat sort
- * @param filterValue the value {@code filterField} must equal on the child supplying the
- *                    sort key; null for a flat sort
- * @param missing     placement of entities with no sort value, or null for the Lucene
- *                    default (selector specs default to {@link MissingPlacement#LAST})
+ * @param field         the field identifier (IRI) to sort by; for a selector spec this is
+ *                      the child value field
+ * @param descending    true for descending order, false for ascending
+ * @param selectorField the co-located child discriminator field identifier (IRI), or null
+ *                      for a flat sort
+ * @param selectorValue the value {@code selectorField} must equal on the child supplying
+ *                      the sort key; null for a flat sort
+ * @param missing       placement of entities with no sort value, or null for the Lucene
+ *                      default (selector specs default to {@link MissingPlacement#LAST})
  */
-public record SortSpec(String field, boolean descending, String filterField,
-                       String filterValue, MissingPlacement missing) {
+public record SortSpec(String field, boolean descending, String selectorField,
+                       String selectorValue, MissingPlacement missing) {
 
     /** Where entities with no sort value land in the final result order. */
     public enum MissingPlacement { FIRST, LAST }
@@ -55,13 +55,13 @@ public record SortSpec(String field, boolean descending, String filterField,
 
     /** True when this spec selects its sort key from a nested child doc. */
     public boolean hasSelector() {
-        return filterField != null;
+        return selectorField != null;
     }
 
     public String toCanonical() {
         StringBuilder sb = new StringBuilder(field);
-        if (filterField != null) {
-            sb.append('[').append(filterField).append('=').append(filterValue).append(']');
+        if (selectorField != null) {
+            sb.append('[').append(selectorField).append('=').append(selectorValue).append(']');
         }
         sb.append(descending ? ":desc" : ":asc");
         if (missing != null) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/SortSpecParser.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SortSpecParser.java
@@ -41,9 +41,13 @@ import org.apache.jena.atlas.json.JsonValue;
  * child by a co-located discriminator:
  * <pre>{@code
  * {"field": "...#identifierValue",
- *  "filter": {"field": "...#identifierType", "eq": "companyID"},
+ *  "selector": {"field": "...#identifierType", "eq": "companyID"},
  *  "order": "asc", "missing": "last"}
  * }</pre>
+ * The selector key is deliberately not called {@code filter}: {@code luc:query} already
+ * takes a {@code filter} that restricts the result set, whereas this one only chooses
+ * which child supplies the sort key.
+ * <p>
  * Parsing here is purely syntactic; the nested scope is inferred and validated against
  * the SHACL mapping in {@code ShaclTextIndexLucene.buildLuceneSort}.
  */
@@ -78,21 +82,21 @@ public class SortSpecParser {
             descending = "desc".equalsIgnoreCase(order);
         }
 
-        String filterField = null;
-        String filterValue = null;
-        if (obj.hasKey("filter")) {
-            JsonValue filterVal = obj.get("filter");
-            if (!filterVal.isObject()) {
+        String selectorField = null;
+        String selectorValue = null;
+        if (obj.hasKey("selector")) {
+            JsonValue selectorVal = obj.get("selector");
+            if (!selectorVal.isObject()) {
                 throw new TextIndexException(
-                    "Sort spec 'filter' must be an object {\"field\":..., \"eq\":...}: " + obj);
+                    "Sort spec 'selector' must be an object {\"field\":..., \"eq\":...}: " + obj);
             }
-            JsonObject filter = filterVal.getAsObject();
-            if (!filter.hasKey("field") || !filter.hasKey("eq")) {
+            JsonObject selector = selectorVal.getAsObject();
+            if (!selector.hasKey("field") || !selector.hasKey("eq")) {
                 throw new TextIndexException(
-                    "Sort spec 'filter' must have both 'field' and 'eq' keys: " + obj);
+                    "Sort spec 'selector' must have both 'field' and 'eq' keys: " + obj);
             }
-            filterField = filter.get("field").getAsString().value();
-            filterValue = asLexicalForm(filter.get("eq"), obj);
+            selectorField = selector.get("field").getAsString().value();
+            selectorValue = asLexicalForm(selector.get("eq"), obj);
         }
 
         SortSpec.MissingPlacement missing = null;
@@ -108,10 +112,10 @@ public class SortSpecParser {
             }
         }
 
-        return new SortSpec(field, descending, filterField, filterValue, missing);
+        return new SortSpec(field, descending, selectorField, selectorValue, missing);
     }
 
-    /** Lexical form of a filter's {@code eq} value — strings, numbers and booleans all
+    /** Lexical form of a selector's {@code eq} value — strings, numbers and booleans all
      *  become the term text the discriminator field was indexed with. */
     private static String asLexicalForm(JsonValue value, JsonObject context) {
         if (value.isString()) {
@@ -124,7 +128,7 @@ public class SortSpecParser {
             return Boolean.toString(value.getAsBoolean().value());
         }
         throw new TextIndexException(
-            "Sort spec filter 'eq' must be a string, number or boolean: " + context);
+            "Sort spec selector 'eq' must be a string, number or boolean: " + context);
     }
 
     /**

--- a/jena-text/src/main/java/org/apache/jena/query/text/SortSpecParser.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/SortSpecParser.java
@@ -46,12 +46,15 @@ import org.apache.jena.atlas.json.JsonValue;
  * }</pre>
  * The selector key is deliberately not called {@code filter}: {@code luc:query} already
  * takes a {@code filter} that restricts the result set, whereas this one only chooses
- * which child supplies the sort key.
+ * which child supplies the sort key. Unknown keys are rejected rather than ignored, so
+ * the old spelling fails loudly instead of silently sorting unselected.
  * <p>
  * Parsing here is purely syntactic; the nested scope is inferred and validated against
  * the SHACL mapping in {@code ShaclTextIndexLucene.buildLuceneSort}.
  */
 public class SortSpecParser {
+
+    private static final List<String> KEYS = List.of("field", "order", "selector", "missing");
 
     public static List<SortSpec> parse(String json) {
         JsonValue val = JSON.parseAny(json);
@@ -72,6 +75,7 @@ public class SortSpecParser {
     }
 
     private static SortSpec parseOne(JsonObject obj) {
+        checkKeys(obj);
         if (!obj.hasKey("field")) {
             throw new TextIndexException("Sort spec must have a 'field' key: " + obj);
         }
@@ -113,6 +117,25 @@ public class SortSpecParser {
         }
 
         return new SortSpec(field, descending, selectorField, selectorValue, missing);
+    }
+
+    /**
+     * Reject keys the sort spec does not define, so a typo or a stale {@code filter} is an
+     * error rather than a silently dropped instruction that returns plausible-looking rows
+     * in the wrong order.
+     */
+    private static void checkKeys(JsonObject obj) {
+        for (String key : obj.keys()) {
+            if (KEYS.contains(key)) {
+                continue;
+            }
+            String hint = "filter".equals(key)
+                ? " The nested sort selector is now 'selector'; 'filter' on luc:query is the "
+                    + "separate CQL result-set filter."
+                : "";
+            throw new TextIndexException("Unknown sort spec key '" + key + "'. Expected one of "
+                + KEYS + "." + hint);
+        }
     }
 
     /** Lexical form of a selector's {@code eq} value — strings, numbers and booleans all

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestExternalContentIndexing.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestExternalContentIndexing.java
@@ -290,7 +290,7 @@ public class TestExternalContentIndexing {
     /** Sort by a nested value drawn from the child where measuredProperty = {@code property}. */
     private static String sortByProperty(String property, String order, String missing) {
         return "{\"field\":\"" + FP + "measuredValue\""
-            + ",\"filter\":{\"field\":\"" + FP + "measuredProperty\",\"eq\":\"" + property + "\"}"
+            + ",\"selector\":{\"field\":\"" + FP + "measuredProperty\",\"eq\":\"" + property + "\"}"
             + ",\"order\":\"" + order + "\",\"missing\":\"" + missing + "\"}";
     }
 
@@ -719,7 +719,7 @@ public class TestExternalContentIndexing {
         buildIntervalIndex(INTERVAL_CSV);
 
         String sortByAu = "{\"field\":\"" + FP + "value\""
-            + ",\"filter\":{\"field\":\"" + FP + "analyte\",\"eq\":\"Au\"}"
+            + ",\"selector\":{\"field\":\"" + FP + "analyte\",\"eq\":\"Au\"}"
             + ",\"order\":\"desc\",\"missing\":\"last\"}";
 
         assertEquals("best Au intercept first: s1 12.4, s3 5.0, s2 0.3, then s4 with none",

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestNestedSortSelector.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestNestedSortSelector.java
@@ -200,12 +200,12 @@ public class TestNestedSortSelector {
 
     // ---- Sort-spec JSON helpers ----
 
-    private static String selectorSort(String valueField, String filterField, String filterValue,
+    private static String selectorSort(String valueField, String selectorField, String selectorValue,
             String order, String missing) {
         StringBuilder sb = new StringBuilder();
         sb.append("{\"field\":\"").append(FP).append(valueField).append("\"")
-          .append(",\"filter\":{\"field\":\"").append(FP).append(filterField)
-          .append("\",\"eq\":\"").append(filterValue).append("\"}")
+          .append(",\"selector\":{\"field\":\"").append(FP).append(selectorField)
+          .append("\",\"eq\":\"").append(selectorValue).append("\"}")
           .append(",\"order\":\"").append(order).append("\"");
         if (missing != null) {
             sb.append(",\"missing\":\"").append(missing).append("\"");

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
@@ -153,6 +153,35 @@ public class TestSortSpec {
         SortSpecParser.parse("{\"field\":\"year\",\"missing\":\"middle\"}");
     }
 
+    /**
+     * The sort selector was called {@code filter} before it was renamed. The old key is not
+     * an alias: {@code luc:query}'s own {@code filter} restricts the result set, and keeping
+     * both spellings alive would preserve exactly the ambiguity the rename removes. An
+     * explicit parse error naming {@code selector} is the migration message.
+     */
+    @Test
+    public void testParseLegacyFilterKeyThrowsNamingSelector() {
+        try {
+            SortSpecParser.parse("{\"field\":\"identifierValue\","
+                + "\"filter\":{\"field\":\"identifierType\",\"eq\":\"companyID\"}}");
+            fail("the legacy 'filter' key must be rejected, not silently accepted");
+        } catch (TextIndexException ex) {
+            assertTrue("message should name the replacement key: " + ex.getMessage(),
+                ex.getMessage().contains("selector"));
+        }
+    }
+
+    @Test
+    public void testParseUnknownKeyThrows() {
+        try {
+            SortSpecParser.parse("{\"field\":\"year\",\"sortby\":\"desc\"}");
+            fail("an unrecognised sort-spec key must be rejected");
+        } catch (TextIndexException ex) {
+            assertTrue("message should name the offending key: " + ex.getMessage(),
+                ex.getMessage().contains("sortby"));
+        }
+    }
+
     @Test
     public void testSelectorToCanonicalDistinguishesSelectorValue() {
         SortSpec companyId = new SortSpec("value", false, "type", "companyID", null);

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSortSpec.java
@@ -110,15 +110,15 @@ public class TestSortSpec {
     public void testParseNestedSelector() {
         List<SortSpec> specs = SortSpecParser.parse(
             "{\"field\":\"identifierValue\","
-            + "\"filter\":{\"field\":\"identifierType\",\"eq\":\"companyID\"},"
+            + "\"selector\":{\"field\":\"identifierType\",\"eq\":\"companyID\"},"
             + "\"order\":\"desc\",\"missing\":\"first\"}");
         assertEquals(1, specs.size());
         SortSpec spec = specs.get(0);
         assertTrue(spec.hasSelector());
         assertEquals("identifierValue", spec.field());
         assertTrue(spec.descending());
-        assertEquals("identifierType", spec.filterField());
-        assertEquals("companyID", spec.filterValue());
+        assertEquals("identifierType", spec.selectorField());
+        assertEquals("companyID", spec.selectorValue());
         assertEquals(SortSpec.MissingPlacement.FIRST, spec.missing());
     }
 
@@ -126,26 +126,26 @@ public class TestSortSpec {
     public void testParseFlatSpecHasNoSelector() {
         SortSpec spec = SortSpecParser.parse("{\"field\":\"year\"}").get(0);
         assertFalse(spec.hasSelector());
-        assertNull(spec.filterField());
-        assertNull(spec.filterValue());
+        assertNull(spec.selectorField());
+        assertNull(spec.selectorValue());
         assertNull("absent 'missing' leaves Lucene's own default in place", spec.missing());
     }
 
     @Test
-    public void testParseNonStringFilterValue() {
+    public void testParseNonStringSelectorValue() {
         SortSpec spec = SortSpecParser.parse(
-            "{\"field\":\"reading\",\"filter\":{\"field\":\"sensorId\",\"eq\":42}}").get(0);
-        assertEquals("42", spec.filterValue());
+            "{\"field\":\"reading\",\"selector\":{\"field\":\"sensorId\",\"eq\":42}}").get(0);
+        assertEquals("42", spec.selectorValue());
     }
 
     @Test(expected = TextIndexException.class)
-    public void testParseFilterWithoutEqThrows() {
-        SortSpecParser.parse("{\"field\":\"identifierValue\",\"filter\":{\"field\":\"identifierType\"}}");
+    public void testParseSelectorWithoutEqThrows() {
+        SortSpecParser.parse("{\"field\":\"identifierValue\",\"selector\":{\"field\":\"identifierType\"}}");
     }
 
     @Test(expected = TextIndexException.class)
-    public void testParseNonObjectFilterThrows() {
-        SortSpecParser.parse("{\"field\":\"identifierValue\",\"filter\":\"companyID\"}");
+    public void testParseNonObjectSelectorThrows() {
+        SortSpecParser.parse("{\"field\":\"identifierValue\",\"selector\":\"companyID\"}");
     }
 
     @Test(expected = TextIndexException.class)
@@ -154,7 +154,7 @@ public class TestSortSpec {
     }
 
     @Test
-    public void testSelectorToCanonicalDistinguishesFilterValue() {
+    public void testSelectorToCanonicalDistinguishesSelectorValue() {
         SortSpec companyId = new SortSpec("value", false, "type", "companyID", null);
         SortSpec govId = new SortSpec("value", false, "type", "govID", null);
         assertEquals("value[type=companyID]:asc", companyId.toCanonical());
@@ -340,7 +340,7 @@ public class TestSortSpec {
                 new SortSpec(FP + "identifierValue", false, FP + "noSuchField", "companyID", null)));
             fail("an unresolvable discriminator field must be rejected");
         } catch (TextIndexException ex) {
-            assertTrue(ex.getMessage(), ex.getMessage().contains("Unknown sort filter field"));
+            assertTrue(ex.getMessage(), ex.getMessage().contains("Unknown sort selector field"));
         } finally {
             textIndex.close();
         }


### PR DESCRIPTION
## Why

The nested sort spec's `filter` named a different operation from `luc:query`'s own `filter`:

| Key | What it does |
|-----|--------------|
| `luc:query` arg 4, `cqlFilter` | restricts **which entities** come back |
| sort spec `filter` (this one) | chooses **which nested child** supplies the sort key |

Same word, two unrelated meanings, in one API. The tell was already in the docs — the page needed a paragraph explaining that the sort `filter` is "a sort selector, not a result filter", plus a whole `#### Why filter in two places?` section. A key that needs to be talked out of its own name is misnamed.

Renamed now rather than after GSWA builds against it, which keeps it an edit instead of a coordination problem.

## What changed

Wire format:

```json
{
  "field":    "urn:jena:lucene:field#identifierValue",
  "selector": {"field":"urn:jena:lucene:field#identifierType","eq":"companyID"},
  "order":    "asc",
  "missing":  "last"
}
```

- `SortSpec.filterField` / `filterValue` → `selectorField` / `selectorValue`
- Error messages now read `Sort selector …`
- `demo/app-static/app.js`, `docs/02-sparql-api.md`, and the presentation slide follow

Per the fork's SHACL-mode policy this is a **hard break — `filter` is not accepted as an alias.** Keeping both spellings alive would preserve exactly the ambiguity the rename removes.

The 2026-07-02 design note keeps its original wording as the record of what was designed, with a Superseded paragraph added to its Status.

## Unknown keys are now rejected (second commit)

The parser previously read the keys it knew and dropped the rest. For this rename that's the worst available outcome: a stale `filter` parses clean, the caller's selector silently vanishes, and the sort still succeeds — plausible-looking rows in an order nobody asked for, no error anywhere. An unrecognised key is now a parse error naming `selector`.

**This caught two live call sites in `TestExternalContentIndexing` that the rename sweep missed** (my grep pattern didn't match Java's escaped `\"filter\"`). Both would have silently sorted unselected. That is the case for the check, found on its first run.

## Unrelated fix, included because it blocked the edit

`ShaclTextIndexLucene.java:2675` held two literal NUL bytes (`0x00`) inside char literals in the child-sort-filter cache key, where the source reads as `' '`. Semantically fine — NUL is a better key separator than a space, since it cannot occur in a field name — but invisible to editors and to `grep`, and it defeated string-matching edits until the line was hexdumped. Now written as `'\0'`: identical bytes at runtime, visible in source. Only file in the tree with this.

## Testing

`mvn test -pl jena-text` → **792 tests, 0 failures** (was 790; the two new tests are the delta).

Both new tests were written first and confirmed **red** against the rename-only parser — legacy key accepted, unknown key accepted — before the check was added. The two commits are split so the mechanical rename reviews separately from the behaviour change.