### PR TITLE
Enable the Vector API for the loader's text indexer, and record the vector search design

### DIFF
--- a/build-files/docker/loader-entrypoint.sh
+++ b/build-files/docker/loader-entrypoint.sh
@@ -12,13 +12,31 @@ NO_STATS="${NO_STATS:-}"
 THREADS="${THREADS:-$(($(nproc) > 1 ? $(nproc) - 1 : 1))}"
 JAVA_OPTS="${JAVA_OPTS:-}"
 
+# Lucene uses the Panama Vector API to SIMD-accelerate vector distance
+# computations. The runtime image enables it in its ENTRYPOINT; without the same
+# flags here the index builder runs unaccelerated.
+#
+# Applied to the text indexer only, and deliberately NOT folded into JAVA_OPTS.
+# Enabling an incubator module makes the JVM print
+#   WARNING: Using incubator modules: jdk.incubator.vector
+# to stderr at startup. The SPARQL commands below merge stderr into stdout and
+# read the result with `awk NR==2`, so applying these flags to them would shift
+# every parsed value by one line and silently yield the TSV header instead of
+# the path. Keeping them out of JAVA_OPTS also means a caller overriding
+# JAVA_OPTS (for heap, say) cannot drop them by accident.
+#
+# Set JAVA_VECTOR_OPTS="" to disable.
+if [ -z "${JAVA_VECTOR_OPTS+set}" ]; then
+  JAVA_VECTOR_OPTS="--enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector"
+fi
+
 # Define all Jena command variables
 SPARQL_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar arq.sparql"
 RIOT_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar riotcmd.riot"
 TDB2_LOADER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar tdb2.tdbloader"
 TDB2_XLOADER_CMD="JVM_ARGS=\"${JAVA_OPTS}\" /fuseki/apache-jena/bin/tdb2.xloader"
 TDB2_STATS_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar tdb2.tdbstats"
-TEXT_INDEXER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.query.text.cmd.shacltextindexer"
+TEXT_INDEXER_CMD="java $JAVA_VECTOR_OPTS $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.query.text.cmd.shacltextindexer"
 SPATIAL_INDEXER_CMD="java $JAVA_OPTS -cp /fuseki/jena-fuseki-server.jar org.apache.jena.geosparql.spatial.cmd.SpatialIndexBuilder"
 
 echo "=== Loader Configuration ==="
@@ -30,6 +48,7 @@ echo "NO_VALIDATION: ${NO_VALIDATION:-false}"
 echo "TDB2_MODE: $TDB2_MODE"
 echo "THREADS: $THREADS (default: nproc-1)"
 echo "NO_STATS: ${NO_STATS:-false}"
+echo "JAVA_VECTOR_OPTS: ${JAVA_VECTOR_OPTS:-<none>}"
 echo "==========================="
 
 # Early failure checks

--- a/docs/2026-08-05_vector_search_and_embeddings_design.md
+++ b/docs/2026-08-05_vector_search_and_embeddings_design.md
@@ -1,0 +1,373 @@
+---
+title: "vector search and embeddings"
+date: "2026-08-05"
+---
+
+# 2026-08-05 Vector Search and Embeddings
+
+## Status
+
+**Designed, not built.** Nothing in this note is implemented. No `VECTOR` field type
+exists, no vector is written to any Lucene document, and there is no embedding code in
+the tree.
+
+Two prerequisites *are* already in place and were verified while writing this note (see
+[Vector API state](#vector-api-state)). A third — the loader image running without the
+Vector API — was found while writing it and **is fixed** in the same change as this note;
+that gap would have blocked the chosen engine.
+
+The decision recorded here is **Jlama as the embedding engine**, with ONNX Runtime via
+LangChain4j as the documented fallback if Jlama does not hold up. The reasoning is in
+[Engine choice](#engine-choice) and the fallback is deliberately kept cheap by putting
+both behind one interface.
+
+## Summary
+
+Add entity-level dense vectors to the SHACL entity-per-document index, so a Lucene KNN
+query can be combined with the existing SHACL-typed filters and facet counts in a single
+SPARQL query.
+
+The differentiating claim is not "we have embeddings". It is:
+
+> semantic search, filtered by typed structured constraints, with facet counts, in one
+> SPARQL query
+
+Standalone vector databases are weak at the filtering and facet half of that. pgvector is
+weak at the filtering half specifically (see [Prior art](#prior-art-what-the-pgvector-ecosystem-settled-on)).
+Lucene pushes the filter into the HNSW traversal, and this repo already has the SHACL
+typing and the facet engine. That combination is the reason to build this here rather
+than bolt a vector store alongside.
+
+## What the vector represents
+
+**An entity, not a triple.**
+
+SHACL mode is entity-per-document, so there is exactly one natural place for a
+`KnnFloatVectorField`: alongside the existing TEXT/KEYWORD/INT/LONG/DOUBLE/TEMPORAL/LATLON
+fields on the entity document. A triple-level vector has nowhere to live in that model,
+and in classic triple-per-document mode it would be both unwieldy and useless for
+faceting.
+
+### Rejected: graph2vec
+
+graph2vec (Narayanan et al., 2017) is a doc2vec analogue where the *document* is an entire
+graph and the *words* are rooted Weisfeiler–Lehman subtree patterns. It was built for graph
+*classification* over datasets of many small graphs — molecules, program dependency graphs.
+Applied to an RDF store it produces **one vector for the whole dataset**. That is not a
+search feature. The name misleads; people reaching for it usually mean node embeddings.
+
+### Rejected: structural embeddings generally
+
+RDF2Vec, node2vec, TransE/ComplEx/RotatE, R-GCN/CompGCN. These embed entities by graph
+position, and fail here for two independent reasons:
+
+**No query-side encoder.** A user types a search string. That string is not an entity in
+the graph, so nothing maps it into the embedding space. Structural embeddings support
+*"more like this entity"* — item-to-item navigation — and never free-text search.
+
+**No incremental update story.** They are globally trained. One added triple in principle
+perturbs the entire space, and new entities are out-of-vocabulary until retraining. That
+is an offline batch artifact, incompatible with a live change listener.
+
+They remain plausible later as a reranking signal or a related-entities feature. Not v1.
+
+### Chosen: text embeddings of verbalised entities
+
+Verbalise the entity from its SHACL-declared properties, embed the text. Query and
+document land in the same space, so free-text semantic search works, and per-entity
+re-embedding on change is tractable.
+
+## What exists today
+
+| Surface | State |
+|---|---|
+| Lucene version | **10.3.1** (`ver.lucene`, root pom). Filtered KNN, HNSW, scalar quantization all available |
+| `FieldType` enum | `TEXT, KEYWORD, INT, LONG, DOUBLE, TEMPORAL, LATLON` — no `VECTOR` (`ShaclIndexMapping.java:42`) |
+| Field construction | `addNodeFieldToDoc` / `addFieldToDoc` switch on `FieldType` (`ShaclTextIndexLucene.java:1152`, `:1264`) — the single insertion point |
+| External row sources | `ExternalRowSource` / `CsvRowSource` already key rows by subject IRI with an optional prefix (`CsvRowSource.java:215-220`) |
+| Embedding code | None |
+| Vector field | None |
+
+The external row source finding matters: a CSV of *document IRI → embedding* is already
+the exact shape `CsvRowSource` produces. The only missing piece on the document side is a
+field type for the binding to land in.
+
+### Vector API state
+
+Verified 2026-08-05 by running the JDK launcher directly.
+
+| Context | `jdk.incubator.vector` | Where |
+|---|---|---|
+| Runtime Docker image | **Enabled** | `build-files/docker/Dockerfile:105` ENTRYPOINT |
+| `jena-text` tests | **Enabled** | auto-activating profile, JDK 21–25 (`jena-text/pom.xml:36-43`) |
+| Loader Docker image | **Enabled 2026-08-05** for the text indexer only | `loader-entrypoint.sh` — was off; see [Prerequisites](#prerequisites) for why it is not blanket |
+| Documented local run | **Not enabled** | CLAUDE.md's `java -jar ...` has no flags |
+
+Two notes on reading this:
+
+The startup warning `WARNING: Using incubator modules: jdk.incubator.vector` means the
+module **is** enabled. It is the opposite of Lucene's `Java vector incubator module is not
+readable...` warning. They are easy to confuse and mean opposite things.
+
+The runtime ENTRYPOINT places `--add-modules` *after* `-jar`, which looks wrong. It was
+tested and works — the launcher accepts VM options there and takes the first non-option
+argument as the jar. Do not "fix" it.
+
+## Prerequisites
+
+**The loader must get the Vector API flags.** `loader-entrypoint.sh` builds every command
+from `JAVA_OPTS`, which defaults to empty — including `shacltextindexer` (line 21), the
+actual index builder. Today the cost is modest. With KNN it is large, because HNSW *graph
+construction* is dominated by distance computations and happens in the indexer, not the
+server. For Jlama it is disqualifying: Jlama's entire performance model is the Vector API.
+
+**Fixed 2026-08-05**, but not the obvious way. Defaulting `JAVA_OPTS` to carry the flags —
+the first thing tried — breaks the loader.
+
+Enabling an incubator module makes the JVM print `WARNING: Using incubator modules:
+jdk.incubator.vector` to **stderr at startup**. The location-discovery commands merge
+stderr into stdout and parse the result positionally:
+
+```sh
+tdb2_result_and_status="$($SPARQL_CMD --query="$TDB2_QUERY" ... --results=tsv 2>&1)"
+TDB2_LOCATION=$(echo "$tdb2_result_and_status" | awk 'NR==2 {print $1}')
+```
+
+The warning lands on line 1, so `NR==2` returns the TSV *header* rather than the path.
+`TDB2_LOCATION`, `TEXT_INDEX_LOCATION`, `SPATIAL_INDEX_LOCATION` and `SRS_URI` (lines 94,
+104, 114, 124) would all silently become `?tdb2Location`-style garbage.
+
+The applied fix instead introduces a separate `JAVA_VECTOR_OPTS`, applied **only** to
+`TEXT_INDEXER_CMD`. Keeping it out of `JAVA_OPTS` has a second benefit: a caller
+overriding `JAVA_OPTS` for heap cannot accidentally drop the flags.
+
+The general rule this establishes: **any future JVM flag that emits a startup warning must
+not be applied to the SPARQL discovery commands in this script.**
+
+**The documented local run command should carry the same flags.** Otherwise local dev has
+the Vector API off while production has it on, and KNN benchmarks taken locally will be
+much worse for reasons unrelated to the code.
+
+## Delivery tiers
+
+Deliberately separable. Each is useful alone.
+
+### Tier 0 — bring your own vectors
+
+Embeddings produced entirely outside Jena; Jena stores and searches them.
+
+- `FieldType` gains `VECTOR`
+- one `case VECTOR ->` in `addNodeFieldToDoc` writing `KnnFloatVectorField`, parsing
+  base64 float32 or comma-separated floats
+- query side accepts a vector parameter and builds
+  `KnnFloatVectorQuery(field, target, k, existingFilterQuery)`, reusing the filter already
+  constructed
+- one assembler term declaring the field, its dimension, and its similarity function
+
+Vectors arrive either as triples in the graph (free ride on the change listener, but ~3KB
+raw / ~4KB base64 per entity of opaque machine noise in TDB2) or via the existing
+`external/` row sources (better fit, already built).
+
+**The entire differentiated pitch lands here.** Filtered KNN + SHACL constraints + facets
+needs no embedding model in-process. Two features are fully covered at Tier 0 with no
+encoder at all:
+
+- **"More like this"** — the query is an entity IRI, which is a key in the map. Look up its
+  vector, KNN against the rest, filter, facet.
+- **Fixed canonical query sets** — saved searches, category landing pages. Precompute and
+  ship in the same CSV keyed by a pseudo-IRI.
+
+### Tier 1 — query-time embedding
+
+So a user can type words instead of 384 floats. This is the only thing a CSV cannot cover,
+by construction: a CSV maps *known IRIs* to vectors, and a search string is neither known
+nor an IRI.
+
+Three places the encoder can live: the client (Jena makes no call, holds no credentials —
+but a bare SPARQL client can no longer do semantic search unaided), an in-process engine
+(chosen — see below), or an HTTP provider (rejected as a default; network on the query
+path and credentials in assembler config).
+
+### Tier 2 — document embedding inside Fuseki
+
+Verbalise and embed on change. This puts inference inside `ShaclTextDocProducer`'s commit
+path and needs an async queue plus a stale-vector marker.
+
+**Deferred.** The loader should own document embedding. See
+[Prior art](#prior-art-what-the-pgvector-ecosystem-settled-on) — everyone who built
+in-database embedding either made it async via a background worker or required a custom
+build, and Postgres had a mature background-worker ecosystem to hang it off. Fuseki does
+not, so this is more expensive here than there.
+
+## Engine choice
+
+**Jlama**, with ONNX Runtime via LangChain4j as the fallback.
+
+| | Jlama | LangChain4j bundled ONNX | DJL | HTTP provider |
+|---|---|---|---|---|
+| Native libs | **None** — pure Java, Vector API | ONNX Runtime natives per platform | Heavy (PyTorch engine) | None |
+| Model delivery | Fetched/converted, mounted or baked | **Inside the jar** (~25MB) | Downloaded at runtime | Remote |
+| arm64 | Free | Needs the right classifier | Varies | Free |
+| Offline | Yes, once the model is present | Yes | After first fetch | No |
+| Maturity | Younger; embeddings secondary to LLM inference | Mature | Mature | Mature |
+| Vector API | **Required** | Optional | Optional | N/A |
+
+Jlama wins on the property that matters most for this repo's deployment story: **no native
+libraries**, which keeps the UBI image clean and makes arm64 free. The incubator flag it
+requires is already being passed in the runtime image, so that friction is largely
+pre-paid — once the loader gap above is closed.
+
+What it costs, honestly:
+
+- **Vector API is not optional for it.** Hard dependency, hence the prerequisite.
+- **Models are not in the jar.** Jlama fetches from HuggingFace and uses its own quantized
+  format, so there is a download-and-convert step. This is what LangChain4j's bundled ONNX
+  models buy that Jlama does not — and it is why the deployment model below exists.
+- **Younger project.** Verify current embedding-model coverage and Maven coordinates
+  (`com.github.tjake:jlama-*`) before committing. Confirm whether the target version needs
+  any flags beyond `--add-modules jdk.incubator.vector`.
+
+`langchain4j-jlama` exists, so both engines can sit behind one interface and the fallback
+stays a dependency swap.
+
+### Module layout
+
+```
+jena-text              → EmbeddingProvider interface only, zero new dependencies
+jena-text-embeddings   → Jlama (and/or ONNX) implementations, opt-in dependency
+```
+
+Keeping implementations out of `jena-text` matters beyond tidiness. This fork intends
+eventual contribution back to Apache, and a model binary or an ML runtime as a default
+dependency is exactly what Apache legal scrutinises. An opt-in module is a footnote; a
+default dependency is an argument.
+
+Note the module list appears in **both** the `-Pdev` and `-Pcomplete` profiles
+(`pom.xml:219` and `:277`). CLAUDE.md flags module lists as a recurring upstream-merge
+conflict site — add to both.
+
+## Deployment model
+
+The intended pattern is a derived image. Users pick their model, bake it into a layer on
+top of the published Jena image, and configure the path.
+
+**Publish the model as its own image**, so the fetch-and-convert step runs once and is
+shared:
+
+```dockerfile
+# built once, per model
+FROM scratch
+COPY bge-small-en-v1.5-q4/ /models/bge-small-en-v1.5-q4/
+```
+
+**Derive both Jena images from it.** This is the part that is easy to get wrong: the
+`loader` target is `FROM runtime`, and *both* need the model — the loader to embed
+documents, the runtime to embed queries. Two derived images, one model artifact:
+
+```dockerfile
+FROM ghcr.io/kurrawong/fuseki-lucene-shacl:sha-abc1234
+COPY --from=myorg/embed-model:bge-small-q4 /models /models
+ENV JENA_EMBEDDING_MODEL_PATH=/models/bge-small-en-v1.5-q4
+```
+
+```dockerfile
+FROM ghcr.io/kurrawong/fuseki-lucene-shacl-loader:sha-abc1234
+COPY --from=myorg/embed-model:bge-small-q4 /models /models
+ENV JENA_EMBEDDING_MODEL_PATH=/models/bge-small-en-v1.5-q4
+```
+
+Pin the base by `sha-<short>`, per the existing immutable-tag policy in CLAUDE.md.
+
+**Mounting is the dev alternative** — `-v ./models:/models`, or a PVC / initContainer under
+Kubernetes. More flexible, less reproducible. Support both by reading a path from config;
+document the baked derived image as the default because it matches the repo's existing
+immutable-provenance philosophy.
+
+**We should eventually publish a default model image ourselves** so the common case is one
+`FROM` line. Note that shipping a model in a *Docker image* rather than a *Maven artifact*
+neatly sidesteps the Apache bundling concern — the source release contains no model
+binary. That is a further point in favour of this deployment shape over the bundled-jar
+approach.
+
+## Model identity is a correctness boundary
+
+Index-time and query-time models must match. A mismatch does not error — it returns
+plausible-looking garbage. With embeddings generated in two separately-owned places (a
+loader image and a runtime image, each independently rebuildable) this *will* eventually
+happen.
+
+Record the model identifier and dimension in the index metadata at build time, and fail
+loudly at startup on mismatch. Lucene fixes dimension and similarity function per field at
+index time anyway, so changing model means a full reindex regardless — the check just makes
+that explicit rather than silent.
+
+## Facet semantics change under KNN
+
+`luc:facet` today counts over the **full** matching set. A KNN query returns top-k by
+construction; there is no "all matching documents". So facet counts over a vector query
+become counts within top-k.
+
+This is a different contract from the one the current documentation promises, and needs an
+explicit decision plus explicit documentation. The likely resolution: facets are exact for
+boolean/filter queries, top-k-scoped for KNN, and hybrid queries inherit the KNN semantics.
+
+## Hybrid retrieval
+
+Worth noting separately because it needs **no** embedding work at all beyond Tier 0: fusing
+the existing BM25 scoring with dense KNN via reciprocal rank fusion is roughly thirty lines
+(Lucene provides no RRF out of the box). That is likely the largest single retrieval-quality
+win available, and it is independent of every decision above.
+
+## Resource notes
+
+- 384-dim float32 is ~1.5KB/doc — comfortably under Lucene's 1024 default dimension cap
+  (raising the cap needs a custom `KnnVectorsFormat`; confirm the exact constant on 10.3.1
+  before choosing a larger model). Scalar/binary quantization is available and wanted.
+- HNSW wants the graph resident for good latency; segment merges rebuild it.
+- Query-side inference on a short string is single-digit milliseconds — a non-issue. Bulk
+  indexing is where cost lands: thousands of entities × forward pass, competing with Lucene
+  for CPU. Bound inference thread counts or it will fight the indexer for cores.
+- Cold start: first embed initialises the model. Warm it at assembler init, not on the
+  first user query.
+
+## Prior art: what the pgvector ecosystem settled on
+
+Useful because it is the largest comparable ecosystem and it resolved the same questions.
+
+**pgvector core holds exactly Lucene's position** — storage, index, distance operators, no
+embedding function, ever. The overwhelming majority of deployments have the application
+embed and pass vectors in. That is Tier 0, and it is the default by weight of practice.
+
+**The in-database layer that grew on top is instructive in its shape.** pgai (Timescale)
+uses a *background worker* keeping an embedding table in sync — explicitly not a
+synchronous trigger. pg_vectorize runs local sentence-transformers via a *sidecar*.
+PostgresML runs models in-process and consequently requires a *custom Postgres build* you
+cannot install on managed RDS. Aurora's `aws_ml` and AlloyDB's `embedding()` are HTTP calls
+wearing a SQL costume.
+
+Nobody does synchronous in-transaction embedding. That is the direct support for deferring
+Tier 2.
+
+**Where the comparison favours this design:** filtered vector search is pgvector's known
+sore spot — HNSW plus a `WHERE` clause forces a choice between pre-filtering and
+post-filtering, the latter able to return fewer than k rows. Iterative index scans (0.8)
+mitigate rather than solve it. And Postgres has no facet engine at all; you hand-roll
+`GROUP BY` per query with no shared machinery.
+
+## Open questions
+
+- Which verbalisation? Which SHACL-declared properties feed the embedded text, in what
+  order, and is that a per-shape config term or a convention?
+- Does `luc:query` gain a vector argument, or is there a separate `luc:knn`? The hybrid/RRF
+  case argues for extending `luc:query`.
+- Does the CSV/external-source path carry vectors as base64 or as comma-separated floats?
+  Base64 float32 is roughly half the bytes and parses faster; 768 comma-separated floats is
+  ~8KB of text per row, which matters at millions of entities.
+- Confirm Jlama's current embedding-model coverage, Maven coordinates, licence, and
+  required JVM flags before committing to it.
+
+## Related
+
+- [2026-07-27_external_content_indexing_design.md](2026-07-27_external_content_indexing_design.md)
+  — the external row source machinery a vector sidecar would reuse
+- [04-architecture.md](04-architecture.md) — entity-per-document model

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This doc set covers the SHACL/entity-per-document search model in `jena-text`.
 | External delta endpoint | Designed | NDJSON deltas over HTTP, via opt-in retained rows. Not built — at reduced volume, load the values as RDF instead |
 | Graph scoping model | Designed | Reserved synthetic field `urn:jena:lucene:field#sourceGraph`; implementation deferred |
 | Source graph indexing | Designed | `idx:storeGraph` flag writing multi-valued `sourceGraph`. Not built — `?graph` was removed from `luc:query` instead, since a union-built document has no single source graph |
+| Vector search | Designed | Entity-level dense vectors as a `VECTOR` field, filtered KNN plus facets. Not built — engine choice is Jlama. The loader's missing Vector API flags, a prerequisite, are fixed |
 | Highlight API | Deferred | Reserved for later, not active in the current `luc:query` signature |
 
 ## Core Rules


### PR DESCRIPTION
Two commits: a small loader fix, and a design note for vector search. The fix is a
prerequisite for the design, which is why they travel together.

## The fix

The runtime image enables `jdk.incubator.vector` in its ENTRYPOINT
(`build-files/docker/Dockerfile:105`). The loader did not — `loader-entrypoint.sh`
built every command from a `JAVA_OPTS` that defaults to empty — so `shacltextindexer`
has been building Lucene indexes unaccelerated.

Modest cost today. It matters once vector search lands, because HNSW graph
construction is dominated by distance computations and happens in the indexer rather
than the server, and it is a hard requirement for any pure-Java embedding engine.

### Why it is not applied via `JAVA_OPTS`

The obvious fix breaks the loader. Enabling an incubator module makes the JVM print

```
WARNING: Using incubator modules: jdk.incubator.vector
```

to **stderr at startup**, and the location-discovery commands merge stderr into stdout
and read the result positionally:

```sh
tdb2_result_and_status="$($SPARQL_CMD --query="$TDB2_QUERY" ... --results=tsv 2>&1)"
TDB2_LOCATION=$(echo "$tdb2_result_and_status" | awk 'NR==2 {print $1}')
```

The warning lands on line 1, so `NR==2` returns the TSV header instead of the value.
`TDB2_LOCATION`, `TEXT_INDEX_LOCATION`, `SPATIAL_INDEX_LOCATION` and `SRS_URI` (lines
94, 104, 114, 124) would all silently become `?tdb2Location`-style garbage, and the
loader would then write to a nonsense path.

So the flags live in a separate `JAVA_VECTOR_OPTS`, applied to `TEXT_INDEXER_CMD` only.
Keeping them out of `JAVA_OPTS` also means a caller overriding it for heap cannot drop
them by accident.

### Verified

- `sh -n` passes
- default: text indexer gets the flags, `SPARQL_CMD` does not
- `JAVA_VECTOR_OPTS=""` opts out
- `JAVA_OPTS=-Xmx8G` keeps the flags and appends the heap setting
- the incubator warning confirmed on stderr, line 1, against a real JDK 21 launcher

## The design note

`docs/2026-08-05_vector_search_and_embeddings_design.md`. Designed, not built —
nothing else in it is implemented.

Entity-level dense vectors as a `VECTOR` field, so a Lucene KNN query composes with the
existing SHACL-typed filters and facet counts in one SPARQL query. Decisions recorded:

- the vector represents an **entity**, not a triple — which the entity-per-document
  model already dictates
- **graph2vec is rejected**: it embeds whole graphs, so an RDF store yields one vector
- **structural embeddings are rejected** (RDF2Vec, TransE et al.): no query-side
  encoder, since a search string is not an entity, and no incremental update path
- **Jlama** as the engine, with ONNX via LangChain4j as a documented fallback behind
  one interface
- implementations in an **opt-in module**, so `jena-text` gains no dependency and no
  model binary reaches an eventual Apache source release
- models ship as a **derived Docker image**, deriving both runtime and loader from one
  model layer

Two things flagged as needing a decision before implementation: facet counts change
meaning under KNN, because there is no full match set to count over; and model identity
must be recorded in index metadata, because a mismatch returns plausible garbage rather
than an error.

## Not addressed here

- `loader-entrypoint.sh:19` bakes `JVM_ARGS="${JAVA_OPTS}"` into `TDB2_XLOADER_CMD` at
  definition time, which shadows the `export JVM_ARGS="${JAVA_OPTS:--Xmx4G}"` at line
  273 when the command is eval'd. The xloader's `-Xmx4G` default has likely never
  applied. Left alone because it changes memory behaviour and deserves its own change.
- The local run command documented in CLAUDE.md still has no Vector API flags, so local
  KNN benchmarks will read worse than production.