### PR TITLE
Correlate root facet hierarchies whose levels' paths form a prefix chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ mvn clean install -Drat.skip
 ## Running Tests
 
 ```bash
-# Run all jena-text tests (790 tests)
+# Run all jena-text tests (805 tests)
 mvn test -pl jena-text
 
 # Run a single test class

--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -93,7 +93,7 @@ it. Pointing `sh:property` straight at a field resource is the old form and is r
 | `sh:targetClass` | yes | Entity class this profile indexes. Repeatable |
 | `sh:property` | yes¹ | A root field occurrence |
 | `idx:nested` | yes¹ | A child collection — see [Nested Child Records](#nested-child-records) |
-| `idx:facetHierarchy` | no | Ordered list of fields forming one hierarchical facet dimension |
+| `idx:facetHierarchy` | no | Ordered list of fields forming one hierarchical facet dimension — see [Hierarchical Facets](#hierarchical-facets) |
 | `idx:docIdField` | no, default `"uri"` | Lucene field holding the entity IRI. Must be identical across every profile in one index |
 | `idx:discriminatorField` | no, default `"docType"` | Lucene field holding the target class's local name, so deletes stay scoped to one profile |
 
@@ -338,6 +338,69 @@ Inverse path:
 sh:path [ sh:inversePath ex:authored ] .
 ```
 
+## Hierarchical Facets
+
+`idx:facetHierarchy` on a shape takes an ordered list of fields, outermost level first,
+and builds one facet dimension named by joining their field names with `_`. A hierarchy
+over `( field:dataTypeGrouping field:dataType )` is addressed as
+`dataTypeGrouping_dataType`: faceting on it returns the groupings, and drilling down into
+one returns the datatypes inside it.
+
+### Correlated levels
+
+How the levels are paired depends on their **paths**. When each level's path extends the
+path of the level below it — a *prefix chain* — the levels are correlated by walking those
+paths through the graph. Otherwise the dimension is the cartesian product of the levels'
+values.
+
+```turtle
+sh:property [ idx:field field:dataType         ; sh:path gswa:hasDisplayTable ] ;
+sh:property [ idx:field field:dataTypeGrouping ; sh:path ( gswa:hasDisplayTable gswa:hasGrouping ) ] ;
+idx:facetHierarchy ( field:dataTypeGrouping field:dataType ) ;
+```
+
+Here the display-table node is where the levels meet: `dataType` **is** that node, and
+`dataTypeGrouping` is one step beyond it. For an entity carrying two display tables in two
+different groupings,
+
+```text
+dataType          = [ display/borehole, display/geochem-results ]
+dataTypeGrouping  = [ datatype/Holes,   datatype/Geochemistry   ]
+```
+
+only the two paths that exist in the data are emitted — `Holes / borehole` and
+`Geochemistry / geochem-results`. Reading the two fields independently would also emit
+`Holes / geochem-results` and `Geochemistry / borehole`, so drilling into `Holes` would
+offer a datatype that is not in it and the children would out-count the parent.
+
+Correlation needs a single unambiguous node at which two levels meet, so it applies when:
+
+- every level has **exactly one** root occurrence — a field fed by two paths (fan-in) has
+  no single meeting node;
+- every level's path has a single variant — no alternative paths;
+- each level's path **strictly extends** the next level's, step for step. Inverse steps
+  chain like any other step.
+
+Levels that are not prefix-chained keep the cartesian product, which is what independent
+levels want. When such a hierarchy has more than one multi-valued level — the shape that
+silently invents paths — a warning is logged at config time naming the dimension and the
+levels involved.
+
+A correlated level's path is walked from the entity outwards, so a value that does not
+reach the level above it contributes nothing to the dimension: a display table with no
+grouping is absent from `dataTypeGrouping_dataType`, while remaining a value of the flat
+`dataType` facet. Partial paths are not emitted, because an entity must not be counted
+under a parent it does not have.
+
+Change tracking needs no extra configuration: correlation is derived from occurrences that
+are already declared, so an edit anywhere along the chain — including one to the
+vocabulary rather than to the entity, such as `display/borehole gswa:hasGrouping …` —
+reindexes every affected entity.
+
+Hierarchy ordinals live in the taxonomy directory. Leave `text:taxonomyDirectory` unset and
+the counts vanish entirely when indexing and querying are separate processes — see
+[Index Resources](#index-resources).
+
 ## Nested Child Records
 
 `idx:nested` declares a repeated child collection on a shape. Each child becomes its own Lucene doc inside the entity's block; clauses targeting the same nested scope can be combined with same-child correlation at query time.
@@ -468,7 +531,7 @@ plain field, and for the n-gram configurations that are permitted but not advise
 - Scope names are resolved across the whole mapping, so an explicit `idx:nestedName` must be unique among all `idx:nested` blocks in the index, not just within its shape.
 - `idx:joinPath` may be a simple predicate, an inverse predicate, or a sequence of predicate steps. It does not support alternative paths.
 - Both the exact-keyword and edge-ngram-text variants can sit on the same SHACL path — they are different Lucene fields driven by their own analyzers.
-- `idx:facetHierarchy` inside an `idx:nested` block defines a hierarchy whose levels are correlated per child record (no cartesian products).
+- `idx:facetHierarchy` inside an `idx:nested` block defines a hierarchy whose levels are correlated per child record (no cartesian products). A hierarchy on the shape correlates instead when its levels' paths form a prefix chain — see [Correlated levels](#correlated-levels).
 - A field named in an `idx:facetHierarchy` keeps its own flat facet dimension. Faceting on the field IRI returns that field's counts across all parents; faceting on the hierarchy's dimension name returns its top level, or the children of a drill-down path. The two are addressed separately and neither shadows the other.
 - Faceting on a field that is not `idx:facetable` is an error — there is no dimension to answer from.
 

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -3,7 +3,7 @@
 ## Running Tests
 
 ```bash
-# Full jena-text suite (790 tests)
+# Full jena-text suite (805 tests)
 mvn test -pl jena-text
 
 # Only SHACL / faceting tests
@@ -53,6 +53,8 @@ A class missing from `@SelectClasses` is **silently never run** — not reported
 |-------|-------|---------------|
 | `TestHierarchicalFacets` | 9 | Java API: taxonomy indexing, top-level facets, drill-down path building, flat+hierarchy coexistence, multi-valued hierarchies, empty dimensions |
 | `TestHierarchicalFacetsSparql` | 3 | SPARQL `luc:facet` with hierarchy: top-level via field IRI, drill-down via CQL filter, flat facets alongside hierarchy |
+| `TestCorrelatedRootHierarchy` | 7 | Root hierarchy whose levels are prefix-chained (`dataType` at `hasDisplayTable`, `dataTypeGrouping` one step beyond): top-level counts, drill-down that invents no paths, children not out-counting the parent, flat facets unaffected, vocabulary-edit reindex, a term with no parent, three-level chain |
+| `TestCorrelatedHierarchyDerivation` | 6 | Which configs get a correlated plan: prefix-chained, independent, reversed chain, fan-in level, inverse ascent step, three levels |
 
 ### Sort Tests
 
@@ -71,7 +73,7 @@ A class missing from `@SelectClasses` is **silently never run** — not reported
 
 ### Existing Tests (unchanged, verifying no regressions)
 
-The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 790 tests.
+The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 805 tests.
 
 ---
 

--- a/docs/2026-08-03_correlated_hierarchy_over_root_fields.md
+++ b/docs/2026-08-03_correlated_hierarchy_over_root_fields.md
@@ -1,0 +1,226 @@
+---
+title: "Correlated hierarchical facets over root fields"
+date: "2026-08-03"
+status: "Resolved — root hierarchies correlate when their levels' paths form a prefix chain"
+---
+
+# Correlated Hierarchical Facets Over Root Fields
+
+## Problem
+
+A shape-level `idx:facetHierarchy` builds its facet paths by taking the **cartesian
+product** of each level's values. When every level is single-valued that is correct. When
+two levels are multi-valued and their values are *pairwise* related, it invents paths that
+are not in the data, and the drill-down counts are wrong.
+
+There is a correlated implementation — `idx:facetHierarchy` inside an `idx:nested` block —
+but it is only reachable when the correlating node has each level hanging off it as a
+sub-property. It cannot express a hierarchy where one of the levels **is** the child node
+itself. That is the case below, so neither construct currently fits.
+
+## Use case
+
+GSWA search facets on the datatype of a document (`dataType`), and wants to add a broader
+grouping above it (`dataTypeGrouping`) so users can select several datatypes at once. The
+UI should show:
+
+```text
+Holes (1,234)
+  downhole-assays (812)
+  borehole (422)
+```
+
+The data:
+
+```turtle
+# instance data — an entity may reference several display tables
+<borehole/123>  gswa:hasDisplayTable  <display/borehole> , <display/downhole-assays> .
+
+# vocabulary — each display table belongs to one or more groupings
+<display/borehole>          gswa:hasGrouping  <datatype/Holes> .
+<display/downhole-assays>   gswa:hasGrouping  <datatype/Holes> .
+<display/geochem-results>   gswa:hasGrouping  <datatype/Geochemistry> .
+```
+
+The current shape indexes the display table IRI itself as `dataType`:
+
+```turtle
+sh:property [ idx:field field:dataType          ; sh:path gswa:hasDisplayTable ] ;
+sh:property [ idx:field field:dataTypeGrouping  ; sh:path ( gswa:hasDisplayTable gswa:hasGrouping ) ] ;
+```
+
+Both fields are `idx:multiValued true`.
+
+## Why the root hierarchy is wrong here
+
+`addDirectHierarchyFacetFields`
+(`jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java:1040`)
+reads each level's values independently from the entity root:
+
+```java
+for (ShaclIndexMapping.FieldDef levelField : hierarchy.getLevels()) {
+    levelValues.add(asHierarchyFacetValues(entity.get(levelField.getFieldName()), ...));
+}
+addFacetPaths(doc, hierarchy.getDimensionName(), levelValues, 0, new ArrayList<>());
+```
+
+and `addFacetPaths` (`:1117`) recurses over every value at every level, emitting one
+`FacetField` per combination.
+
+So for an entity carrying two display tables in two different groupings:
+
+```text
+dataType          = [ display/borehole, display/geochem-results ]
+dataTypeGrouping  = [ datatype/Holes,   datatype/Geochemistry   ]
+```
+
+it emits four paths, two of them fabricated:
+
+```text
+Holes / borehole                  ✓ in the data
+Holes / geochem-results           ✗ invented
+Geochemistry / borehole           ✗ invented
+Geochemistry / geochem-results    ✓ in the data
+```
+
+Drilling into `Holes` then offers `geochem-results` as a child, and the child counts sum to
+more than the parent count. This is the "no repeated intermediate node" limitation recorded
+in [`2026-04-07_nested_hierarchical_faceting_design.md`](2026-04-07_nested_hierarchical_faceting_design.md);
+the note assumed such cases would move to `idx:nested`, which is where this one gets stuck.
+
+## Why the nested block does not reach it
+
+The natural correlating node is the display table, so the block would be:
+
+```turtle
+idx:nested [
+    idx:joinPath gswa:hasDisplayTable ;
+    idx:property [ idx:field field:dataType         ; sh:path ??? ] ;
+    idx:property [ idx:field field:dataTypeGrouping ; sh:path gswa:hasGrouping ] ;
+    idx:facetHierarchy ( field:dataTypeGrouping field:dataType ) ;
+] ;
+```
+
+`addNestedHierarchyFacetFields` (`:1050`) would then do the right thing — it builds paths
+per child record, so no cartesian product across children.
+
+The blocker is the `???`. `dataType`'s value **is** the child node, `<display/borehole>`.
+Every `idx:property` inside a nested block is evaluated as a path *from* the child, and
+there is no way to express "the child node itself" — no `idx:self`, no empty path, no
+`sh:this`. The existing nested patterns never needed one: `schema:identifier` and
+`prov:qualifiedAttribution` children are blank-node bundles where every indexed value is
+reached by stepping off the child.
+
+## What is actually needed
+
+A way to declare a hierarchy whose levels stay pairwise correlated, where one level is the
+correlating node itself. Some directions, none evaluated:
+
+1. **Identity path.** Let an `idx:property` inside a nested block bind the child node
+   itself — `idx:self true` on the occurrence, or an empty `sh:path` list. Smallest change;
+   makes the existing correlated code path reachable. Worth checking what else an identity
+   path would enable, and whether it is coherent for a non-facet field.
+2. **Correlated root hierarchy.** Teach `addDirectHierarchyFacetFields` to walk the paths
+   rather than the flattened field values, so a hierarchy over `( A B )` where B's path
+   extends A's stays correlated without a nested block. Larger change, and it needs a rule
+   for when two root occurrences count as correlated.
+3. **Nothing** — declare this out of scope and require callers to materialise a correlated
+   child structure in the data. Cheapest for us, but pushes a denormalisation onto every
+   dataset that has a taxonomy attached to a term rather than to the entity.
+
+## Notes for whoever picks this up
+
+- Both a flat facet on the field and the hierarchy dimension are addressable separately and
+  neither shadows the other (`docs/03-configuration.md:472`), so a fix must not change how
+  `dataType` behaves as a flat facet today.
+- The failure is silent. Nothing warns at index time that a hierarchy's levels are
+  multi-valued and uncorrelated; the counts are simply wrong. A config-time warning may be
+  worth having regardless of which direction is chosen.
+- Hierarchical facet ordinals live in the taxonomy directory. If it is left unset the
+  counts vanish entirely when indexing and querying are separate processes
+  (`docs/03-configuration.md:64`) — worth confirming in any test that exercises this.
+- This shape recurs: commodity groupings, report-type hierarchies and sample-of chains are
+  all taxonomies attached to a term rather than to the entity, and all are flat facets
+  today.
+
+## Resolution (2026-08-03) — option 2, correlated root hierarchy
+
+Direction 2 was taken, in the form of a **prefix chain**: when each hierarchy level's
+occurrence path strictly extends the path of the level below it, the levels are correlated
+by walking those paths through the graph instead of cross-producting the flattened field
+values. The config in the use case above is already such a chain, so it needs **no new
+vocabulary and no config change** beyond declaring the hierarchy:
+
+```turtle
+sh:property [ idx:field field:dataType         ; sh:path gswa:hasDisplayTable ] ;
+sh:property [ idx:field field:dataTypeGrouping ; sh:path ( gswa:hasDisplayTable gswa:hasGrouping ) ] ;
+idx:facetHierarchy ( field:dataTypeGrouping field:dataType ) ;
+```
+
+### Why not the identity path (option 1)
+
+`idx:self` was the first recommendation and was dropped once the flat-facet constraint was
+tested rather than assumed. It fails on its own terms:
+
+- Making it reachable requires the hierarchy leaf to live in the `idx:nested` block, and
+  "one field IRI belongs to one scope" then forces `field:dataType` to be either a root
+  field or the nested leaf — not both. Keeping the working flat facet therefore needs a
+  **twin field** carrying identical values in the child scope.
+- Moving `dataType` wholly into the nested block instead does not relocate the flat facet,
+  it removes it. Facet collection filters to parent docs (`filterToParents`), and nested
+  values live only on child docs, so the flat `dataType` facet would return nothing under
+  an active query — precisely the case a search UI is always in. Open (no-query) requests
+  count child docs instead. The client's `dataType` facet is in daily use, so this is not
+  a viable break.
+- It also materialises one child document per display table purely to carry a facet.
+
+The prefix chain has none of these costs: both fields stay root-scoped, both flat facets
+are untouched, no child documents are created, and there is no twin.
+
+### What was built
+
+| Piece | Change |
+|---|---|
+| `ShaclIndexMapping.CorrelatedHierarchy` | Derives the plan: one root occurrence per level, single path variant, each level's steps strictly extending the next's. Holds the innermost path and the per-level ascent paths |
+| `ShaclIndexMapping.IndexProfile` | Derives plans once at config time; warns when a hierarchy stays cartesian **and** has more than one multi-valued level |
+| `ShaclEntityBuilder` | Walks the chain from the innermost level outwards, emitting one facet path per real edge chain |
+| `Entity` | Carries the walked paths — the correlation is a property of the graph and cannot be recovered from the flattened values |
+| `ShaclTextIndexLucene.addDirectHierarchyFacetFields` | Emits the walked paths for a correlated dimension; unchanged cartesian behaviour otherwise |
+
+Notes on the semantics chosen:
+
+- **No partial paths.** A display table with no grouping contributes nothing to the
+  dimension, rather than a one-component path, since an entity must not be counted under a
+  parent it does not have. It remains a value of the flat `dataType` facet.
+- **Branching is genuine.** A display table in two groupings yields two paths — those are
+  real edges, unlike the cartesian combinations.
+- **Change tracking needed nothing.** Correlation is derived from occurrences that are
+  already declared, so their predicates are already registered; a vocabulary edit reverse-
+  evaluates to the affected entities as before. Pinned by a test.
+- **Fan-in stays cartesian.** A level fed by two occurrences has no single meeting node,
+  so no plan is derived. Same for alternative paths.
+
+### Tests
+
+`TestCorrelatedRootHierarchy` (integration, 7 tests) — the exact GSWA shape with both
+fields multi-valued: top-level counts, drill-down that does not invent paths, children not
+out-counting the parent, flat facets unaffected, vocabulary-edit reindex, a display table
+with no grouping, and a three-level chain. `TestCorrelatedHierarchyDerivation` (assembler,
+6 tests) — which configurations produce a plan: prefix-chained, independent, reversed,
+fan-in, inverse ascent step, three levels. Both registered in `TS_Text`.
+
+The first two assertions were written red first and failed on the invented
+`Holes / geochem-results` path before the fix (commit "Add failing test for correlated
+hierarchy over prefix-chained root fields").
+
+### Still open
+
+- **Value-anchored sugar** (`idx:leaf` / `idx:ancestorPath`) remains unbuilt and is now
+  much less pressing: the prefix chain already expresses the taxonomy-attached-to-a-term
+  case with the config authors were writing anyway. It would only add value for a
+  taxonomy walked transitively (`skos:broader+`), where the number of levels is not known
+  in advance.
+- **Deep chains are walked per entity at index time.** Each ascent step is a `PathEval`
+  from the node reached. For the two- and three-step vocabularies here that is
+  negligible, but a long chain over a large vocabulary would be worth measuring.
+

--- a/jena-text/src/main/java/org/apache/jena/query/text/Entity.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/Entity.java
@@ -39,6 +39,7 @@ public class Entity
     private final RDFDatatype datatype ;
     private final Map<String, Object> map = new HashMap<>() ;
     private final Map<String, List<NestedRecord>> nestedRecords = new LinkedHashMap<>() ;
+    private final Map<String, List<List<String>>> hierarchyPaths = new LinkedHashMap<>() ;
 
     public static class NestedRecord {
         private final Map<String, Object> values = new LinkedHashMap<>() ;
@@ -108,6 +109,19 @@ public class Entity
 
     public Map<String, List<NestedRecord>> getNestedRecords() {
         return nestedRecords;
+    }
+
+    /**
+     * Record one facet path for a correlated hierarchy dimension. Such paths are walked
+     * out of the graph while the entity is built, because the correlation between levels
+     * is a property of the graph and cannot be recovered from the flattened field values.
+     */
+    public void addHierarchyPath(String dimensionName, List<String> path) {
+        hierarchyPaths.computeIfAbsent(dimensionName, k -> new ArrayList<>()).add(path);
+    }
+
+    public List<List<String>> getHierarchyPaths(String dimensionName) {
+        return hierarchyPaths.getOrDefault(dimensionName, Collections.emptyList());
     }
 
     @SuppressWarnings("unchecked")

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
@@ -25,6 +25,7 @@ import java.util.*;
 
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
+import org.apache.jena.query.text.ShaclIndexMapping.CorrelatedHierarchy;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
 import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
@@ -96,7 +97,68 @@ final class ShaclEntityBuilder {
             }
         }
 
+        for (CorrelatedHierarchy hierarchy : profile.getCorrelatedHierarchies()) {
+            addCorrelatedHierarchyPaths(graph, subject, entity, hierarchy);
+        }
+
         return entity;
+    }
+
+    /**
+     * Walk the graph to build the facet paths of a correlated hierarchy.
+     * <p>
+     * Starts at the innermost (deepest, shortest-path) level and ascends one level at a
+     * time, so each emitted path is a chain of edges that exists in the data. An entity
+     * with two display tables in different groupings yields exactly its two real paths,
+     * where cross-producting the two levels' values would yield four.
+     */
+    private static void addCorrelatedHierarchyPaths(Graph graph, Node subject, Entity entity,
+            CorrelatedHierarchy hierarchy) {
+        int innermost = hierarchy.getDepth() - 1;
+        Iterator<Node> iter = PathEval.eval(graph, subject, hierarchy.getInnermostPath(), indexingContext());
+        while (iter.hasNext()) {
+            Node node = iter.next();
+            ascendHierarchy(graph, entity, hierarchy, innermost, node, new ArrayDeque<>());
+        }
+    }
+
+    /**
+     * Prepend the value of {@code node} at {@code level} and recurse to the level above,
+     * emitting a facet path once level 0 is reached. A level that contributes no usable
+     * value, or whose ancestor step finds nothing, contributes no path at all — a
+     * partial path would count the entity under a parent it does not have.
+     */
+    private static void ascendHierarchy(Graph graph, Entity entity, CorrelatedHierarchy hierarchy,
+            int level, Node node, Deque<String> pathSoFar) {
+        FieldOccurrence occurrence = hierarchy.getLevelOccurrence(level);
+        if (!satisfiesConstraints(graph, node, occurrence)) {
+            return;
+        }
+        Object value = nodeToValue(node, occurrence.getField().getFieldType(),
+            occurrence.getField().preservesLiteralMetadata());
+        if (value == null) {
+            return;
+        }
+        String component = value.toString();
+        if (component.isBlank()) {
+            return;
+        }
+
+        pathSoFar.addFirst(component);
+        if (level == 0) {
+            entity.addHierarchyPath(hierarchy.getDimensionName(), new ArrayList<>(pathSoFar));
+        } else {
+            Iterator<Node> iter = PathEval.eval(graph, node, hierarchy.getAscentPath(level - 1),
+                indexingContext());
+            Set<Node> seen = new LinkedHashSet<>();
+            while (iter.hasNext()) {
+                Node ancestor = iter.next();
+                if (seen.add(ancestor)) {
+                    ascendHierarchy(graph, entity, hierarchy, level - 1, ancestor, pathSoFar);
+                }
+            }
+        }
+        pathSoFar.removeFirst();
     }
 
     private static Entity.NestedRecord toNestedRecord(Map<String, LinkedHashSet<Object>> recordValues) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -28,8 +28,11 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.text.analyzer.EdgeNGramAnalyzer;
 import org.apache.jena.query.text.analyzer.LowerCaseKeywordAnalyzer;
 import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Parsed representation of SHACL-driven index shapes.
@@ -38,6 +41,8 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
  * separately as root or nested field occurrences.
  */
 public class ShaclIndexMapping {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ShaclIndexMapping.class);
 
     public enum FieldType {
         TEXT, KEYWORD, INT, LONG, DOUBLE, TEMPORAL, LATLON
@@ -245,6 +250,124 @@ public class ShaclIndexMapping {
         @Override
         public String toString() {
             return "HierarchyDef(" + dimensionName + ", levels=" + levels + ")";
+        }
+    }
+
+    /**
+     * A {@link HierarchyDef} whose levels can be built by walking the graph instead of
+     * by taking the cartesian product of independently-read field values.
+     * <p>
+     * This applies when the level occurrences form a <em>prefix chain</em>: each level's
+     * SHACL path extends the path of the level below it. In
+     * <pre>
+     * sh:property [ idx:field field:dataType         ; sh:path gswa:hasDisplayTable ] ;
+     * sh:property [ idx:field field:dataTypeGrouping ; sh:path ( gswa:hasDisplayTable gswa:hasGrouping ) ] ;
+     * idx:facetHierarchy ( field:dataTypeGrouping field:dataType ) ;
+     * </pre>
+     * the display-table node is where the two levels meet: {@code dataType} <em>is</em>
+     * that node and {@code dataTypeGrouping} is one step beyond it. Reading the two
+     * fields independently loses that pairing, so an entity with display tables in two
+     * different groupings yields four paths, two of which are not in the data.
+     * <p>
+     * The walk instead starts at the innermost (last, shortest-path) level and ascends
+     * one level at a time, so every emitted path corresponds to a chain of real edges.
+     * Levels that are not prefix-chained keep the cartesian behaviour.
+     */
+    public static class CorrelatedHierarchy {
+        private final HierarchyDef hierarchy;
+        private final List<FieldOccurrence> levelOccurrences;
+        private final List<Path> ascentPaths;
+
+        private CorrelatedHierarchy(HierarchyDef hierarchy, List<FieldOccurrence> levelOccurrences,
+                                    List<Path> ascentPaths) {
+            this.hierarchy = hierarchy;
+            this.levelOccurrences = Collections.unmodifiableList(new ArrayList<>(levelOccurrences));
+            this.ascentPaths = Collections.unmodifiableList(new ArrayList<>(ascentPaths));
+        }
+
+        public HierarchyDef getHierarchy()      { return hierarchy; }
+        public String getDimensionName()        { return hierarchy.getDimensionName(); }
+        public int getDepth()                   { return hierarchy.getDepth(); }
+        public FieldDef getLevel(int index)     { return hierarchy.getLevel(index); }
+        public FieldOccurrence getLevelOccurrence(int index) { return levelOccurrences.get(index); }
+
+        /** Path from the entity root to the innermost level's node. */
+        public Path getInnermostPath() {
+            return levelOccurrences.get(levelOccurrences.size() - 1).getPath();
+        }
+
+        /** Path from the node at {@code level + 1} to the node at {@code level}. */
+        public Path getAscentPath(int level) {
+            return ascentPaths.get(level);
+        }
+
+        /**
+         * Derive a correlated plan for {@code hierarchy}, or return {@code null} when its
+         * levels are not prefix-chained and the cartesian product must be kept.
+         * <p>
+         * Requires exactly one root occurrence per level with a single path variant:
+         * a field reached by two different paths (fan-in) or by an alternative path has
+         * no single node at which the levels meet.
+         */
+        static CorrelatedHierarchy derive(HierarchyDef hierarchy, List<FieldOccurrence> rootOccurrences) {
+            List<FieldOccurrence> levelOccurrences = new ArrayList<>(hierarchy.getDepth());
+            for (FieldDef level : hierarchy.getLevels()) {
+                FieldOccurrence match = null;
+                for (FieldOccurrence occurrence : rootOccurrences) {
+                    if (!occurrence.isRootScoped()
+                            || !occurrence.getField().getFieldName().equals(level.getFieldName())) {
+                        continue;
+                    }
+                    if (match != null) {
+                        return null;
+                    }
+                    match = occurrence;
+                }
+                if (match == null || match.getPathVariants().size() != 1) {
+                    return null;
+                }
+                levelOccurrences.add(match);
+            }
+
+            List<Path> ascentPaths = new ArrayList<>(hierarchy.getDepth() - 1);
+            for (int level = 0; level < hierarchy.getDepth() - 1; level++) {
+                List<JoinStep> outer = levelOccurrences.get(level).getPathVariants().get(0);
+                List<JoinStep> inner = levelOccurrences.get(level + 1).getPathVariants().get(0);
+                if (inner.size() >= outer.size() || !isPrefix(inner, outer)) {
+                    return null;
+                }
+                ascentPaths.add(toPath(outer.subList(inner.size(), outer.size())));
+            }
+
+            return new CorrelatedHierarchy(hierarchy, levelOccurrences, ascentPaths);
+        }
+
+        private static boolean isPrefix(List<JoinStep> prefix, List<JoinStep> steps) {
+            for (int i = 0; i < prefix.size(); i++) {
+                JoinStep a = prefix.get(i);
+                JoinStep b = steps.get(i);
+                if (a.isInverse() != b.isInverse() || !a.getPredicate().equals(b.getPredicate())) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static Path toPath(List<JoinStep> steps) {
+            Path path = null;
+            for (JoinStep step : steps) {
+                Path link = PathFactory.pathLink(step.getPredicate());
+                if (step.isInverse()) {
+                    link = PathFactory.pathInverse(link);
+                }
+                path = (path == null) ? link : PathFactory.pathSeq(path, link);
+            }
+            return path;
+        }
+
+        @Override
+        public String toString() {
+            return "CorrelatedHierarchy(" + getDimensionName() + ", ascent=" + ascentPaths + ")";
         }
     }
 
@@ -619,6 +742,7 @@ public class ShaclIndexMapping {
         private final List<FieldOccurrence> rootOccurrences;
         private final List<HierarchyDef> hierarchies;
         private final List<NestedDef> nestedDefs;
+        private final Map<String, CorrelatedHierarchy> correlatedHierarchies;
 
         public IndexProfile(Node shapeNode, Set<Node> targetClasses,
                             String docIdField, String discriminatorField,
@@ -657,6 +781,46 @@ public class ShaclIndexMapping {
             this.nestedDefs = nestedDefs != null
                 ? Collections.unmodifiableList(new ArrayList<>(nestedDefs))
                 : Collections.emptyList();
+            this.correlatedHierarchies = deriveCorrelatedHierarchies(
+                this.shapeNode, this.hierarchies, this.rootOccurrences);
+        }
+
+        /**
+         * Work out, once at config time, which root hierarchies can be built by walking
+         * the graph rather than by cross-producting their levels.
+         * <p>
+         * A hierarchy that stays cartesian and has more than one multi-valued level is
+         * the shape that silently produces wrong counts, so it is warned about here —
+         * the alternative is a config that looks fine and quietly invents facet paths.
+         */
+        private static Map<String, CorrelatedHierarchy> deriveCorrelatedHierarchies(
+                Node shapeNode, List<HierarchyDef> hierarchies, List<FieldOccurrence> rootOccurrences) {
+            if (hierarchies.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            Map<String, CorrelatedHierarchy> correlated = new LinkedHashMap<>();
+            for (HierarchyDef hierarchy : hierarchies) {
+                CorrelatedHierarchy plan = CorrelatedHierarchy.derive(hierarchy, rootOccurrences);
+                if (plan != null) {
+                    correlated.put(hierarchy.getDimensionName(), plan);
+                    continue;
+                }
+                List<String> multiValued = new ArrayList<>();
+                for (FieldDef level : hierarchy.getLevels()) {
+                    if (level.isMultiValued()) {
+                        multiValued.add(level.getFieldName());
+                    }
+                }
+                if (multiValued.size() > 1) {
+                    LOG.warn("Hierarchy '{}' on shape {} has multi-valued levels {} that are not "
+                        + "prefix-chained, so its facet paths are the cartesian product of those "
+                        + "levels. Where the values are pairwise related, drill-down will show "
+                        + "combinations that are not in the data. Give the levels SHACL paths where "
+                        + "each extends the one below it, or move them into an idx:nested block.",
+                        hierarchy.getDimensionName(), shapeNode, multiValued);
+                }
+            }
+            return Collections.unmodifiableMap(correlated);
         }
 
         public Node getShapeNode()               { return shapeNode; }
@@ -667,6 +831,16 @@ public class ShaclIndexMapping {
         public List<FieldOccurrence> getRootOccurrences() { return rootOccurrences; }
         public List<HierarchyDef> getHierarchies() { return hierarchies; }
         public List<NestedDef> getNestedDefs()   { return nestedDefs; }
+
+        /** Correlated build plans for root hierarchies, keyed by dimension name. */
+        public Collection<CorrelatedHierarchy> getCorrelatedHierarchies() {
+            return correlatedHierarchies.values();
+        }
+
+        /** The correlated plan for {@code dimensionName}, or null if it stays cartesian. */
+        public CorrelatedHierarchy getCorrelatedHierarchy(String dimensionName) {
+            return correlatedHierarchies.get(dimensionName);
+        }
 
         /** True when any nested block of this profile draws its children from an
          *  external source. Such a profile can only be built by {@link ShaclBulkIndexer};

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java
@@ -1039,6 +1039,17 @@ public class ShaclTextIndexLucene extends TextIndexLucene {
 
     private void addDirectHierarchyFacetFields(Document doc, Entity entity,
             ShaclIndexMapping.IndexProfile profile, ShaclIndexMapping.HierarchyDef hierarchy) {
+        // Prefix-chained levels were correlated against the graph while the entity was
+        // built; their paths are already exact, so no cartesian product is taken here.
+        if (profile.getCorrelatedHierarchy(hierarchy.getDimensionName()) != null) {
+            for (List<String> path : entity.getHierarchyPaths(hierarchy.getDimensionName())) {
+                if (!path.isEmpty()) {
+                    doc.add(new FacetField(hierarchy.getDimensionName(), path.toArray(new String[0])));
+                }
+            }
+            return;
+        }
+
         List<List<String>> levelValues = new ArrayList<>();
         for (ShaclIndexMapping.FieldDef levelField : hierarchy.getLevels()) {
             levelValues.add(asHierarchyFacetValues(entity.get(levelField.getFieldName()),

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -138,6 +138,7 @@ import org.apache.jena.query.text.changes.TestDatasetMonitor;
     , TestHierarchicalFacets.class
     , TestHierarchicalFacetsSparql.class
     , TestNestedHierarchicalFacets.class
+    , TestCorrelatedRootHierarchy.class
     , TestCorrelatedNestedAttribution.class
     , TestTypeaheadFieldConfigurations.class
     , TestNestedJoinPathSupport.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -139,6 +139,7 @@ import org.apache.jena.query.text.changes.TestDatasetMonitor;
     , TestHierarchicalFacetsSparql.class
     , TestNestedHierarchicalFacets.class
     , TestCorrelatedRootHierarchy.class
+    , org.apache.jena.query.text.assembler.TestCorrelatedHierarchyDerivation.class
     , TestCorrelatedNestedAttribution.class
     , TestTypeaheadFieldConfigurations.class
     , TestNestedJoinPathSupport.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestCorrelatedRootHierarchy.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestCorrelatedRootHierarchy.java
@@ -303,6 +303,91 @@ public class TestCorrelatedRootHierarchy {
             Long.valueOf(2), geochemistry.get(GEOCHEM_RESULTS));
     }
 
+    /**
+     * Three prefix-chained levels: theme above grouping above datatype. A document
+     * straddling two branches of the taxonomy must produce one path per branch, not the
+     * eight combinations a cartesian product over three multi-valued levels would give.
+     */
+    @Test
+    public void testThreeLevelChainStaysCorrelated() {
+        Node hasTheme = NodeFactory.createURI(NS + "hasTheme");
+        String geology = NS + "theme/Geology";
+        String chemistry = NS + "theme/Chemistry";
+        String dim = "dataTypeTheme_dataTypeGrouping_dataType";
+
+        Node dataTypeIRI = NodeFactory.createURI(FIELD_NS + "dataType");
+        Node groupingIRI = NodeFactory.createURI(FIELD_NS + "dataTypeGrouping");
+        Node themeIRI = NodeFactory.createURI(FIELD_NS + "dataTypeTheme");
+
+        FieldDef dataType = new FieldDef("dataType", FieldType.KEYWORD, null, null,
+            true, true, true, false, true, false, false, dataTypeIRI);
+        FieldDef grouping = new FieldDef("dataTypeGrouping", FieldType.KEYWORD, null, null,
+            true, true, true, false, true, false, false, groupingIRI);
+        FieldDef theme = new FieldDef("dataTypeTheme", FieldType.KEYWORD, null, null,
+            true, true, true, false, true, false, false, themeIRI);
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + "DocumentShape"),
+            Collections.singleton(DOCUMENT_CLASS),
+            "uri", "docType",
+            Arrays.asList(dataType, grouping, theme),
+            Arrays.asList(
+                occurrence(dataType, HAS_DISPLAY_TABLE),
+                occurrence(grouping, HAS_DISPLAY_TABLE, HAS_GROUPING),
+                occurrence(theme, HAS_DISPLAY_TABLE, HAS_GROUPING, hasTheme)),
+            Collections.singletonList(
+                new HierarchyDef(dim, Arrays.asList(theme, grouping, dataType))),
+            Collections.emptyList());
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        TextIndexConfig config = new TextIndexConfig(ShaclIndexAssembler.deriveEntityDefinition(mapping));
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+
+        ShaclTextIndexLucene index = new ShaclTextIndexLucene(
+            new ByteBuffersDirectory(), new ByteBuffersDirectory(), config);
+        Dataset baseDs = DatasetFactory.create();
+        Dataset ds = TextDatasetFactory.create(baseDs, index, true,
+            new ShaclTextDocProducer(baseDs.asDatasetGraph(), index, mapping));
+        try {
+            ds.begin(ReadWrite.WRITE);
+            try {
+                Model model = ds.getDefaultModel();
+                addGrouping(model, BOREHOLE, HOLES);
+                addGrouping(model, GEOCHEM_RESULTS, GEOCHEMISTRY);
+                model.add(ResourceFactory.createResource(HOLES),
+                    ResourceFactory.createProperty(hasTheme.getURI()),
+                    ResourceFactory.createResource(geology));
+                model.add(ResourceFactory.createResource(GEOCHEMISTRY),
+                    ResourceFactory.createProperty(hasTheme.getURI()),
+                    ResourceFactory.createResource(chemistry));
+                addDocument(model, "doc1", BOREHOLE, GEOCHEM_RESULTS);
+                ds.commit();
+            } finally {
+                ds.end();
+            }
+
+            Map<String, String[]> geologyGrouping = new HashMap<>();
+            geologyGrouping.put(dim, new String[] {geology});
+            Map<String, Long> underGeology = toFacetMap(index.getFacetCounts(
+                null, null, Collections.singletonList(dim), 20, 0, geologyGrouping).get(dim));
+            assertEquals(Long.valueOf(1), underGeology.get(HOLES));
+            assertFalse("Geochemistry does not sit under the Geology theme",
+                underGeology.containsKey(GEOCHEMISTRY));
+
+            Map<String, String[]> geologyHoles = new HashMap<>();
+            geologyHoles.put(dim, new String[] {geology, HOLES});
+            Map<String, Long> underHoles = toFacetMap(index.getFacetCounts(
+                null, null, Collections.singletonList(dim), 20, 0, geologyHoles).get(dim));
+            assertEquals(Long.valueOf(1), underHoles.get(BOREHOLE));
+            assertFalse("geochem-results is not reachable through Geology / Holes",
+                underHoles.containsKey(GEOCHEM_RESULTS));
+        } finally {
+            ds.close();
+        }
+    }
+
     /** A display table with no grouping contributes nothing to the hierarchy dimension. */
     @Test
     public void testDisplayTableWithoutGroupingIsAbsentFromHierarchy() {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestCorrelatedRootHierarchy.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestCorrelatedRootHierarchy.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.HierarchyDef;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * A hierarchy over two <em>root</em> fields whose SHACL paths are prefix-chained —
+ * {@code dataType} at {@code gswa:hasDisplayTable} and {@code dataTypeGrouping} at
+ * {@code (gswa:hasDisplayTable gswa:hasGrouping)}.
+ * <p>
+ * Both fields are multi-valued, and their values are pairwise related through the
+ * display-table node. Taking the cartesian product of the two levels invents paths that
+ * are not in the data; the hierarchy must stay correlated per display table.
+ * <p>
+ * Design note: {@code docs/2026-08-03_correlated_hierarchy_over_root_fields.md}.
+ */
+public class TestCorrelatedRootHierarchy {
+
+    private static final String NS = "http://example.org/";
+    private static final String FIELD_NS = "urn:jena:lucene:field#";
+    private static final String DIM = "dataTypeGrouping_dataType";
+
+    private static final Node DOCUMENT_CLASS = NodeFactory.createURI(NS + "Document");
+    private static final Node HAS_DISPLAY_TABLE = NodeFactory.createURI(NS + "hasDisplayTable");
+    private static final Node HAS_GROUPING = NodeFactory.createURI(NS + "hasGrouping");
+
+    private static final String BOREHOLE = NS + "display/borehole";
+    private static final String DOWNHOLE_ASSAYS = NS + "display/downhole-assays";
+    private static final String GEOCHEM_RESULTS = NS + "display/geochem-results";
+    private static final String HOLES = NS + "datatype/Holes";
+    private static final String GEOCHEMISTRY = NS + "datatype/Geochemistry";
+
+    private Dataset dataset;
+    private ShaclTextIndexLucene textIndex;
+
+    @Before
+    public void setUp() {
+        TextQuery.init();
+
+        Node dataTypeIRI = NodeFactory.createURI(FIELD_NS + "dataType");
+        Node groupingIRI = NodeFactory.createURI(FIELD_NS + "dataTypeGrouping");
+
+        FieldDef dataType = new FieldDef("dataType", FieldType.KEYWORD, null, null,
+            true, true, true, false, true, false, false, dataTypeIRI);
+        FieldDef dataTypeGrouping = new FieldDef("dataTypeGrouping", FieldType.KEYWORD, null, null,
+            true, true, true, false, true, false, false, groupingIRI);
+
+        FieldOccurrence dataTypeOccurrence = occurrence(dataType, HAS_DISPLAY_TABLE);
+        FieldOccurrence groupingOccurrence = occurrence(dataTypeGrouping, HAS_DISPLAY_TABLE, HAS_GROUPING);
+
+        HierarchyDef hierarchy = new HierarchyDef(DIM, Arrays.asList(dataTypeGrouping, dataType));
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + "DocumentShape"),
+            Collections.singleton(DOCUMENT_CLASS),
+            "uri", "docType",
+            Arrays.asList(dataType, dataTypeGrouping),
+            Arrays.asList(dataTypeOccurrence, groupingOccurrence),
+            Collections.singletonList(hierarchy),
+            Collections.emptyList());
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        EntityDefinition defn = ShaclIndexAssembler.deriveEntityDefinition(mapping);
+
+        TextIndexConfig config = new TextIndexConfig(defn);
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+
+        // Hierarchy ordinals live in the taxonomy directory — without it the
+        // hierarchical counts vanish entirely (docs/03-configuration.md:64).
+        textIndex = new ShaclTextIndexLucene(
+            new ByteBuffersDirectory(), new ByteBuffersDirectory(), config);
+
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), textIndex, mapping);
+
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true, producer);
+        loadData();
+    }
+
+    /**
+     * doc1 sits wholly inside Holes; doc2 straddles both groupings (the case the
+     * cartesian product gets wrong); doc3 sits wholly inside Geochemistry.
+     */
+    private void loadData() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+
+            addGrouping(model, BOREHOLE, HOLES);
+            addGrouping(model, DOWNHOLE_ASSAYS, HOLES);
+            addGrouping(model, GEOCHEM_RESULTS, GEOCHEMISTRY);
+
+            addDocument(model, "doc1", BOREHOLE, DOWNHOLE_ASSAYS);
+            addDocument(model, "doc2", BOREHOLE, GEOCHEM_RESULTS);
+            addDocument(model, "doc3", GEOCHEM_RESULTS);
+
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private void addGrouping(Model model, String displayTable, String grouping) {
+        model.add(ResourceFactory.createResource(displayTable),
+            ResourceFactory.createProperty(HAS_GROUPING.getURI()),
+            ResourceFactory.createResource(grouping));
+    }
+
+    private void addDocument(Model model, String id, String... displayTables) {
+        Resource doc = ResourceFactory.createResource(NS + id);
+        model.add(doc, RDF.type, ResourceFactory.createResource(DOCUMENT_CLASS.getURI()));
+        for (String displayTable : displayTables) {
+            model.add(doc, ResourceFactory.createProperty(HAS_DISPLAY_TABLE.getURI()),
+                ResourceFactory.createResource(displayTable));
+        }
+    }
+
+    private static FieldOccurrence occurrence(FieldDef field, Node... predicates) {
+        List<JoinStep> steps = new ArrayList<>();
+        Set<Node> predicateSet = new LinkedHashSet<>();
+        Path path = null;
+        for (Node predicate : predicates) {
+            steps.add(new JoinStep(predicate, false));
+            predicateSet.add(predicate);
+            Path link = PathFactory.pathLink(predicate);
+            path = (path == null) ? link : PathFactory.pathSeq(path, link);
+        }
+        return new FieldOccurrence(field, path, List.of(List.copyOf(steps)),
+            predicateSet, null, null, null, null);
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    private Map<String, Long> topLevel() {
+        return facets(null);
+    }
+
+    private Map<String, Long> drillInto(String grouping) {
+        return facets(new String[] {grouping});
+    }
+
+    private Map<String, Long> facets(String[] drillPath) {
+        Map<String, String[]> drillDown = null;
+        if (drillPath != null) {
+            drillDown = new HashMap<>();
+            drillDown.put(DIM, drillPath);
+        }
+        Map<String, List<FacetValue>> counts = textIndex.getFacetCounts(
+            null, null, Collections.singletonList(DIM), 20, 0, drillDown);
+        return toFacetMap(counts.get(DIM));
+    }
+
+    private Map<String, Long> flatFacet(String field) {
+        Map<String, List<FacetValue>> counts = textIndex.getFacetCounts(
+            null, null, Collections.singletonList(field), 20, 0);
+        return toFacetMap(counts.get(field));
+    }
+
+    private static Map<String, Long> toFacetMap(List<FacetValue> values) {
+        Map<String, Long> map = new HashMap<>();
+        if (values != null) {
+            for (FacetValue value : values) {
+                map.put(value.getValue(), value.getCount());
+            }
+        }
+        return map;
+    }
+
+    @Test
+    public void testTopLevelGroupingCounts() {
+        Map<String, Long> values = topLevel();
+        assertEquals(Long.valueOf(2), values.get(HOLES));            // doc1, doc2
+        assertEquals(Long.valueOf(2), values.get(GEOCHEMISTRY));     // doc2, doc3
+    }
+
+    /**
+     * The defect: doc2 carries borehole (Holes) and geochem-results (Geochemistry).
+     * A cartesian product over the two multi-valued levels invents
+     * {@code Holes / geochem-results} and {@code Geochemistry / borehole}.
+     */
+    @Test
+    public void testDrillDownDoesNotInventPaths() {
+        Map<String, Long> holes = drillInto(HOLES);
+        assertEquals(Long.valueOf(2), holes.get(BOREHOLE));           // doc1, doc2
+        assertEquals(Long.valueOf(1), holes.get(DOWNHOLE_ASSAYS));    // doc1
+        assertFalse("geochem-results is not in the Holes grouping",
+            holes.containsKey(GEOCHEM_RESULTS));
+
+        Map<String, Long> geochemistry = drillInto(GEOCHEMISTRY);
+        assertEquals(Long.valueOf(2), geochemistry.get(GEOCHEM_RESULTS)); // doc2, doc3
+        assertFalse("borehole is not in the Geochemistry grouping",
+            geochemistry.containsKey(BOREHOLE));
+    }
+
+    /**
+     * Children of a grouping must not sum to more than the parent count unless
+     * documents genuinely carry several datatypes within that grouping. Holes has
+     * doc1 (two datatypes) and doc2 (one), so 2 + 1 over a parent count of 2 is
+     * correct; the invented-path failure shows up as Geochemistry's children
+     * exceeding its own count.
+     */
+    @Test
+    public void testGeochemistryChildrenDoNotExceedParent() {
+        long parent = topLevel().get(GEOCHEMISTRY);
+        long children = drillInto(GEOCHEMISTRY).values().stream().mapToLong(Long::longValue).sum();
+        assertTrue("Geochemistry children (" + children + ") exceed parent count (" + parent + ")",
+            children <= parent);
+    }
+
+    /** The flat facets on the same fields keep their own dimensions and counts. */
+    @Test
+    public void testFlatFacetsAreUnaffected() {
+        Map<String, Long> dataTypes = flatFacet("dataType");
+        assertEquals(Long.valueOf(2), dataTypes.get(BOREHOLE));
+        assertEquals(Long.valueOf(1), dataTypes.get(DOWNHOLE_ASSAYS));
+        assertEquals(Long.valueOf(2), dataTypes.get(GEOCHEM_RESULTS));
+
+        Map<String, Long> groupings = flatFacet("dataTypeGrouping");
+        assertEquals(Long.valueOf(2), groupings.get(HOLES));
+        assertEquals(Long.valueOf(2), groupings.get(GEOCHEMISTRY));
+    }
+
+    /** A vocabulary edit — not a change on the entity — must reindex affected entities. */
+    @Test
+    public void testGroupingVocabularyChangeReindexesEntities() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            addGrouping(dataset.getDefaultModel(), GEOCHEM_RESULTS, HOLES);
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+
+        Map<String, Long> holes = drillInto(HOLES);
+        assertEquals("geochem-results now also sits under Holes",
+            Long.valueOf(2), holes.get(GEOCHEM_RESULTS));
+        assertEquals(Long.valueOf(2), holes.get(BOREHOLE));
+
+        Map<String, Long> geochemistry = drillInto(GEOCHEMISTRY);
+        assertEquals("and is still under Geochemistry",
+            Long.valueOf(2), geochemistry.get(GEOCHEM_RESULTS));
+    }
+
+    /** A display table with no grouping contributes nothing to the hierarchy dimension. */
+    @Test
+    public void testDisplayTableWithoutGroupingIsAbsentFromHierarchy() {
+        String orphan = NS + "display/orphan";
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            addDocument(dataset.getDefaultModel(), "doc4", orphan);
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+
+        assertEquals("orphan display table is still a flat dataType facet value",
+            Long.valueOf(1), flatFacet("dataType").get(orphan));
+
+        Map<String, Long> values = topLevel();
+        assertEquals(Long.valueOf(2), values.get(HOLES));
+        assertEquals(Long.valueOf(2), values.get(GEOCHEMISTRY));
+        assertFalse(values.containsKey(orphan));
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestCorrelatedHierarchyDerivation.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestCorrelatedHierarchyDerivation.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text.assembler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.query.text.ShaclIndexMapping;
+import org.apache.jena.query.text.ShaclIndexMapping.CorrelatedHierarchy;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclTextIndexLucene;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.Test;
+
+/**
+ * Which root hierarchies get a correlated build plan, derived from the parsed config.
+ * <p>
+ * Correlation applies when the level occurrences form a prefix chain — each level's
+ * SHACL path extends the path of the level below it. Anything else keeps the cartesian
+ * product, which is correct whenever the levels are genuinely independent.
+ *
+ * @see org.apache.jena.query.text.TestCorrelatedRootHierarchy for the counts this produces
+ */
+public class TestCorrelatedHierarchyDerivation {
+
+    private static final String SH = "http://www.w3.org/ns/shacl#";
+    private static final String EX = "http://example.org/";
+    private static final String FIELD_NS = "urn:jena:lucene:field#";
+    private static final String DIM = "dataTypeGrouping_dataType";
+
+    static {
+        JenaSystem.init();
+        TextAssembler.init();
+    }
+
+    private Resource keywordField(Model model, String name) {
+        return model.createResource(FIELD_NS + name)
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), name)
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), IndexVocab.KeywordField)
+            .addProperty(model.createProperty(IndexVocab.NS, "facetable"), model.createTypedLiteral(true))
+            .addProperty(model.createProperty(IndexVocab.NS, "multiValued"), model.createTypedLiteral(true));
+    }
+
+    private Resource occurrence(Model model, Resource field, RDFNode pathNode) {
+        return model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "field"), field)
+            .addProperty(model.createProperty(SH, "path"), pathNode);
+    }
+
+    /** {@code sh:path ( a b )} — a SHACL sequence path. */
+    private RDFNode sequence(Model model, String... predicates) {
+        RDFNode[] links = new RDFNode[predicates.length];
+        for (int i = 0; i < predicates.length; i++) {
+            links[i] = model.createResource(EX + predicates[i]);
+        }
+        return model.createList(links);
+    }
+
+    private RDFNode inverse(Model model, String predicate) {
+        return model.createResource()
+            .addProperty(model.createProperty(SH, "inversePath"), model.createResource(EX + predicate));
+    }
+
+    /**
+     * Build a shape whose {@code dataType} / {@code dataTypeGrouping} occurrences use the
+     * supplied paths, declare a hierarchy over them, and return the parsed profile.
+     */
+    private IndexProfile parseProfile(Model model, RDFNode dataTypePath, RDFNode groupingPath,
+                                      RDFNode... extraDataTypePaths) {
+        Resource dataType = keywordField(model, "dataType");
+        Resource grouping = keywordField(model, "dataTypeGrouping");
+
+        Resource shape = model.createResource(EX + "DocumentShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Document"))
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, dataType, dataTypePath))
+            .addProperty(model.createProperty(SH, "property"), occurrence(model, grouping, groupingPath))
+            .addProperty(model.createProperty(IndexVocab.NS, "facetHierarchy"),
+                model.createList(new RDFNode[] { grouping, dataType }));
+        for (RDFNode extra : extraDataTypePaths) {
+            shape.addProperty(model.createProperty(SH, "property"), occurrence(model, dataType, extra));
+        }
+
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, model.createList(new RDFNode[] { shape }));
+
+        ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
+        try {
+            ShaclIndexMapping mapping = index.getShaclMapping();
+            assertEquals(1, mapping.getProfiles().size());
+            return mapping.getProfiles().get(0);
+        } finally {
+            index.close();
+        }
+    }
+
+    /** The GSWA shape: the grouping path extends the datatype path by one step. */
+    @Test
+    public void testPrefixChainedLevelsAreCorrelated() {
+        Model model = ModelFactory.createDefaultModel();
+        IndexProfile profile = parseProfile(model,
+            model.createResource(EX + "hasDisplayTable"),
+            sequence(model, "hasDisplayTable", "hasGrouping"));
+
+        CorrelatedHierarchy plan = profile.getCorrelatedHierarchy(DIM);
+        assertNotNull("prefix-chained levels must be correlated", plan);
+        assertEquals(2, plan.getDepth());
+        assertEquals("dataType", plan.getLevel(1).getFieldName());
+    }
+
+    /** Independent paths off the entity — a genuine cartesian hierarchy, left alone. */
+    @Test
+    public void testIndependentLevelsStayCartesian() {
+        Model model = ModelFactory.createDefaultModel();
+        IndexProfile profile = parseProfile(model,
+            model.createResource(EX + "hasDisplayTable"),
+            model.createResource(EX + "hasGrouping"));
+
+        assertNull("independent paths have no node at which the levels meet",
+            profile.getCorrelatedHierarchy(DIM));
+    }
+
+    /** The chain must run the right way: the outer level extends the inner one. */
+    @Test
+    public void testReversedChainStaysCartesian() {
+        Model model = ModelFactory.createDefaultModel();
+        IndexProfile profile = parseProfile(model,
+            sequence(model, "hasGrouping", "hasDisplayTable"),
+            model.createResource(EX + "hasGrouping"));
+
+        assertNull(profile.getCorrelatedHierarchy(DIM));
+    }
+
+    /**
+     * A level reached by two different paths (fan-in) has no single meeting node, so
+     * correlation cannot be derived and the cartesian product is kept.
+     */
+    @Test
+    public void testFanInLevelStaysCartesian() {
+        Model model = ModelFactory.createDefaultModel();
+        IndexProfile profile = parseProfile(model,
+            model.createResource(EX + "hasDisplayTable"),
+            sequence(model, "hasDisplayTable", "hasGrouping"),
+            model.createResource(EX + "hasLegacyDisplayTable"));
+
+        assertNull("a fan-in level cannot be correlated",
+            profile.getCorrelatedHierarchy(DIM));
+    }
+
+    /** Inverse steps chain like any other step. */
+    @Test
+    public void testInverseStepInChainIsCorrelated() {
+        Model model = ModelFactory.createDefaultModel();
+        Model seqModel = model;
+        RDFNode groupingPath = seqModel.createList(new RDFNode[] {
+            seqModel.createResource(EX + "hasDisplayTable"),
+            inverse(seqModel, "groups")
+        });
+
+        IndexProfile profile = parseProfile(model,
+            model.createResource(EX + "hasDisplayTable"),
+            groupingPath);
+
+        assertNotNull("an inverse ascent step is still a chain",
+            profile.getCorrelatedHierarchy(DIM));
+    }
+
+    /** Three prefix-chained levels correlate the whole way up. */
+    @Test
+    public void testThreeLevelChainIsCorrelated() {
+        Model model = ModelFactory.createDefaultModel();
+
+        Resource dataType = keywordField(model, "dataType");
+        Resource grouping = keywordField(model, "dataTypeGrouping");
+        Resource theme = keywordField(model, "dataTypeTheme");
+
+        Resource shape = model.createResource(EX + "DocumentShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Document"))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, dataType, model.createResource(EX + "hasDisplayTable")))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, grouping, sequence(model, "hasDisplayTable", "hasGrouping")))
+            .addProperty(model.createProperty(SH, "property"),
+                occurrence(model, theme, sequence(model, "hasDisplayTable", "hasGrouping", "hasTheme")))
+            .addProperty(model.createProperty(IndexVocab.NS, "facetHierarchy"),
+                model.createList(new RDFNode[] { theme, grouping, dataType }));
+
+        Resource indexSpec = model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, model.createList(new RDFNode[] { shape }));
+
+        ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
+        try {
+            IndexProfile profile = index.getShaclMapping().getProfiles().get(0);
+            CorrelatedHierarchy plan = profile.getCorrelatedHierarchy(
+                "dataTypeTheme_dataTypeGrouping_dataType");
+            assertNotNull(plan);
+            assertEquals(3, plan.getDepth());
+        } finally {
+            index.close();
+        }
+    }
+}


### PR DESCRIPTION
Closes #147.

## The bug

A shape-level `idx:facetHierarchy` read each level's values independently from the entity and took their cartesian product. Where two multi-valued levels are pairwise related through an intermediate node, that invents facet paths.

GSWA facets documents on `dataType` (the display-table IRI) and wants `dataTypeGrouping` above it. A document carrying display tables in two different groupings produced four paths:

```text
Holes / borehole                  ✓ in the data
Holes / geochem-results           ✗ invented
Geochemistry / borehole           ✗ invented
Geochemistry / geochem-results    ✓ in the data
```

Drilling into `Holes` offered a datatype that is not in it, and the children out-counted the parent. The failure was silent.

## The fix

When each level's occurrence path **strictly extends the path of the level below it** — a prefix chain — the levels correlate by walking those paths through the graph, ascending one step at a time from the innermost level. Every emitted path is a chain of edges that exists in the data.

This needs **no new vocabulary and no config change**: the config that describes the taxonomy is already the chain.

```turtle
sh:property [ idx:field field:dataType         ; sh:path gswa:hasDisplayTable ] ;
sh:property [ idx:field field:dataTypeGrouping ; sh:path ( gswa:hasDisplayTable gswa:hasGrouping ) ] ;
idx:facetHierarchy ( field:dataTypeGrouping field:dataType ) ;
```

Correlation needs a single unambiguous meeting node, so it applies only when every level has exactly one root occurrence with a single path variant. Fan-in levels, alternative paths and independent levels keep the cartesian product — correct when the levels really are independent — and now **warn at config time** when more than one such level is multi-valued.

## Why not `idx:self` in an `idx:nested` block (the direction proposed in #147)

Dropped once the flat-facet constraint was tested rather than assumed:

- "One field IRI belongs to one scope" means `field:dataType` cannot be both the root flat-facet field and the nested hierarchy leaf, so keeping the working flat facet needs a **twin field** carrying identical values.
- Moving `dataType` into the nested block instead does not relocate the flat facet, it **removes** it. Facet collection filters to parent docs (`filterToParents`) and nested values live only on child docs, so the flat facet returns nothing under an active query — exactly the state a search UI is always in. The client's `dataType` facet is in daily use.
- It also materialises one child document per display table purely to carry a facet.

The prefix chain has none of those costs: both fields stay root-scoped, both flat facets are untouched, and no child documents are created.

## Semantics worth reviewing

- **No partial paths.** A display table with no grouping is absent from the dimension rather than counted under a parent it does not have. It remains a value of the flat `dataType` facet.
- **Branching is genuine.** A display table in two groupings yields two paths — real edges, unlike cartesian combinations.
- **Change tracking needed nothing.** Correlation is derived from occurrences that are already declared, so a vocabulary edit (`display/borehole gswa:hasGrouping …`, not a change on the entity) still reverse-evaluates to the affected entities. Pinned by a test.

## Changes

| Piece | Change |
|---|---|
| `ShaclIndexMapping.CorrelatedHierarchy` | Derives the plan: one occurrence per level, single path variant, strict step-for-step extension. Holds the innermost path and per-level ascent paths |
| `ShaclIndexMapping.IndexProfile` | Derives plans once at config time; warns on the cartesian-and-multi-valued shape |
| `ShaclEntityBuilder` | Walks the chain outwards from the innermost level |
| `Entity` | Carries the walked paths — correlation is a graph property, unrecoverable from flattened values |
| `ShaclTextIndexLucene` | Emits walked paths for a correlated dimension; cartesian path unchanged otherwise |

## Tests

805 pass (was 798 before this branch), full build with RAT.

The first two assertions were written **red first** and failed on the invented `Holes / geochem-results` path (first commit) before the fix.

- `TestCorrelatedRootHierarchy` (7) — the exact GSWA shape, both fields multi-valued: top-level counts, drill-down inventing no paths, children not out-counting the parent, flat facets unaffected, vocabulary-edit reindex, term with no parent, three-level chain.
- `TestCorrelatedHierarchyDerivation` (6) — which configs get a plan: prefix-chained, independent, reversed, fan-in, inverse ascent step, three levels.

Both registered in `TS_Text`.

Docs: new "Hierarchical Facets" section in `03-configuration.md`, resolution recorded in `docs/2026-08-03_correlated_hierarchy_over_root_fields.md`, test tables and counts updated.