### PR TITLE
Bind an occurrence to the focus node with idx:self

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ mvn clean install -Drat.skip
 ## Running Tests
 
 ```bash
-# Run all jena-text tests (790 tests)
+# Run all jena-text tests (806 tests)
 mvn test -pl jena-text
 
 # Run a single test class

--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -183,13 +183,42 @@ one field cannot end up with two different definitions.
 | Property | Required | Meaning |
 |---|---|---|
 | `idx:field` | yes | The canonical field this occurrence feeds |
-| `sh:path` | yes | Direct, sequence, inverse, or alternative path from the entity (or, inside `idx:nested`, from the child node) |
+| `sh:path` | yes¹ | Direct, sequence, inverse, or alternative path from the entity (or, inside `idx:nested`, from the child node) |
+| `idx:self` | yes¹ | Bind the focus node itself instead of a path from it — see [Indexing the focus node](#indexing-the-focus-node) |
 | `sh:class` | no | Only index values whose reached node has this `rdf:type` |
 | `sh:nodeKind` | no | Restrict to `sh:IRI`, `sh:Literal`, or `sh:BlankNode` |
 | `sh:datatype` | no | Only index literals with this datatype |
 
+¹ Exactly one of `sh:path` / `idx:self`. Neither is an error, and so is both.
+
 Several occurrences may feed one field — that is how a value fans in from more than one
 path. They must all resolve to the same canonical definition.
+
+### Indexing the focus node
+
+`idx:self true` feeds a field from the node the occurrence is evaluated against, rather
+than from a path leading away from it. That node is the **entity** for a root occurrence
+and the **child node** inside an `idx:nested` block.
+
+```turtle
+sh:property [ idx:field field:entityIri ; idx:self true ] ;
+```
+
+The value constraints still apply — they filter the focus node itself, so
+`sh:nodeKind sh:IRI` on a self occurrence means "only index this child when it is an IRI".
+
+A focus node is a resource, so a self-bound field must be `idx:KeywordField` or
+`idx:TextField`; the numeric and temporal types have nothing to convert and are rejected at
+config time. Blank nodes yield no value at all — their labels are not stable across a
+reload, so indexing them would be meaningless — and the field is simply absent from that
+document.
+
+A self occurrence contributes no predicates to change tracking, which is correct: its value
+cannot change without the entity or the join that reaches it changing, and both are already
+tracked.
+
+The main use is a nested block whose child node is itself one of the values you want —
+see [Pattern 4](#pattern-4--hierarchy-whose-level-is-the-child-node).
 
 ## Choosing an Analyzer for a TEXT Field
 
@@ -462,13 +491,58 @@ No n-gram twin on the agent, on purpose — see
 `TestCorrelatedNestedAttribution` pins the correlation for `=`, for `text_query` on a
 plain field, and for the n-gram configurations that are permitted but not advised.
 
+### Pattern 4 — Hierarchy whose level is the child node
+
+A taxonomy is often attached to a *term* rather than to the entity: the entity references
+some term, and the term belongs to a broader grouping. Faceting on both, correlated, needs
+the term itself as a hierarchy level.
+
+```turtle
+# instance data — an entity may reference several display tables
+ex:doc1  ex:hasDisplayTable  ex:borehole , ex:downholeAssays .
+
+# vocabulary — each display table belongs to a grouping
+ex:borehole        ex:hasGrouping  ex:Holes .
+ex:downholeAssays  ex:hasGrouping  ex:Holes .
+ex:geochemResults  ex:hasGrouping  ex:Geochemistry .
+```
+
+```turtle
+<#DocumentShape>
+    sh:targetClass ex:Document ;
+    idx:nested [
+        idx:joinPath ex:hasDisplayTable ;
+        idx:property [ idx:field field:displayTable ; idx:self true ] ;
+        idx:property [ idx:field field:grouping     ; sh:path ex:hasGrouping ] ;
+        idx:facetHierarchy ( field:grouping field:displayTable ) ;
+    ] .
+```
+
+The child node **is** the display table, so its occurrence binds the focus node; the
+grouping is one step off it. Each child record carries one display table and its grouping,
+so the hierarchy is pairwise correct: a document referencing display tables in two
+different groupings produces exactly its two real paths.
+
+Declaring the two fields as **root** occurrences instead — `sh:path ex:hasDisplayTable` and
+`sh:path ( ex:hasDisplayTable ex:hasGrouping )` — would read each level's values
+independently and emit the cartesian product of the two, including
+`Holes / geochemResults`, which is not in the data. Drilling into a grouping would then
+offer terms that are not in it, and the children would out-count the parent.
+
+Both fields are child-scoped here, which is what makes them correlated, and it is also
+what determines how they behave elsewhere: they filter same-child, and they are not
+available as entity-level flat facets. If you also want a flat facet over the term across
+all entities, declare a **separate field** with its own name fed by a root occurrence on
+`ex:hasDisplayTable`. One field cannot be both — see the first rule below.
+
 ### Rules
 
 - One field IRI belongs to one scope: either root or one nested collection.
 - Scope names are resolved across the whole mapping, so an explicit `idx:nestedName` must be unique among all `idx:nested` blocks in the index, not just within its shape.
 - `idx:joinPath` may be a simple predicate, an inverse predicate, or a sequence of predicate steps. It does not support alternative paths.
 - Both the exact-keyword and edge-ngram-text variants can sit on the same SHACL path — they are different Lucene fields driven by their own analyzers.
-- `idx:facetHierarchy` inside an `idx:nested` block defines a hierarchy whose levels are correlated per child record (no cartesian products).
+- `idx:facetHierarchy` inside an `idx:nested` block defines a hierarchy whose levels are correlated per child record (no cartesian products). On a shape, the levels are read independently from the entity and cross-produced — correct when they are independent, wrong when they are pairwise related, which is what [Pattern 4](#pattern-4--hierarchy-whose-level-is-the-child-node) is for.
+- `idx:self` binds the focus node: the child node inside `idx:nested`, the entity at root. It replaces `sh:path` rather than accompanying it, and is not available on an `idx:column` — an external child is a row, not a node.
 - A field named in an `idx:facetHierarchy` keeps its own flat facet dimension. Faceting on the field IRI returns that field's counts across all parents; faceting on the hierarchy's dimension name returns its top level, or the children of a drill-down path. The two are addressed separately and neither shadows the other.
 - Faceting on a field that is not `idx:facetable` is an error — there is no dimension to answer from.
 
@@ -728,6 +802,7 @@ Every term the assembler reads, and where it is defined above:
 | Term | Goes on | Section |
 |---|---|---|
 | `idx:field` | occurrence, `idx:column` | [Occurrence properties](#occurrence-properties) |
+| `idx:self` | occurrence | [Indexing the focus node](#indexing-the-focus-node) |
 | `idx:fieldName` `idx:fieldType` | canonical field | [Field Properties](#field-properties) |
 | `idx:stored` `idx:indexed` `idx:facetable` `idx:sortable` `idx:multiValued` `idx:defaultSearch` | canonical field | [Field Properties](#field-properties) |
 | `idx:analyzer` `idx:queryAnalyzer` `idx:normalizer` | canonical field | [Field Properties](#field-properties) |

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -3,7 +3,7 @@
 ## Running Tests
 
 ```bash
-# Full jena-text suite (790 tests)
+# Full jena-text suite (806 tests)
 mvn test -pl jena-text
 
 # Only SHACL / faceting tests
@@ -53,6 +53,8 @@ A class missing from `@SelectClasses` is **silently never run** — not reported
 |-------|-------|---------------|
 | `TestHierarchicalFacets` | 9 | Java API: taxonomy indexing, top-level facets, drill-down path building, flat+hierarchy coexistence, multi-valued hierarchies, empty dimensions |
 | `TestHierarchicalFacetsSparql` | 3 | SPARQL `luc:facet` with hierarchy: top-level via field IRI, drill-down via CQL filter, flat facets alongside hierarchy |
+| `TestSelfBoundOccurrences` | 6 | `idx:self` in a nested block, where the child node is itself a hierarchy level: top-level counts, drill-down correlated per child, children not out-counting the parent, same-child correlation with a sibling field, vocabulary-edit reindex, child-added reindex |
+| `TestSelfOccurrenceAssembler` | 8 | `idx:self` config surface: parses in a nested block and at root; rejects self+`sh:path`, neither, `idx:self false`, a numeric field, and use on an `idx:column` |
 
 ### Sort Tests
 
@@ -71,7 +73,7 @@ A class missing from `@SelectClasses` is **silently never run** — not reported
 
 ### Existing Tests (unchanged, verifying no regressions)
 
-The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 790 tests.
+The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 806 tests.
 
 ---
 

--- a/docs/2026-08-03_correlated_hierarchy_over_root_fields.md
+++ b/docs/2026-08-03_correlated_hierarchy_over_root_fields.md
@@ -1,0 +1,230 @@
+---
+title: "Correlated hierarchical facets over root fields"
+date: "2026-08-03"
+status: "Resolved — idx:self binds the focus node, making the nested correlated hierarchy reachable"
+---
+
+# Correlated Hierarchical Facets Over Root Fields
+
+## Problem
+
+A shape-level `idx:facetHierarchy` builds its facet paths by taking the **cartesian
+product** of each level's values. When every level is single-valued that is correct. When
+two levels are multi-valued and their values are *pairwise* related, it invents paths that
+are not in the data, and the drill-down counts are wrong.
+
+There is a correlated implementation — `idx:facetHierarchy` inside an `idx:nested` block —
+but it is only reachable when the correlating node has each level hanging off it as a
+sub-property. It cannot express a hierarchy where one of the levels **is** the child node
+itself. That is the case below, so neither construct currently fits.
+
+## Use case
+
+GSWA search facets on the datatype of a document (`dataType`), and wants to add a broader
+grouping above it (`dataTypeGrouping`) so users can select several datatypes at once. The
+UI should show:
+
+```text
+Holes (1,234)
+  downhole-assays (812)
+  borehole (422)
+```
+
+The data:
+
+```turtle
+# instance data — an entity may reference several display tables
+<borehole/123>  gswa:hasDisplayTable  <display/borehole> , <display/downhole-assays> .
+
+# vocabulary — each display table belongs to one or more groupings
+<display/borehole>          gswa:hasGrouping  <datatype/Holes> .
+<display/downhole-assays>   gswa:hasGrouping  <datatype/Holes> .
+<display/geochem-results>   gswa:hasGrouping  <datatype/Geochemistry> .
+```
+
+The current shape indexes the display table IRI itself as `dataType`:
+
+```turtle
+sh:property [ idx:field field:dataType          ; sh:path gswa:hasDisplayTable ] ;
+sh:property [ idx:field field:dataTypeGrouping  ; sh:path ( gswa:hasDisplayTable gswa:hasGrouping ) ] ;
+```
+
+Both fields are `idx:multiValued true`.
+
+## Why the root hierarchy is wrong here
+
+`addDirectHierarchyFacetFields`
+(`jena-text/src/main/java/org/apache/jena/query/text/ShaclTextIndexLucene.java:1040`)
+reads each level's values independently from the entity root:
+
+```java
+for (ShaclIndexMapping.FieldDef levelField : hierarchy.getLevels()) {
+    levelValues.add(asHierarchyFacetValues(entity.get(levelField.getFieldName()), ...));
+}
+addFacetPaths(doc, hierarchy.getDimensionName(), levelValues, 0, new ArrayList<>());
+```
+
+and `addFacetPaths` (`:1117`) recurses over every value at every level, emitting one
+`FacetField` per combination.
+
+So for an entity carrying two display tables in two different groupings:
+
+```text
+dataType          = [ display/borehole, display/geochem-results ]
+dataTypeGrouping  = [ datatype/Holes,   datatype/Geochemistry   ]
+```
+
+it emits four paths, two of them fabricated:
+
+```text
+Holes / borehole                  ✓ in the data
+Holes / geochem-results           ✗ invented
+Geochemistry / borehole           ✗ invented
+Geochemistry / geochem-results    ✓ in the data
+```
+
+Drilling into `Holes` then offers `geochem-results` as a child, and the child counts sum to
+more than the parent count. This is the "no repeated intermediate node" limitation recorded
+in [`2026-04-07_nested_hierarchical_faceting_design.md`](2026-04-07_nested_hierarchical_faceting_design.md);
+the note assumed such cases would move to `idx:nested`, which is where this one gets stuck.
+
+## Why the nested block does not reach it
+
+The natural correlating node is the display table, so the block would be:
+
+```turtle
+idx:nested [
+    idx:joinPath gswa:hasDisplayTable ;
+    idx:property [ idx:field field:dataType         ; sh:path ??? ] ;
+    idx:property [ idx:field field:dataTypeGrouping ; sh:path gswa:hasGrouping ] ;
+    idx:facetHierarchy ( field:dataTypeGrouping field:dataType ) ;
+] ;
+```
+
+`addNestedHierarchyFacetFields` (`:1050`) would then do the right thing — it builds paths
+per child record, so no cartesian product across children.
+
+The blocker is the `???`. `dataType`'s value **is** the child node, `<display/borehole>`.
+Every `idx:property` inside a nested block is evaluated as a path *from* the child, and
+there is no way to express "the child node itself" — no `idx:self`, no empty path, no
+`sh:this`. The existing nested patterns never needed one: `schema:identifier` and
+`prov:qualifiedAttribution` children are blank-node bundles where every indexed value is
+reached by stepping off the child.
+
+## What is actually needed
+
+A way to declare a hierarchy whose levels stay pairwise correlated, where one level is the
+correlating node itself. Some directions, none evaluated:
+
+1. **Identity path.** Let an `idx:property` inside a nested block bind the child node
+   itself — `idx:self true` on the occurrence, or an empty `sh:path` list. Smallest change;
+   makes the existing correlated code path reachable. Worth checking what else an identity
+   path would enable, and whether it is coherent for a non-facet field.
+2. **Correlated root hierarchy.** Teach `addDirectHierarchyFacetFields` to walk the paths
+   rather than the flattened field values, so a hierarchy over `( A B )` where B's path
+   extends A's stays correlated without a nested block. Larger change, and it needs a rule
+   for when two root occurrences count as correlated.
+3. **Nothing** — declare this out of scope and require callers to materialise a correlated
+   child structure in the data. Cheapest for us, but pushes a denormalisation onto every
+   dataset that has a taxonomy attached to a term rather than to the entity.
+
+## Notes for whoever picks this up
+
+- Both a flat facet on the field and the hierarchy dimension are addressable separately and
+  neither shadows the other (`docs/03-configuration.md:472`), so a fix must not change how
+  `dataType` behaves as a flat facet today.
+- The failure is silent. Nothing warns at index time that a hierarchy's levels are
+  multi-valued and uncorrelated; the counts are simply wrong. A config-time warning may be
+  worth having regardless of which direction is chosen.
+- Hierarchical facet ordinals live in the taxonomy directory. If it is left unset the
+  counts vanish entirely when indexing and querying are separate processes
+  (`docs/03-configuration.md:64`) — worth confirming in any test that exercises this.
+- This shape recurs: commodity groupings, report-type hierarchies and sample-of chains are
+  all taxonomies attached to a term rather than to the entity, and all are flat facets
+  today.
+
+## Resolution (2026-08-03) — option 1, the identity path
+
+`idx:self true` on an occurrence binds the **focus node** itself instead of a path from it:
+the child node inside an `idx:nested` block, the entity at root scope. That is the whole
+change. It is the one primitive the model was missing, and with it the existing correlated
+nested hierarchy becomes reachable for this shape:
+
+```turtle
+idx:nested [
+    idx:joinPath ex:hasDisplayTable ;
+    idx:property [ idx:field field:displayTable ; idx:self true ] ;
+    idx:property [ idx:field field:grouping     ; sh:path ex:hasGrouping ] ;
+    idx:facetHierarchy ( field:grouping field:displayTable ) ;
+] ;
+```
+
+### Why not option 2 (correlate the root hierarchy)
+
+Option 2 was built first, in the form of a "prefix chain": correlate a shape-level
+hierarchy when each level's path is found to extend the level below it. It was **discarded
+before merge**, for reasons worth keeping:
+
+- **It is a second mechanism for one semantic.** `idx:nested` already models "these values
+  belong together". Deriving the same thing a second way, from the shape of paths, means
+  two implementations of correlation that must agree forever.
+- **It is implicit.** Nothing in the config says the hierarchy is correlated. Two
+  configurations that look alike behave differently, and the difference is only visible by
+  reasoning about path prefixes. Correctness became a property of how the paths happened
+  to be written.
+- **Its fallbacks are silent.** Fan-in, alternative paths, or a level with two occurrences
+  all drop back to the cartesian product — the wrong answer — with only a log line.
+
+The scope rule that made option 1 look expensive turned out to be the right rule, not an
+obstacle. A field's scope determines its behaviour; wanting entity-level flat faceting and
+child-correlated hierarchy from one field IRI is wanting two behaviours from one
+declaration. Two behaviours, two fields, two names — which is honest, and states in the
+config what is actually being asked for.
+
+### What was built
+
+| Piece | Change |
+|---|---|
+| `IndexVocab` | `idx:self` |
+| `ShaclIndexMapping.FieldOccurrence` | `FieldOccurrence.self(...)` factory; null path, one zero-step path variant, no predicates; `isSelf()` |
+| `ShaclIndexAssembler` | Parses and validates: exactly one of `sh:path` / `idx:self`, `idx:self false` rejected, KEYWORD/TEXT only, not on `idx:column` |
+| `ShaclEntityBuilder` | Self occurrences take the focus node, with the occurrence's constraints applied to it |
+| `ShaclTextDocProducer` | Reverse-walking an identity path from a node arrives at that node |
+
+Nothing else moved. The nested hierarchy builder, the facet code and the block-join query
+path were already correct — they were simply unreachable for a hierarchy whose level is the
+child node.
+
+Semantics worth knowing:
+
+- **Constraints filter the focus node.** `sh:nodeKind sh:IRI` on a self occurrence means
+  "index this child only when it is an IRI".
+- **Blank nodes yield nothing.** Their labels are not stable across a reload, so there is
+  nothing meaningful to index; the field is absent from that document.
+- **Field type is restricted to KEYWORD/TEXT.** A focus node is a resource, so the numeric
+  and temporal types have nothing to convert — rejected at config time rather than
+  producing empty fields.
+- **No new change tracking.** A self occurrence contributes no predicates, which is
+  correct: its value cannot change unless the entity or the join reaching it changes, and
+  both are already tracked. Pinned by two tests (a vocabulary edit, and a child added to an
+  entity).
+- **It is not facet machinery.** A self-bound field is an ordinary child-scope field: it
+  filters same-child with its siblings like any other value. Pinned by a test.
+
+### Tests
+
+`TestSelfBoundOccurrences` (6) — the correlated hierarchy: top-level counts, drill-down
+staying correlated per child, children not out-counting the parent, same-child correlation
+with a sibling field, vocabulary-edit reindex, child-added reindex.
+`TestSelfOccurrenceAssembler` (8) — config surface: parses in a nested block and at root,
+and rejects self+path, neither, `idx:self false`, a numeric field, and `idx:column`.
+
+Written red first: with the builder's self branch removed, all six behaviour tests fail on
+the null path.
+
+### Still open
+
+- **Deeper taxonomies.** A hierarchy walked transitively (`skos:broader+`, unknown depth)
+  is still not expressible. `idx:self` does not help there; that needs a path-walking
+  hierarchy declaration, and should wait for a real case.
+

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclEntityBuilder.java
@@ -118,6 +118,16 @@ final class ShaclEntityBuilder {
 
     private static List<Object> extractOccurrenceValues(Graph graph, Node subject, FieldOccurrence occurrence) {
         LinkedHashSet<Object> values = new LinkedHashSet<>();
+        if (occurrence.isSelf()) {
+            // The focus node itself: the entity at root scope, the child node inside a
+            // nested block. Constraints still apply — they filter the focus node.
+            if (!satisfiesConstraints(graph, subject, occurrence)) {
+                return Collections.emptyList();
+            }
+            Object value = nodeToValue(subject, occurrence.getField().getFieldType(),
+                occurrence.getField().preservesLiteralMetadata());
+            return value != null ? List.of(value) : Collections.emptyList();
+        }
         Iterator<Node> iter = PathEval.eval(graph, subject, occurrence.getPath(), indexingContext());
         while (iter.hasNext()) {
             Node endpoint = iter.next();

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclIndexMapping.java
@@ -302,8 +302,37 @@ public class ShaclIndexMapping {
             }
         }
 
+        private FieldOccurrence(FieldDef field, Node requiredClass,
+                                NodeKindConstraint nodeKindConstraint, Node datatype,
+                                String nestedName) {
+            this.field = Objects.requireNonNull(field);
+            this.path = null;
+            // One variant of zero steps: the identity walk. Not the empty list, which
+            // would mean "no way to reach this field at all".
+            this.pathVariants = List.of(List.of());
+            this.predicates = Collections.emptySet();
+            this.requiredClass = requiredClass;
+            this.nodeKindConstraint = nodeKindConstraint;
+            this.datatype = datatype;
+            this.nestedName = nestedName;
+        }
+
+        /**
+         * An occurrence that binds the focus node itself rather than a path from it —
+         * the entity at root scope, the child node inside an {@code idx:nested} block.
+         * Written {@code idx:self true} in place of {@code sh:path}.
+         */
+        public static FieldOccurrence self(FieldDef field, Node requiredClass,
+                                           NodeKindConstraint nodeKindConstraint, Node datatype,
+                                           String nestedName) {
+            return new FieldOccurrence(field, requiredClass, nodeKindConstraint, datatype, nestedName);
+        }
+
         public FieldDef getField()                { return field; }
+        /** The path from the focus node, or null when this occurrence is self-bound. */
         public Path getPath()                     { return path; }
+        /** True when this occurrence binds the focus node itself ({@code idx:self}). */
+        public boolean isSelf()                   { return path == null; }
         public List<List<JoinStep>> getPathVariants() { return pathVariants; }
         public Set<Node> getPredicates()          { return predicates; }
         public Node getRequiredClass()            { return requiredClass; }
@@ -316,9 +345,10 @@ public class ShaclIndexMapping {
 
         @Override
         public String toString() {
+            String source = isSelf() ? "self" : String.valueOf(path);
             return nestedName == null
-                ? field.getFieldName() + " <- " + path
-                : field.getFieldName() + "@" + nestedName + " <- " + path;
+                ? field.getFieldName() + " <- " + source
+                : field.getFieldName() + "@" + nestedName + " <- " + source;
         }
 
         private static List<List<JoinStep>> deepUnmodifiable(List<List<JoinStep>> variants) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/ShaclTextDocProducer.java
@@ -148,6 +148,10 @@ public class ShaclTextDocProducer implements TextDocProducer {
     }
 
     private Set<Node> findScopeRootsForConstraintChange(Graph graph, Node endpoint, FieldOccurrence occurrence) {
+        if (occurrence.isSelf()) {
+            // Walking an identity path backwards from a node arrives at that same node.
+            return Collections.singleton(endpoint);
+        }
         Set<Node> roots = new LinkedHashSet<>();
         Iterator<Node> iter = PathEval.evalReverse(graph, endpoint, occurrence.getPath(), ShaclEntityBuilder.indexingContext());
         while (iter.hasNext()) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/IndexVocab.java
@@ -85,6 +85,7 @@ public class IndexVocab {
     public static final Property pDefaultSearch = Vocab.property(NS, "defaultSearch");
     public static final Property pStoreLiteralMetadata = Vocab.property(NS, "storeLiteralMetadata");
     public static final Property pPath          = Vocab.property(NS, "path");
+    public static final Property pSelf          = Vocab.property(NS, "self");
     public static final Property pJoinPath      = Vocab.property(NS, "joinPath");
     public static final Property pProperty      = Vocab.property(NS, "property");
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclIndexAssembler.java
@@ -41,6 +41,11 @@ import org.slf4j.LoggerFactory;
 public class ShaclIndexAssembler {
     private static final Logger log = LoggerFactory.getLogger(ShaclIndexAssembler.class);
 
+    /** Field types an {@code idx:self} occurrence can feed. A focus node is a resource,
+     *  so the numeric and temporal types have nothing to convert. */
+    private static final Set<FieldType> SELF_BINDABLE_TYPES =
+        Collections.unmodifiableSet(EnumSet.of(FieldType.KEYWORD, FieldType.TEXT));
+
     private static final String SH = "http://www.w3.org/ns/shacl#";
     private static final String SH_BLANK_NODE = SH + "BlankNode";
     private static final String SH_IRI = SH + "IRI";
@@ -326,6 +331,11 @@ public class ShaclIndexAssembler {
                 "idx:column " + columnRes + " must not carry sh:path — its value comes from the "
                 + "bound column, and a path would be a second, contradicting source for the field.");
         }
+        if (columnRes.hasProperty(IndexVocab.pSelf)) {
+            throw new TextIndexException(
+                "idx:column " + columnRes + " must not carry idx:self — an external child is a "
+                + "row, not a node in the graph, so there is no focus node to bind.");
+        }
         Statement fieldStmt = columnRes.getProperty(IndexVocab.pField);
         if (fieldStmt == null || !fieldStmt.getObject().isResource()) {
             throw new TextIndexException("idx:column " + columnRes + " is missing idx:field");
@@ -441,19 +451,57 @@ public class ShaclIndexAssembler {
         reachableFields.putIfAbsent(field.getFieldIRI().getURI(), field);
 
         Path path = extractOccurrencePath(occurrenceRes);
-        if (path == null) {
-            throw new TextIndexException("Field occurrence " + occurrenceRes + " is missing sh:path");
+        boolean self = isSelfBound(occurrenceRes);
+        if (self && path != null) {
+            throw new TextIndexException("Field occurrence " + occurrenceRes
+                + " has both idx:self and sh:path. A field is fed by the focus node or by a "
+                + "path from it, never both.");
+        }
+        if (!self && path == null) {
+            throw new TextIndexException("Field occurrence " + occurrenceRes
+                + " is missing sh:path (or idx:self)");
         }
 
         Node requiredClass = getOptionalResourceNode(occurrenceRes, shClass);
         NodeKindConstraint nodeKindConstraint = getOptionalNodeKindConstraint(occurrenceRes);
         Node datatype = getOptionalResourceNode(occurrenceRes, shDatatype);
 
+        if (self) {
+            if (!SELF_BINDABLE_TYPES.contains(field.getFieldType())) {
+                throw new TextIndexException("Field occurrence " + occurrenceRes
+                    + " binds the focus node with idx:self into field "
+                    + field.getFieldIRI().getURI() + ", which has type " + field.getFieldType()
+                    + ". A focus node is a resource, so a self-bound field must be "
+                    + SELF_BINDABLE_TYPES + ".");
+            }
+            return FieldOccurrence.self(field, requiredClass, nodeKindConstraint, datatype, nestedName);
+        }
+
         List<List<JoinStep>> pathVariants = extractPathVariants(path);
         Set<Node> predicates = extractLeafPredicates(path);
 
         return new FieldOccurrence(field, path, pathVariants, predicates,
             requiredClass, nodeKindConstraint, datatype, nestedName);
+    }
+
+    /**
+     * {@code idx:self} is a marker, so it is only ever written {@code true}. An explicit
+     * {@code false} is rejected rather than read as "no self binding": the author meant
+     * something by writing it, and silently indexing nothing is the worst reading.
+     */
+    private static boolean isSelfBound(Resource occurrenceRes) {
+        Statement stmt = occurrenceRes.getProperty(IndexVocab.pSelf);
+        if (stmt == null) {
+            return false;
+        }
+        if (!stmt.getObject().isLiteral()) {
+            throw new TextIndexException("idx:self on " + occurrenceRes + " must be true");
+        }
+        if (!stmt.getObject().asLiteral().getBoolean()) {
+            throw new TextIndexException("idx:self on " + occurrenceRes
+                + " is false. Omit idx:self and give the occurrence an sh:path instead.");
+        }
+        return true;
     }
 
     private static void rejectCanonicalFieldPropertiesOnOccurrence(Resource occurrenceRes) {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -138,6 +138,9 @@ import org.apache.jena.query.text.changes.TestDatasetMonitor;
     , TestHierarchicalFacets.class
     , TestHierarchicalFacetsSparql.class
     , TestNestedHierarchicalFacets.class
+    // idx:self — an occurrence bound to the focus node itself
+    , TestSelfBoundOccurrences.class
+    , org.apache.jena.query.text.assembler.TestSelfOccurrenceAssembler.class
     , TestCorrelatedNestedAttribution.class
     , TestTypeaheadFieldConfigurations.class
     , TestNestedJoinPathSupport.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestSelfBoundOccurrences.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestSelfBoundOccurrences.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldDef;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldType;
+import org.apache.jena.query.text.ShaclIndexMapping.HierarchyDef;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclIndexMapping.JoinStep;
+import org.apache.jena.query.text.ShaclIndexMapping.NestedDef;
+import org.apache.jena.query.text.assembler.ShaclIndexAssembler;
+import org.apache.jena.query.text.cql.CqlExpression;
+import org.apache.jena.query.text.cql.CqlParser;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.sparql.path.PathFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * An {@code idx:self} occurrence binds the focus node itself — the child node inside an
+ * {@code idx:nested} block, the entity at root scope.
+ * <p>
+ * Without it, a correlated hierarchy cannot be expressed when one of its levels <em>is</em>
+ * the correlating node. Here the child is a display table, the hierarchy is
+ * (grouping, display table), and the display table is reached only by being the child.
+ * Every value on a child record is correlated with its siblings by construction, so the
+ * hierarchy stays pairwise correct where a cartesian product over entity-level values
+ * would invent combinations.
+ * <p>
+ * Design note: {@code docs/2026-08-03_correlated_hierarchy_over_root_fields.md}.
+ */
+public class TestSelfBoundOccurrences {
+
+    private static final String NS = "http://example.org/";
+    private static final String FIELD_NS = "urn:jena:lucene:field#";
+    private static final String DIM = "grouping_displayTable";
+
+    private static final Node DOCUMENT_CLASS = NodeFactory.createURI(NS + "Document");
+    private static final Node HAS_DISPLAY_TABLE = NodeFactory.createURI(NS + "hasDisplayTable");
+    private static final Node HAS_GROUPING = NodeFactory.createURI(NS + "hasGrouping");
+    private static final String SCOPE = PathFactory.pathLink(HAS_DISPLAY_TABLE).toString();
+
+    private static final String BOREHOLE = NS + "display/borehole";
+    private static final String DOWNHOLE_ASSAYS = NS + "display/downhole-assays";
+    private static final String GEOCHEM_RESULTS = NS + "display/geochem-results";
+    private static final String HOLES = NS + "datatype/Holes";
+    private static final String GEOCHEMISTRY = NS + "datatype/Geochemistry";
+
+    private Dataset dataset;
+    private ShaclTextIndexLucene textIndex;
+
+    @Before
+    public void setUp() {
+        TextQuery.init();
+
+        FieldDef displayTable = new FieldDef("displayTable", FieldType.KEYWORD, null, null,
+            true, true, true, false, true, false, false,
+            NodeFactory.createURI(FIELD_NS + "displayTable"));
+        FieldDef grouping = new FieldDef("grouping", FieldType.KEYWORD, null, null,
+            true, true, true, false, true, false, false,
+            NodeFactory.createURI(FIELD_NS + "grouping"));
+
+        // The child node IS the display table, so its occurrence binds the focus node.
+        NestedDef displayTables = new NestedDef(
+            SCOPE,
+            PathFactory.pathLink(HAS_DISPLAY_TABLE),
+            List.of(new JoinStep(HAS_DISPLAY_TABLE, false)),
+            Collections.singleton(HAS_DISPLAY_TABLE),
+            List.of(
+                FieldOccurrence.self(displayTable, null, null, null, SCOPE),
+                pathOccurrence(grouping, HAS_GROUPING)),
+            Collections.singletonList(
+                new HierarchyDef(DIM, Arrays.asList(grouping, displayTable))));
+
+        IndexProfile profile = new IndexProfile(
+            NodeFactory.createURI(NS + "DocumentShape"),
+            Collections.singleton(DOCUMENT_CLASS),
+            "uri", "docType",
+            Arrays.asList(displayTable, grouping),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.singletonList(displayTables));
+
+        ShaclIndexMapping mapping = new ShaclIndexMapping(Collections.singletonList(profile));
+        TextIndexConfig config = new TextIndexConfig(ShaclIndexAssembler.deriveEntityDefinition(mapping));
+        config.setShaclMapping(mapping);
+        config.setFacetFields(mapping.getFacetFieldNames());
+        config.setValueStored(true);
+
+        // Hierarchy ordinals live in the taxonomy directory — without it the counts
+        // vanish entirely (docs/03-configuration.md).
+        textIndex = new ShaclTextIndexLucene(
+            new ByteBuffersDirectory(), new ByteBuffersDirectory(), config);
+
+        Dataset baseDs = DatasetFactory.create();
+        dataset = TextDatasetFactory.create(baseDs, textIndex, true,
+            new ShaclTextDocProducer(baseDs.asDatasetGraph(), textIndex, mapping));
+        loadData();
+    }
+
+    private static FieldOccurrence pathOccurrence(FieldDef field, Node predicate) {
+        return new FieldOccurrence(field, PathFactory.pathLink(predicate),
+            List.of(List.of(new JoinStep(predicate, false))),
+            Collections.singleton(predicate), null, null, null, SCOPE);
+    }
+
+    /**
+     * doc1 sits wholly inside Holes; doc2 straddles both groupings — the case a cartesian
+     * product over entity-level values gets wrong; doc3 sits wholly inside Geochemistry.
+     */
+    private void loadData() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            Model model = dataset.getDefaultModel();
+            addGrouping(model, BOREHOLE, HOLES);
+            addGrouping(model, DOWNHOLE_ASSAYS, HOLES);
+            addGrouping(model, GEOCHEM_RESULTS, GEOCHEMISTRY);
+
+            addDocument(model, "doc1", BOREHOLE, DOWNHOLE_ASSAYS);
+            addDocument(model, "doc2", BOREHOLE, GEOCHEM_RESULTS);
+            addDocument(model, "doc3", GEOCHEM_RESULTS);
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+    }
+
+    private void addGrouping(Model model, String displayTable, String grouping) {
+        model.add(ResourceFactory.createResource(displayTable),
+            ResourceFactory.createProperty(HAS_GROUPING.getURI()),
+            ResourceFactory.createResource(grouping));
+    }
+
+    private void addDocument(Model model, String id, String... displayTables) {
+        Resource doc = ResourceFactory.createResource(NS + id);
+        model.add(doc, RDF.type, ResourceFactory.createResource(DOCUMENT_CLASS.getURI()));
+        for (String displayTable : displayTables) {
+            model.add(doc, ResourceFactory.createProperty(HAS_DISPLAY_TABLE.getURI()),
+                ResourceFactory.createResource(displayTable));
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (dataset != null) {
+            dataset.close();
+        }
+    }
+
+    private Map<String, Long> topLevel() {
+        return facets(null);
+    }
+
+    private Map<String, Long> drillInto(String grouping) {
+        return facets(new String[] {grouping});
+    }
+
+    private Map<String, Long> facets(String[] drillPath) {
+        Map<String, String[]> drillDown = null;
+        if (drillPath != null) {
+            drillDown = new HashMap<>();
+            drillDown.put(DIM, drillPath);
+        }
+        return toFacetMap(textIndex.getFacetCounts(
+            null, null, Collections.singletonList(DIM), 20, 0, drillDown).get(DIM));
+    }
+
+    private static Map<String, Long> toFacetMap(List<FacetValue> values) {
+        Map<String, Long> map = new HashMap<>();
+        if (values != null) {
+            for (FacetValue value : values) {
+                map.put(value.getValue(), value.getCount());
+            }
+        }
+        return map;
+    }
+
+    @Test
+    public void testSelfBoundLevelGivesTopLevelCounts() {
+        Map<String, Long> values = topLevel();
+        assertEquals(Long.valueOf(2), values.get(HOLES));           // doc1, doc2
+        assertEquals(Long.valueOf(2), values.get(GEOCHEMISTRY));    // doc2, doc3
+    }
+
+    /**
+     * doc2 carries borehole (Holes) and geochem-results (Geochemistry). Reading the two
+     * levels independently from the entity would emit {@code Holes / geochem-results} and
+     * {@code Geochemistry / borehole}; per child record, neither can arise.
+     */
+    @Test
+    public void testDrillDownStaysCorrelatedPerChild() {
+        Map<String, Long> holes = drillInto(HOLES);
+        assertEquals(Long.valueOf(2), holes.get(BOREHOLE));         // doc1, doc2
+        assertEquals(Long.valueOf(1), holes.get(DOWNHOLE_ASSAYS));  // doc1
+        assertFalse("geochem-results is not in the Holes grouping",
+            holes.containsKey(GEOCHEM_RESULTS));
+
+        Map<String, Long> geochemistry = drillInto(GEOCHEMISTRY);
+        assertEquals(Long.valueOf(2), geochemistry.get(GEOCHEM_RESULTS));
+        assertFalse("borehole is not in the Geochemistry grouping",
+            geochemistry.containsKey(BOREHOLE));
+    }
+
+    /** Geochemistry holds one datatype, so its children cannot out-count it. */
+    @Test
+    public void testChildrenDoNotExceedParent() {
+        long parent = topLevel().get(GEOCHEMISTRY);
+        long children = drillInto(GEOCHEMISTRY).values().stream().mapToLong(Long::longValue).sum();
+        assertTrue("Geochemistry children (" + children + ") exceed parent count (" + parent + ")",
+            children <= parent);
+    }
+
+    /**
+     * A self-bound field is an ordinary child-scope field, not facet machinery: it takes
+     * part in same-child correlation like any sibling value.
+     */
+    @Test
+    public void testSelfBoundFieldCorrelatesWithSiblingInSameChild() {
+        assertEquals("both documents carrying borehole have it inside Holes",
+            Set.of(NS + "doc1", NS + "doc2"), matchingEntities(BOREHOLE, HOLES));
+        assertTrue("no document has borehole inside Geochemistry on one child",
+            matchingEntities(BOREHOLE, GEOCHEMISTRY).isEmpty());
+    }
+
+    private Set<String> matchingEntities(String displayTable, String grouping) {
+        CqlExpression cql = CqlParser.parse("""
+            {"op":"and","args":[
+              {"op":"=","args":[{"property":"%sdisplayTable"},"%s"]},
+              {"op":"=","args":[{"property":"%sgrouping"},"%s"]}
+            ]}""".formatted(FIELD_NS, displayTable, FIELD_NS, grouping));
+
+        Set<String> uris = new HashSet<>();
+        for (TextHit hit : textIndex.queryWithCql(null, null, cql, null, null, null, 20, null)) {
+            uris.add(hit.getNode().getURI());
+        }
+        return uris;
+    }
+
+    /** A vocabulary edit — not a change on the entity — reindexes the affected entities. */
+    @Test
+    public void testGroupingVocabularyChangeReindexesEntities() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            addGrouping(dataset.getDefaultModel(), GEOCHEM_RESULTS, HOLES);
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+
+        Map<String, Long> holes = drillInto(HOLES);
+        assertEquals("geochem-results now also sits under Holes",
+            Long.valueOf(2), holes.get(GEOCHEM_RESULTS));
+        assertEquals(Long.valueOf(2), holes.get(BOREHOLE));
+        assertEquals("and is still under Geochemistry",
+            Long.valueOf(2), drillInto(GEOCHEMISTRY).get(GEOCHEM_RESULTS));
+    }
+
+    /** Adding a display table to an entity reindexes it through the join predicate. */
+    @Test
+    public void testAddingChildReindexesEntity() {
+        dataset.begin(ReadWrite.WRITE);
+        try {
+            dataset.getDefaultModel().add(
+                ResourceFactory.createResource(NS + "doc3"),
+                ResourceFactory.createProperty(HAS_DISPLAY_TABLE.getURI()),
+                ResourceFactory.createResource(DOWNHOLE_ASSAYS));
+            dataset.commit();
+        } finally {
+            dataset.end();
+        }
+
+        assertEquals("doc3 joins doc1 and doc2 under Holes",
+            Long.valueOf(3), topLevel().get(HOLES));
+        assertEquals("downhole-assays is now on doc1 and doc3",
+            Long.valueOf(2), drillInto(HOLES).get(DOWNHOLE_ASSAYS));
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestSelfOccurrenceAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestSelfOccurrenceAssembler.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.query.text.assembler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.exceptions.AssemblerException;
+import org.apache.jena.query.text.ShaclIndexMapping.FieldOccurrence;
+import org.apache.jena.query.text.ShaclIndexMapping.IndexProfile;
+import org.apache.jena.query.text.ShaclTextIndexLucene;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.Test;
+
+/**
+ * Parsing and validation of {@code idx:self} — an occurrence bound to the focus node
+ * rather than to a path from it.
+ *
+ * @see org.apache.jena.query.text.TestSelfBoundOccurrences for the behaviour it produces
+ */
+public class TestSelfOccurrenceAssembler {
+
+    private static final String SH = "http://www.w3.org/ns/shacl#";
+    private static final String EX = "http://example.org/";
+    private static final String FIELD_NS = "urn:jena:lucene:field#";
+
+    static {
+        JenaSystem.init();
+        TextAssembler.init();
+    }
+
+    private Resource field(Model model, String name, Resource type) {
+        return model.createResource(FIELD_NS + name)
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldName"), name)
+            .addProperty(model.createProperty(IndexVocab.NS, "fieldType"), type)
+            .addProperty(model.createProperty(IndexVocab.NS, "facetable"), model.createTypedLiteral(true));
+    }
+
+    private Resource selfOccurrence(Model model, Resource field) {
+        return model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "field"), field)
+            .addProperty(model.createProperty(IndexVocab.NS, "self"), model.createTypedLiteral(true));
+    }
+
+    private Resource pathOccurrence(Model model, Resource field, RDFNode path) {
+        return model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "field"), field)
+            .addProperty(model.createProperty(SH, "path"), path);
+    }
+
+    /** A nested block joined on {@code ex:hasDisplayTable}, with the given occurrences. */
+    private Resource nested(Model model, Resource... occurrences) {
+        Resource nested = model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "joinPath"),
+                model.createResource(EX + "hasDisplayTable"));
+        for (Resource occurrence : occurrences) {
+            nested.addProperty(model.createProperty(IndexVocab.NS, "property"), occurrence);
+        }
+        return nested;
+    }
+
+    private Resource indexSpec(Model model, Resource shape) {
+        return model.createResource(EX + "index")
+            .addProperty(RDF.type, TextVocab.textIndexShacl)
+            .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
+            .addProperty(TextVocab.pShapes, model.createList(new RDFNode[] { shape }));
+    }
+
+    private Resource shape(Model model) {
+        return model.createResource(EX + "DocumentShape")
+            .addProperty(model.createProperty(SH, "targetClass"), model.createResource(EX + "Document"));
+    }
+
+    private AssemblerException openExpectingFailure(Model model, Resource shape) {
+        return assertThrows(AssemblerException.class,
+            () -> Assembler.general().open(indexSpec(model, shape)));
+    }
+
+    @Test
+    public void testSelfOccurrenceInNestedBlockParses() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource displayTable = field(model, "displayTable", IndexVocab.KeywordField);
+        Resource grouping = field(model, "grouping", IndexVocab.KeywordField);
+
+        Resource shape = shape(model).addProperty(model.createProperty(IndexVocab.NS, "nested"),
+            nested(model,
+                selfOccurrence(model, displayTable),
+                pathOccurrence(model, grouping, model.createResource(EX + "hasGrouping"))));
+
+        ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec(model, shape));
+        try {
+            IndexProfile profile = index.getShaclMapping().getProfiles().get(0);
+            assertEquals(1, profile.getNestedDefs().size());
+
+            FieldOccurrence self = profile.getNestedDefs().get(0).getOccurrences().stream()
+                .filter(o -> o.getField().getFieldName().equals("displayTable"))
+                .findFirst().orElseThrow();
+
+            assertTrue("occurrence is self-bound", self.isSelf());
+            assertEquals("a self occurrence has no path", null, self.getPath());
+            assertTrue("and contributes no predicates to change tracking",
+                self.getPredicates().isEmpty());
+        } finally {
+            index.close();
+        }
+    }
+
+    /** At root scope the focus node is the entity itself. */
+    @Test
+    public void testSelfOccurrenceAtRootParses() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource entityIri = field(model, "entityIri", IndexVocab.KeywordField);
+
+        Resource shape = shape(model)
+            .addProperty(model.createProperty(SH, "property"), selfOccurrence(model, entityIri));
+
+        ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec(model, shape));
+        try {
+            IndexProfile profile = index.getShaclMapping().getProfiles().get(0);
+            assertTrue(profile.getRootOccurrences().get(0).isSelf());
+        } finally {
+            index.close();
+        }
+    }
+
+    @Test
+    public void testSelfAndPathTogetherIsRejected() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource displayTable = field(model, "displayTable", IndexVocab.KeywordField);
+
+        Resource occurrence = selfOccurrence(model, displayTable)
+            .addProperty(model.createProperty(SH, "path"), model.createResource(EX + "hasGrouping"));
+        Resource shape = shape(model)
+            .addProperty(model.createProperty(IndexVocab.NS, "nested"), nested(model, occurrence));
+
+        assertTrue(openExpectingFailure(model, shape).getMessage()
+            .contains("has both idx:self and sh:path"));
+    }
+
+    @Test
+    public void testOccurrenceWithNeitherSelfNorPathIsRejected() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource displayTable = field(model, "displayTable", IndexVocab.KeywordField);
+
+        Resource occurrence = model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "field"), displayTable);
+        Resource shape = shape(model)
+            .addProperty(model.createProperty(IndexVocab.NS, "nested"), nested(model, occurrence));
+
+        assertTrue(openExpectingFailure(model, shape).getMessage()
+            .contains("is missing sh:path (or idx:self)"));
+    }
+
+    /** {@code idx:self false} is a mistake, not a way to say "no self binding". */
+    @Test
+    public void testSelfFalseIsRejected() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource displayTable = field(model, "displayTable", IndexVocab.KeywordField);
+
+        Resource occurrence = model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "field"), displayTable)
+            .addProperty(model.createProperty(IndexVocab.NS, "self"), model.createTypedLiteral(false));
+        Resource shape = shape(model)
+            .addProperty(model.createProperty(IndexVocab.NS, "nested"), nested(model, occurrence));
+
+        assertTrue(openExpectingFailure(model, shape).getMessage().contains("idx:self on"));
+    }
+
+    /** A focus node is a resource, so a numeric field has nothing to bind. */
+    @Test
+    public void testSelfOnNumericFieldIsRejected() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource count = field(model, "count", IndexVocab.IntField);
+
+        Resource shape = shape(model)
+            .addProperty(model.createProperty(IndexVocab.NS, "nested"),
+                nested(model, selfOccurrence(model, count)));
+
+        String message = openExpectingFailure(model, shape).getMessage();
+        assertTrue(message.contains("idx:self"));
+        assertTrue(message.contains("INT"));
+    }
+
+    /** An external child is a row, so there is no focus node to bind. */
+    @Test
+    public void testSelfOnExternalColumnIsRejected() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource analyte = field(model, "analyte", IndexVocab.KeywordField);
+
+        Resource column = model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "field"), analyte)
+            .addProperty(model.createProperty(IndexVocab.NS, "columnName"), "analyte")
+            .addProperty(model.createProperty(IndexVocab.NS, "self"), model.createTypedLiteral(true));
+
+        Resource source = model.createResource()
+            .addProperty(model.createProperty(IndexVocab.NS, "format"),
+                model.createResource(IndexVocab.NS + "CsvFile"))
+            .addProperty(model.createProperty(IndexVocab.NS, "location"), "assays.csv")
+            .addProperty(model.createProperty(IndexVocab.NS, "subjectColumn"), "hole")
+            .addProperty(model.createProperty(IndexVocab.NS, "column"), column);
+
+        Resource shape = shape(model)
+            .addProperty(model.createProperty(IndexVocab.NS, "nested"),
+                model.createResource()
+                    .addProperty(model.createProperty(IndexVocab.NS, "nestedName"), "assays")
+                    .addProperty(model.createProperty(IndexVocab.NS, "externalSource"), source));
+
+        assertTrue(openExpectingFailure(model, shape).getMessage()
+            .contains("must not carry idx:self"));
+    }
+
+    /** A path occurrence is unaffected by any of this. */
+    @Test
+    public void testPathOccurrenceIsNotSelfBound() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource grouping = field(model, "grouping", IndexVocab.KeywordField);
+
+        Resource shape = shape(model).addProperty(model.createProperty(SH, "property"),
+            pathOccurrence(model, grouping, model.createResource(EX + "hasGrouping")));
+
+        ShaclTextIndexLucene index = (ShaclTextIndexLucene) Assembler.general().open(indexSpec(model, shape));
+        try {
+            assertFalse(index.getShaclMapping().getProfiles().get(0)
+                .getRootOccurrences().get(0).isSelf());
+        } finally {
+            index.close();
+        }
+    }
+}


### PR DESCRIPTION
Closes #147. Supersedes #148.

## The gap

An `idx:facetHierarchy` inside an `idx:nested` block builds its facet paths **per child record**, so its levels stay pairwise correlated. That is the correct mechanism whenever a hierarchy's levels are related rather than independent — but it was unreachable whenever one of the levels **is** the correlating node.

Every `idx:property` in a nested block is evaluated as a path *from* the child, and there was no way to express "the child node itself" — no identity path in SHACL, and the workarounds people reach for (`sh:path [ sh:inversePath rdf:type ]` and friends) only work by accident of the data.

So a taxonomy attached to a *term* — an entity references a term, the term belongs to a grouping — could only be declared as two independent root fields, which cross-produce:

```text
Holes / borehole                  ✓ in the data
Holes / geochem-results           ✗ invented
Geochemistry / borehole           ✗ invented
Geochemistry / geochem-results    ✓ in the data
```

Drilling into a grouping then offers terms that are not in it, and the children out-count the parent.

## The change

`idx:self true` binds the **focus node**: the child node inside an `idx:nested` block, the entity at root scope.

```turtle
idx:nested [
    idx:joinPath ex:hasDisplayTable ;
    idx:property [ idx:field field:displayTable ; idx:self true ] ;
    idx:property [ idx:field field:grouping     ; sh:path ex:hasGrouping ] ;
    idx:facetHierarchy ( field:grouping field:displayTable ) ;
] ;
```

That is the whole feature. Nothing else moved — the nested hierarchy builder, the facet code and the block-join query path were already correct, just unreachable for this shape. It is not facet machinery either: a self-bound field is an ordinary child-scope field that filters same-child with its siblings like any other value.

| Piece | Change |
|---|---|
| `IndexVocab` | `idx:self` |
| `FieldOccurrence` | `self(...)` factory — null path, one zero-step path variant, no predicates; `isSelf()` |
| `ShaclIndexAssembler` | Parse + validation |
| `ShaclEntityBuilder` | Self occurrences take the focus node, constraints applied to it |
| `ShaclTextDocProducer` | Reverse-walking an identity path from a node arrives at that node |

## Design notes

**Why not correlate the root hierarchy instead** (#148, built then discarded): it inferred correlation from whether one level's path extended another's. That is a *second* mechanism for a semantic `idx:nested` already models, it is implicit — nothing in the config says the hierarchy is correlated — and its fallbacks are silent, since fan-in or an alternative path drops back to the cartesian product with only a log line. Correctness became a property of how the paths happened to be written.

**Scope still determines behaviour.** A child-scoped field filters same-child and is not an entity-level flat facet. Wanting both from one field IRI is wanting two behaviours from one declaration; that remains two fields with two names, which states in the config what is actually being asked for.

**Validation.** `idx:self` replaces `sh:path` rather than accompanying it (both, or neither, is an error). `idx:self false` is rejected rather than read as "no self binding". A focus node is a resource, so the field must be `KEYWORD` or `TEXT` — numeric and temporal types are refused at config time instead of producing empty fields. It is refused on an `idx:column`, where the child is a row and there is no node to bind. Blank nodes yield no value: their labels do not survive a reload, so there is nothing meaningful to index.

**No new change tracking.** A self occurrence contributes no predicates, which is correct — its value cannot change unless the entity or the join reaching it changes, and both are already tracked. Two tests pin this (a vocabulary edit, and a child added to an entity).

## Tests

806 pass (was 790), full build with RAT.

Written **red first**: with the builder's self branch removed, all six behaviour tests fail on the null path (first commit).

- `TestSelfBoundOccurrences` (6) — top-level counts, drill-down correlated per child, children not out-counting the parent, same-child correlation with a sibling, vocabulary-edit reindex, child-added reindex.
- `TestSelfOccurrenceAssembler` (8) — parses in a nested block and at root; rejects self+path, neither, `idx:self false`, a numeric field, and `idx:column`.

Both registered in `TS_Text`.

Docs: `idx:self` in the occurrence-properties table with an "Indexing the focus node" section, a new "Pattern 4 — Hierarchy whose level is the child node" alongside the existing nested patterns, rules and vocabulary index updated, and the decision recorded in `docs/2026-08-03_correlated_hierarchy_over_root_fields.md`.