### PR TITLE
Derive the taxonomy directory default from text:directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ mvn clean install -Drat.skip
 ## Running Tests
 
 ```bash
-# Run all jena-text tests (806 tests)
+# Run all jena-text tests (809 tests)
 mvn test -pl jena-text
 
 # Run a single test class

--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -46,7 +46,6 @@ Notes:
 <#index> a text:TextIndexShacl ;
     text:indexId "default" ;
     text:directory "mem" ;
-    text:taxonomyDirectory <file:Taxonomy> ;
     text:shapes ( <#BookShape> <#ArticleShape> ) ;
     text:storeValues true ;
     text:maxFacetHits 50000 .
@@ -61,13 +60,26 @@ one with `text:entityMap`.
 | `text:indexId` | no | Token id used by `indexSelector`, for example `"default"` or `"objects"` |
 | `text:directory` | yes | Lucene storage location. The literal `"mem"` is in-memory; anything else is a path or file IRI |
 | `text:shapes` | yes | RDF list of SHACL shapes, one document profile each |
-| `text:taxonomyDirectory` | no | Where hierarchical-facet ordinals live. Left unset the taxonomy is in-memory — fine when indexing and querying share a JVM, and a silent total loss of hierarchical facet counts when they do not (a bulk build writes the ordinals, the process exits, the server starts empty) |
+| `text:taxonomyDirectory` | no | Where hierarchical-facet ordinals live. Defaults to a sibling of `text:directory` named `<path>_taxonomy`, or to memory when `text:directory` is `"mem"`. Set it only to put the taxonomy somewhere else |
 | `text:storeValues` | no, default `false` | Store values for `luc:match` and facet value binding |
 | `text:maxFacetHits` | no | Maximum documents considered during facet collection |
 | `text:analyzer` | no | Index-wide default analyzer |
 | `text:queryAnalyzer` | no | Index-wide query analyzer |
 
 If the index resource itself is a URI resource, that URI is also accepted as an `indexSelector`.
+
+### Upgrading: the taxonomy directory
+
+A config that declares hierarchies with `text:directory <path>` and no
+`text:taxonomyDirectory` now creates `<path>_taxonomy` beside the index on first open.
+Previously such a config kept its ordinals in memory, so hierarchical facet counts were
+lost whenever the process that built the index was not the process that served it — the
+`fuseki-lucene-shacl-loader` / `fuseki-lucene-shacl` split, which is the normal
+deployment. Those configs start returning hierarchical counts on upgrade with no edit.
+
+Rebuild the index after upgrading. An index built under the old default carries facet
+ordinals that no on-disk taxonomy resolves, and the new empty taxonomy beside it will not
+match them.
 
 ## Shapes
 

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -3,7 +3,7 @@
 ## Running Tests
 
 ```bash
-# Full jena-text suite (806 tests)
+# Full jena-text suite (809 tests)
 mvn test -pl jena-text
 
 # Only SHACL / faceting tests
@@ -73,7 +73,7 @@ A class missing from `@SelectClasses` is **silently never run** — not reported
 
 ### Existing Tests (unchanged, verifying no regressions)
 
-The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 806 tests.
+The remaining suite covers text search, multilingual support, graph indexing, deletion, analyzers, property lists, spatial filtering, nested identifiers, and demo mining scenarios. The full `jena-text` module currently passes at 809 tests.
 
 ---
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclTextIndexAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/ShaclTextIndexAssembler.java
@@ -25,6 +25,7 @@ import static org.apache.jena.query.text.assembler.TextVocab.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.assembler.Mode;
@@ -46,9 +47,9 @@ import org.apache.lucene.store.*;
  * <pre>
  * :index rdf:type text:TextIndexShacl ;
  *     text:directory &lt;file:Lucene&gt; ;
- *     text:taxonomyDirectory &lt;file:Taxonomy&gt; ;   # optional; required to persist
- *                                                 # hierarchical facets across a
- *                                                 # separate bulk-index step
+ *     text:taxonomyDirectory &lt;file:Taxonomy&gt; ;   # optional; defaults to a sibling
+ *                                                 # &lt;text:directory&gt;_taxonomy, or to
+ *                                                 # memory for a "mem" index
  *     text:shapes ( :Shape1 :Shape2 ) ;
  *     text:storeValues true ;
  *     text:maxFacetHits 50000 .
@@ -68,16 +69,6 @@ public class ShaclTextIndexAssembler extends AssemblerBase {
 
             Directory directory = asDirectory(root.getProperty(pDirectory).getObject());
 
-            // Optional taxonomy directory — hierarchical facet ordinals. Left unset, the
-            // taxonomy is in-memory: fine when indexing and querying share a JVM, and a
-            // silent total loss of hierarchical facet counts when they do not (a bulk
-            // build writes the ordinals, the process exits, the server starts empty).
-            Directory taxonomyDirectory = null;
-            Statement taxonomyStatement = root.getProperty(pTaxonomyDirectory);
-            if (taxonomyStatement != null) {
-                taxonomyDirectory = asDirectory(taxonomyStatement.getObject());
-            }
-
             // Shapes (required)
             Statement shapesStmt = root.getProperty(pShapes);
             if (shapesStmt == null)
@@ -85,6 +76,16 @@ public class ShaclTextIndexAssembler extends AssemblerBase {
 
             ShaclIndexMapping shaclMapping = ShaclIndexAssembler.parseShapes(a, shapesStmt.getObject().asResource());
             EntityDefinition docDef = ShaclIndexAssembler.deriveEntityDefinition(shaclMapping);
+
+            // Optional taxonomy directory — hierarchical facet ordinals. Resolved after
+            // the shapes because the default depends on whether any hierarchy exists.
+            Directory taxonomyDirectory = null;
+            Statement taxonomyStatement = root.getProperty(pTaxonomyDirectory);
+            if (taxonomyStatement != null) {
+                taxonomyDirectory = asDirectory(taxonomyStatement.getObject());
+            } else if (shaclMapping.hasHierarchies()) {
+                taxonomyDirectory = defaultTaxonomyDirectory(directory);
+            }
 
             // Optional analyzers
             Analyzer analyzer = null;
@@ -137,6 +138,27 @@ public class ShaclTextIndexAssembler extends AssemblerBase {
             IO.exception(e);
             return null;
         }
+    }
+
+    /**
+     * Where hierarchical facet ordinals go when {@code text:taxonomyDirectory} is absent.
+     * <p>
+     * Tied to {@code text:directory} rather than fixed, because the two have to agree
+     * about persistence. A persistent index paired with an in-memory taxonomy is the
+     * loader/server split: the bulk build writes ordinals into a directory that dies with
+     * the process, and the server then reads an index whose facet ordinals nothing can
+     * resolve. An in-memory index paired with a persistent taxonomy is the mirror image,
+     * and equally pointless.
+     * <p>
+     * So an {@link FSDirectory} index gets an {@code FSDirectory} taxonomy at a sibling
+     * {@code <path>_taxonomy}, and anything else keeps the in-memory default.
+     */
+    private static Directory defaultTaxonomyDirectory(Directory directory) throws IOException {
+        if (directory instanceof FSDirectory fsDirectory) {
+            Path indexPath = fsDirectory.getDirectory();
+            return FSDirectory.open(indexPath.resolveSibling(indexPath.getFileName() + "_taxonomy"));
+        }
+        return new ByteBuffersDirectory();
     }
 
     /** Resolve a directory-valued config node: the literal {@code "mem"} for an

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTaxonomyDirectoryAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTaxonomyDirectoryAssembler.java
@@ -26,13 +26,24 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.jena.assembler.Assembler;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.text.FacetValue;
+import org.apache.jena.query.text.ShaclTextDocProducer;
 import org.apache.jena.query.text.ShaclTextIndexLucene;
+import org.apache.jena.query.text.TextDatasetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,14 +51,19 @@ import org.junit.Test;
 /**
  * {@code text:taxonomyDirectory} — where hierarchical facet ordinals are written.
  * <p>
- * Without it the taxonomy lives in memory, which is invisible while indexing and
- * querying happen in one JVM (the live change-listener path) and fatal when they
- * do not. A bulk build writes its facet ordinals into a taxonomy that is discarded
- * when the process exits, and the server then starts on an empty one and reports no
- * hierarchical facet counts at all — a silent, total loss with no error anywhere.
+ * The default is derived from {@code text:directory} rather than fixed: a persistent
+ * index gets a persistent taxonomy at a sibling {@code <path>_taxonomy}, and only an
+ * in-memory index gets an in-memory taxonomy. {@code text:taxonomyDirectory} remains an
+ * explicit override.
  * <p>
- * That combination is not exotic: an {@code idx:externalSource} profile is
- * rebuild-only, so bulk indexing is the <em>only</em> way to build it.
+ * Before that, the default was in-memory regardless. Pairing a persistent index with an
+ * ephemeral taxonomy is invisible while indexing and querying share a JVM (the live
+ * change-listener path) and fatal when they do not: a bulk build writes its facet
+ * ordinals into a taxonomy discarded when the process exits, and the server then starts
+ * on an empty one and reports no hierarchical facet counts at all — a silent, total loss
+ * with no error anywhere. That is the ordinary loader/server split, not an edge case, and
+ * an {@code idx:externalSource} profile is rebuild-only, so bulk indexing is the
+ * <em>only</em> way to build it.
  */
 public class TestTaxonomyDirectoryAssembler {
 
@@ -82,7 +98,21 @@ public class TestTaxonomyDirectoryAssembler {
         + "    sh:property [ idx:field field:sub  ; sh:path ex:sub ] ;\n"
         + "    idx:facetHierarchy ( field:kind field:sub ) .\n";
 
+    /** The same two fields with no {@code idx:facetHierarchy}, so the mapping carries no
+     *  hierarchy and the index needs no taxonomy at all. */
+    private static final String SHAPE_WITHOUT_HIERARCHY =
+        "field:kind idx:fieldName \"kind\" ; idx:fieldType idx:KeywordField ; idx:facetable true .\n"
+        + "field:sub  idx:fieldName \"sub\"  ; idx:fieldType idx:KeywordField ; idx:facetable true .\n"
+        + "ex:ThingShape\n"
+        + "    sh:targetClass ex:Thing ;\n"
+        + "    sh:property [ idx:field field:kind ; sh:path ex:kind ] ;\n"
+        + "    sh:property [ idx:field field:sub  ; sh:path ex:sub ] .\n";
+
     private ShaclTextIndexLucene openIndex(String indexProperties) {
+        return openIndex(indexProperties, SHAPE_AND_FIELDS);
+    }
+
+    private ShaclTextIndexLucene openIndex(String indexProperties, String shapeBlock) {
         String turtle =
             "@prefix idx:   <urn:jena:lucene:index#> .\n"
             + "@prefix field: <urn:jena:lucene:field#> .\n"
@@ -90,7 +120,7 @@ public class TestTaxonomyDirectoryAssembler {
             + "@prefix text:  <http://jena.apache.org/text#> .\n"
             + "@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n"
             + "@prefix ex:    <http://example.org/> .\n"
-            + SHAPE_AND_FIELDS
+            + shapeBlock
             + "ex:index rdf:type text:TextIndexShacl ;\n"
             + "    text:shapes ( ex:ThingShape ) ;\n"
             + indexProperties
@@ -100,6 +130,45 @@ public class TestTaxonomyDirectoryAssembler {
         model.read(new java.io.StringReader(turtle), null, "TTL");
         Resource indexSpec = model.getResource("http://example.org/index");
         return (ShaclTextIndexLucene) Assembler.general().open(indexSpec);
+    }
+
+    /** True when {@code path} holds a Lucene index, not merely an empty directory. */
+    private static boolean holdsLuceneIndex(Path path) throws IOException {
+        if (!Files.isDirectory(path)) {
+            return false;
+        }
+        try (var paths = Files.list(path)) {
+            return paths.anyMatch(p -> p.getFileName().toString().startsWith("segments"));
+        }
+    }
+
+    /** Write three entities through the change-listener path, as a bulk build would. */
+    private void indexThings(ShaclTextIndexLucene index) {
+        Dataset baseDs = DatasetFactory.create();
+        ShaclTextDocProducer producer = new ShaclTextDocProducer(
+            baseDs.asDatasetGraph(), index, index.getShaclMapping());
+        Dataset ds = TextDatasetFactory.create(baseDs, index, true, producer);
+        ds.begin(ReadWrite.WRITE);
+        try {
+            Model model = ds.getDefaultModel();
+            addThing(model, "t1", "Water", "Shallow");
+            addThing(model, "t2", "Water", "Deep");
+            addThing(model, "t3", "Mineral", "Gold");
+            ds.commit();
+        } finally {
+            ds.end();
+        }
+        // closeIndexOnDSGClose is set, so this closes the index and commits the taxonomy.
+        ds.close();
+    }
+
+    private static void addThing(Model model, String id, String kind, String sub) {
+        Resource thing = ResourceFactory.createResource("http://example.org/" + id);
+        model.add(thing, RDF.type, ResourceFactory.createResource("http://example.org/Thing"));
+        model.add(thing, ResourceFactory.createProperty("http://example.org/kind"),
+            ResourceFactory.createPlainLiteral(kind));
+        model.add(thing, ResourceFactory.createProperty("http://example.org/sub"),
+            ResourceFactory.createPlainLiteral(sub));
     }
 
     /** The taxonomy is written where the config says, so it survives the process that
@@ -139,17 +208,94 @@ public class TestTaxonomyDirectoryAssembler {
         }
     }
 
-    /** Omitting it keeps the previous behaviour — an in-memory taxonomy — so existing
-     *  configs are unaffected. */
+    /** Omitted against a persistent index, the taxonomy defaults to a sibling of
+     *  {@code text:directory} rather than to memory. */
     @Test
-    public void absentTaxonomyDirectoryStillWorksInMemory() {
+    public void absentTaxonomyDirectoryDerivesFromIndexDirectory() throws IOException {
         Path lucene = dir.resolve("Lucene3");
+        Path derived = dir.resolve("Lucene3_taxonomy");
+
         ShaclTextIndexLucene index = openIndex(
             "    text:directory <file://" + lucene + "> ;\n");
         try {
             assertTrue("hierarchies still enable faceting", index.hasHierarchies());
+            index.commit();
+            assertTrue("taxonomy should default to " + derived + ", not to memory",
+                holdsLuceneIndex(derived));
         } finally {
             index.close();
+        }
+    }
+
+    /** An in-memory index keeps an in-memory taxonomy: persisting ordinals for an index
+     *  that does not itself persist would make no sense, and nothing should reach disk. */
+    @Test
+    public void memIndexDirectoryKeepsTaxonomyInMemory() throws IOException {
+        ShaclTextIndexLucene index = openIndex("    text:directory \"mem\" ;\n");
+        try {
+            assertTrue("hierarchies still enable faceting", index.hasHierarchies());
+            index.commit();
+            try (var paths = Files.list(dir)) {
+                assertEquals("a \"mem\" index must not write a taxonomy to disk",
+                    Collections.emptyList(), paths.toList());
+            }
+        } finally {
+            index.close();
+        }
+    }
+
+    /** No hierarchy in the mapping means no taxonomy is needed, so no directory should be
+     *  created beside the index. */
+    @Test
+    public void noTaxonomyDirectoryCreatedWithoutHierarchies() throws IOException {
+        Path lucene = dir.resolve("Lucene4");
+        Path derived = dir.resolve("Lucene4_taxonomy");
+
+        ShaclTextIndexLucene index = openIndex(
+            "    text:directory <file://" + lucene + "> ;\n", SHAPE_WITHOUT_HIERARCHY);
+        try {
+            assertFalse("no hierarchy declared", index.hasHierarchies());
+            index.commit();
+            assertFalse("nothing should be created at " + derived,
+                Files.exists(derived));
+        } finally {
+            index.close();
+        }
+    }
+
+    /** The regression that matters: the loader image builds the index in one process and
+     *  the server reads it in another. Hierarchical counts must survive that boundary
+     *  without {@code text:taxonomyDirectory} being set. */
+    @Test
+    public void hierarchyFacetsSurviveReopen() {
+        Path lucene = dir.resolve("Reopen");
+        String indexProperties = "    text:directory <file://" + lucene + "> ;\n";
+
+        String dimension;
+        ShaclTextIndexLucene builder = openIndex(indexProperties);
+        try {
+            dimension = builder.getHierarchyDimensions().iterator().next();
+        } catch (RuntimeException e) {
+            builder.close();
+            throw e;
+        }
+        indexThings(builder);
+
+        ShaclTextIndexLucene reopened = openIndex(indexProperties);
+        try {
+            Map<String, List<FacetValue>> counts = reopened.getFacetCounts(
+                null, null, Collections.singletonList(dimension), 10, 0);
+            List<FacetValue> values = counts.get(dimension);
+            assertNotNull("hierarchy dimension absent after reopen", values);
+
+            Map<String, Long> byLabel = new java.util.HashMap<>();
+            for (FacetValue value : values) {
+                byLabel.put(value.getValue(), value.getCount());
+            }
+            assertEquals("Water count lost across reopen", Long.valueOf(2), byLabel.get("Water"));
+            assertEquals("Mineral count lost across reopen", Long.valueOf(1), byLabel.get("Mineral"));
+        } finally {
+            reopened.close();
         }
     }
 }


### PR DESCRIPTION
Closes #151.

Takes the proposed fix rather than the weaker config-time-error alternative, so existing
configs start working on upgrade instead of needing an edit.

## The change

`ShaclTextIndexAssembler` left `taxonomyDirectory` null whenever
`text:taxonomyDirectory` was absent, and the `ShaclTextIndexLucene` constructor
substituted a `ByteBuffersDirectory`. The default was decoupled from where the index
itself lives, so a persistent index silently got an ephemeral taxonomy.

The default now follows `text:directory`:

| `text:directory` | taxonomy default |
|---|---|
| `"mem"` | `ByteBuffersDirectory` — unchanged |
| a path or file IRI | `FSDirectory` at a sibling `<path>_taxonomy` |

`text:taxonomyDirectory` is unchanged as an explicit override.

Resolution moves below the shapes parse because it is gated on
`shaclMapping.hasHierarchies()`. A mapping with no hierarchy needs no taxonomy, and
`FSDirectory.open` creates eagerly, so an ungated default would litter a `_taxonomy`
directory beside every SHACL index.

## The failure is worse than reported

The issue describes a silent drop to zero rows. The reopen regression test, run against
`main`, does not fail silently — it throws:

```
java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 1
  at org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts.count(FastTaxonomyFacetCounts.java:104)
  at org.apache.jena.query.text.ShaclTextIndexLucene.createCombinedFacets(ShaclTextIndexLucene.java:2071)
```

The persisted index carries facet ordinals that the fresh in-memory taxonomy cannot
resolve, so the lookup runs off the end of a length-1 counts array. Worth knowing when
triaging: on a populated index the same root cause can crash the facet query outright
rather than return nothing.

## Tests

TDD, red and green as separate commits.

Four tests in `TestTaxonomyDirectoryAssembler` (already registered in `TS_Text`):

- `absentTaxonomyDirectoryDerivesFromIndexDirectory` — red before, green after
- `hierarchyFacetsSurviveReopen` — the regression that matters. Indexes through the
  change-listener path, closes, reopens from the same config in a second index instance,
  and asserts the hierarchy counts are still right. This is the loader-builds /
  server-reads split.
- `memIndexDirectoryKeepsTaxonomyInMemory` — green throughout; asserts nothing reaches
  disk for a `"mem"` index
- `noTaxonomyDirectoryCreatedWithoutHierarchies` — green throughout; asserts no stray
  directory when the mapping declares no hierarchy

The last two bound the fix so it cannot over-reach.

`absentTaxonomyDirectoryStillWorksInMemory` was retargeted rather than deleted — it
asserted the behaviour being changed.

Full suite: **809 passing, 0 failures** (806 before, +3 net). Counts updated in
`docs/05-testing.md` and `CLAUDE.md`.

## Docs

`docs/03-configuration.md:64` documented the old behaviour accurately and is corrected.
The worked example lost its `text:taxonomyDirectory` line, which paired a persistent
taxonomy with `text:directory "mem"` — the mirror image of this bug.

Added an upgrade note. **An index built under the old default needs rebuilding**: its
ordinals have no on-disk taxonomy to resolve against, so the new empty `_taxonomy`
directory beside it will not match them.